### PR TITLE
Adds back default recipe for auto clicker

### DIFF
--- a/kubejs/data/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/data/enigmatica/kubejs/base/recipes/shaped.js
@@ -41,7 +41,12 @@ events.listen('recipes', function (event) {
             L: 'mekanism:ultimate_bin',
             C: '#forge:ingots/compressed_iron',
             B: '#forge:glass'
-        })
+        }),
+        shapedRecipe('clickmachine:auto_clicker', ['AAA', 'ABA', 'ACA'], {
+          A: 'minecraft:diorite',
+          B: 'minecraft:chorus_flower',
+          C: 'minecraft:redstone_block'
+      })
     ];
 
     recipes.forEach(function (recipe) {


### PR DESCRIPTION
As per #111, this just adds the default recipe back for the ClickMachine Auto Clicker (which to me seems appropriate considering the rather end-game nature of click automation).