### PR TITLE
Industrial Foregoing Ore Laser Cleanup

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_fluid.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_fluid.js
@@ -1,0 +1,29 @@
+events.listen('recipes', function (event) {
+    event.recipes.industrialforegoing.laser_drill_fluid({
+        "output": "{FluidName:\"pneumaticcraft:oil\",Amount:10}",
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:nether_wastes",
+                "minecraft:basalt_deltas",
+                "minecraft:warped_forest",
+                "minecraft:crimson_forest",
+                "minecraft:soul_sand_valley"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 20,
+            "weight": 8
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens15"
+        },
+        "entity": "minecraft:empty",
+        "type": "industrialforegoing:laser_drill_fluid"
+      });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
@@ -1,0 +1,1051 @@
+events.listen('recipes', function (event) {
+  event.remove({id: 'industrialforegoing:laser_drill_ore/sapphire'})
+  event.remove({id: 'industrialforegoing:laser_drill_ore/ruby'})
+
+    event.recipes.industrialforegoing.laser_drill_ore({
+      "output": {
+        "item": "rftoolsbase:dimensionalshard_end"
+      },
+      "rarity": [
+        {
+          "whitelist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+              "minecraft:the_end",
+              "minecraft:the_void",
+              "minecraft:small_end_islands",
+              "minecraft:end_barrens",
+              "minecraft:end_highlands",
+              "minecraft:end_midlands"
+            ]
+          },
+          "blacklist": {},
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+        }
+      ],
+      "pointer": 0,
+      "catalyst": {
+        "item": "industrialforegoing:laser_lens0"
+      },
+      "type": "industrialforegoing:laser_drill_ore"
+    });
+
+    event.recipes.industrialforegoing.laser_drill_ore({
+      "output": {
+        "item": "rftoolsbase:dimensionalshard_nether"
+      },
+      "rarity": [
+        {
+          "whitelist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+              "minecraft:nether_wastes",
+              "minecraft:basalt_deltas",
+              "minecraft:warped_forest",
+              "minecraft:crimson_forest",
+              "minecraft:soul_sand_valley"
+            ]
+          },
+          "blacklist": {},
+          "depth_min": 7,
+          "depth_max": 117,
+          "weight": 12
+        }
+      ],
+      "pointer": 0,
+      "catalyst": {
+        "item": "industrialforegoing:laser_lens0"
+      },
+      "type": "industrialforegoing:laser_drill_ore"
+    });
+    
+    event.recipes.industrialforegoing.laser_drill_ore({
+      "output": {
+        "item": "rftoolsbase:dimensionalshard_overworld"
+      },
+      "rarity": [
+        {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+              "minecraft:the_end",
+              "minecraft:the_void",
+              "minecraft:small_end_islands",
+              "minecraft:end_barrens",
+              "minecraft:end_highlands",
+              "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+        }
+      ],
+      "pointer": 0,
+      "catalyst": {
+        "item": "industrialforegoing:laser_lens0"
+      },
+      "type": "industrialforegoing:laser_drill_ore"
+    });
+    
+    event.remove({id: 'industrialforegoing:laser_drill_ore/aluminum'})
+    event.recipes.industrialforegoing.laser_drill_ore({
+      "output": {
+        "tag": "forge:chunks/aluminum"
+      },
+      "rarity": [
+        {
+        "whitelist": {},
+        "blacklist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+          "minecraft:the_end",
+          "minecraft:the_void",
+          "minecraft:small_end_islands",
+          "minecraft:end_barrens",
+          "minecraft:end_highlands",
+          "minecraft:end_midlands"
+          ]
+        },
+        "depth_min": 68,
+        "depth_max": 84,
+        "weight": 5
+        },
+        {
+        "whitelist": {},
+        "blacklist": {
+          "type": "minecraft:worldgen/biome",
+          "values": [
+          "minecraft:the_end",
+          "minecraft:the_void",
+          "minecraft:small_end_islands",
+          "minecraft:end_barrens",
+          "minecraft:end_highlands",
+          "minecraft:end_midlands"
+          ]
+        },
+        "depth_min": 0,
+        "depth_max": 255,
+        "weight": 1
+        }
+      ],
+      "pointer": 0,
+      "catalyst": {
+        "item": "industrialforegoing:laser_lens12"
+      },
+      "type": "industrialforegoing:laser_drill_ore"
+      }
+      );
+
+    event.remove({id: 'industrialforegoing:laser_drill_ore/coal'})
+    event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/coal"
+        },
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 132,
+            "weight": 10
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 4
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens15"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/copper'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/copper"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 35,
+          "depth_max": 65,
+          "weight": 10
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 2
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens1"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/diamond'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/diamond"
+        },
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 16,
+            "weight": 4
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens3"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/cinnabar'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/cinnabar"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 30,
+          "depth_max": 70,
+          "weight": 2
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens14"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/lapis'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/lapis"
+        },
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 13,
+            "depth_max": 34,
+            "weight": 14
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 2
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens11"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/lead'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/lead"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 10,
+          "depth_max": 40,
+          "weight": 6
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens10"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/nickel'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/nickel"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 5,
+          "depth_max": 68,
+          "weight": 4
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens12"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/quartz'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "item": "minecraft:nether_quartz_ore"
+        },
+        "rarity": [
+          {
+            "whitelist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:nether_wastes",
+                "minecraft:basalt_deltas",
+                "minecraft:warped_forest",
+                "minecraft:crimson_forest",
+                "minecraft:soul_sand_valley"
+              ]
+            },
+            "blacklist": {},
+            "depth_min": 7,
+            "depth_max": 117,
+            "weight": 12
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens0"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/redstone'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/redstone"
+        },
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 16,
+            "weight": 28
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 4
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens14"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/silver'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/silver"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 10,
+          "depth_max": 40,
+          "weight": 5
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens7"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/sulfur'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/sulfur"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 5,
+          "depth_max": 10,
+          "weight": 6
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens4"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/tin'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/tin"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 64,
+          "depth_max": 96,
+          "weight": 8
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 2
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens8"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/uranium'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/uranium"
+        },
+        "rarity": [
+          {
+          "whitelist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:nether_wastes",
+            "minecraft:basalt_deltas",
+            "minecraft:warped_forest",
+            "minecraft:crimson_forest",
+            "minecraft:soul_sand_valley"
+            ]
+          },
+          "blacklist": {},
+          "depth_min": 5,
+          "depth_max": 29,
+          "weight": 5
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens5"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        event.remove({id: 'industrialforegoing:laser_drill_ore/emerald'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/emerald"
+        },
+        "rarity": [
+          {
+            "whitelist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:mountains",
+                "minecraft:mountain_edge",
+                "minecraft:gravelly_mountains",
+                "minecraft:modified_gravelly_mountains",
+                "minecraft:snowy_mountains",
+                "minecraft:snowy_taiga_mountains"
+              ]
+            },
+            "blacklist": {},
+            "depth_min": 5,
+            "depth_max": 29,
+            "weight": 8
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens5"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/glowstone'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "item": "minecraft:glowstone"
+        },
+        "rarity": [
+          {
+            "whitelist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:nether_wastes",
+                "minecraft:basalt_deltas",
+                "minecraft:warped_forest",
+                "minecraft:crimson_forest",
+                "minecraft:soul_sand_valley"
+              ]
+            },
+            "blacklist": {},
+            "depth_min": 7,
+            "depth_max": 117,
+            "weight": 8
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens4"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/gold'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/gold"
+        },
+        "rarity": [
+          {
+            "whitelist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:badlands",
+                "minecraft:badlands_plateau",
+                "minecraft:eroded_badlands",
+                "minecraft:modified_badlands_plateau",
+                "minecraft:modified_wooded_badlands_plateau",
+                "minecraft:wooded_badlands_plateau"
+              ]
+            },
+            "blacklist": {},
+            "depth_min": 32,
+            "depth_max": 80,
+            "weight": 16
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 32,
+            "weight": 6
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens4"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/iron'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:chunks/iron"
+        },
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 68,
+            "weight": 20
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 3
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens12"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      });
+
+      event.remove({id: 'industrialforegoing:laser_drill_ore/yellorium'})
+      event.recipes.industrialforegoing.laser_drill_ore({
+        "output": {
+          "tag": "forge:ores/yellorium"
+        },
+        "rarity": [
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 16,
+          "depth_max": 68,
+          "weight": 3
+          },
+          {
+          "whitelist": {},
+          "blacklist": {
+            "type": "minecraft:worldgen/biome",
+            "values": [
+            "minecraft:the_end",
+            "minecraft:the_void",
+            "minecraft:small_end_islands",
+            "minecraft:end_barrens",
+            "minecraft:end_highlands",
+            "minecraft:end_midlands"
+            ]
+          },
+          "depth_min": 0,
+          "depth_max": 255,
+          "weight": 1
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens4"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+        });
+
+        
+      event.remove({id: 'industrialforegoing:laser_drill_ore/ancient_debris'})
+        event.recipes.industrialforegoing.laser_drill_ore({
+          "output": {
+            "item": "minecraft:ancient_debris"
+          },
+          "rarity": [
+            {
+              "whitelist": {
+                "type": "minecraft:worldgen/biome",
+                "values": [
+                  "minecraft:nether_wastes",
+                  "minecraft:basalt_deltas",
+                  "minecraft:warped_forest",
+                  "minecraft:crimson_forest",
+                  "minecraft:soul_sand_valley"
+                ]
+              },
+              "blacklist": {},
+              "depth_min": 1,
+              "depth_max": 20,
+              "weight": 1
+            }
+          ],
+          "pointer": 0,
+          "catalyst": {
+            "item": "industrialforegoing:laser_lens12"
+          },
+          "type": "industrialforegoing:laser_drill_ore"
+        });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/ores.js
@@ -1,0 +1,9 @@
+events.listen('block.tags', function (event) {
+    event.get('forge:ores/ancient_debris').add('minecraft:ancient_debris');
+    event.get('forge:ores').add(oreUraninite).add('minecraft:ancient_debris');
+    event.get('forge:ores/dimensional').add(oreDimensional);
+	event.get('forge:ores/nether/gold').add('minecraft:nether_gold_ore');
+	event.get('forge:ores/yellorium').add('bigreactors:yellorite_ore');
+    // event.get('forge:ores').add('create:zinc_ore');
+    // event.get('forge:ores').add('occultism:iesnium_ore');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
@@ -1,0 +1,9 @@
+events.listen('item.tags', function (event) {
+    event.get('forge:ores/ancient_debris').add('minecraft:ancient_debris');
+    event.get('forge:ores').add(oreUraninite).add('minecraft:ancient_debris');
+    event.get('forge:ores/dimensional').add(oreDimensional);
+	event.get('forge:ores/nether/gold').add('minecraft:nether_gold_ore');
+	event.get('forge:ores/yellorium').add('bigreactors:yellorite_ore');
+    // event.get('forge:ores').add('create:zinc_ore');
+    // event.get('forge:ores').add('occultism:iesnium_ore');
+});


### PR DESCRIPTION
Removed Sapphire and Ruby as they are not used.
Added Dimensional Shards (Rates TBD)
Unified all possible ores on EE ore chunks
Brought all remaining ores in as scripts for future weight/distribution changes if desired.
Added appropriate tags to Yellorium to bring it into the Ore Laser in case reactors are staying.
Added Oil as a fluid that can be mined with the new fluid laser.