### PR TITLE
Energizer Recipe

### DIFF
--- a/openloader/data/enigmatica/data/powah/recipes/energizing/charged_certus.json
+++ b/openloader/data/enigmatica/data/powah/recipes/energizing/charged_certus.json
@@ -1,0 +1,10 @@
+{
+  "type": "powah:energizing",
+  "ingredients": [
+	{"item": "emendatusenigmatica:gem_certus_quartz"}
+  ],
+  "energy": 10000,
+  "result": {
+	"item": "emendatusenigmatica:gem_charged_certus_quartz"
+  }
+}


### PR DESCRIPTION
Quick recipe to turn EE Certus Quartz to EE Charged Certus Quartz using Powah! Energizer. AE2 Charger is not compatible at the moment, and they will look into unlocking it for non-AE2 items, but not any time soon.