### PR TITLE
Nature's Aura Ore Generator Cleanup

### DIFF
--- a/config/naturesaura-common.toml
+++ b/config/naturesaura-common.toml
@@ -7,9 +7,9 @@
 	#The Aura to RF ratio used by the RF converter, read as aura*ratio = rf
 	auraToRFRatio = 0.05
 	#Blocks that are exempt from being recognized as generatable ores for the passive ore generation effect. Each entry needs to be formatted as modid:block[prop1=value1,...] where block state properties are optional
-	oreExceptions = ["mekanism:copper_ore"]
+	oreExceptions = ["mekanism:copper_ore", "mekanism:tin_ore", "immersiveengineering:ore_silver", "mekanism:lead_ore", "mekanism:osmium_ore", "mekanism:uranium_ore", "immersiveengineering:ore_copper", "immersiveengineering:ore_aluminum", "immersiveengineering:ore_nickel", "immersiveengineering:ore_uranium", "immersiveengineering:ore_lead"]
 	#Additional blocks that are recognized as generatable ores for the passive ore generation effect. Each entry needs to be formatted as tag_name->oreWeight->dimension where a higher weight makes the ore more likely to spawn with 5000 being the weight of coal, the default ore with the highest weight, and dimension being any of overworld and nether
-	additionalOres = []
+	additionalOres = ["forge:ores/nether/gold->1000->nether", "forge:ores/netherite_scrap->1->nether"]
 	#Additional dimensions that map to Aura types that should be present in them. This is useful if you have a modpack with custom dimensions that should have Aura act similarly to an existing dimension in them. Each entry needs to be formatted as dimension_name->aura_type, where aura_type can be any of naturesaura:overworld, naturesaura:nether and naturesaura:end.
 	auraTypeOverrides = []
 	#The amount of blocks that can be between two Aura Field Creators for them to be connectable and work together

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/ores.js
@@ -2,6 +2,7 @@ events.listen('block.tags', function (event) {
     event.get('forge:ores/ancient_debris').add('minecraft:ancient_debris');
     event.get('forge:ores').add(oreUraninite).add('minecraft:ancient_debris');
     event.get('forge:ores/dimensional').add(oreDimensional);
+	event.get('forge:ores/nether/gold').add('minecraft:nether_gold_ore');
     // event.get('forge:ores').add('create:zinc_ore');
     // event.get('forge:ores').add('occultism:iesnium_ore');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
@@ -2,6 +2,7 @@ events.listen('item.tags', function (event) {
     event.get('forge:ores/ancient_debris').add('minecraft:ancient_debris');
     event.get('forge:ores').add(oreUraninite).add('minecraft:ancient_debris');
     event.get('forge:ores/dimensional').add(oreDimensional);
+	event.get('forge:ores/nether/gold').add('minecraft:nether_gold_ore');
     // event.get('forge:ores').add('create:zinc_ore');
     // event.get('forge:ores').add('occultism:iesnium_ore');
 });


### PR DESCRIPTION
Removed mod specific ores so only EE ores spawn.

Added tags to nether gold to allow the nether version of ore generator to spawn it.

Added nether gold ore to the nether drop table.
Added Ancient Debris to the drop table (very rare)

For reference with the spawn weights, by default coal is 5000, diamond is 50, and emerald is 30. Putting Debris at 1 therefore makes it every rare.  Nether Gold at 1000 makes it relatively rare compared to quartz (default 3000)