### PR TITLE
Optimise unification scripts for Rhino

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/constants.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants.js
@@ -113,7 +113,8 @@ var modPriorities = [
     'botania',
     'quark',
     'pedestals',
-    'refinedstorage'
+    'refinedstorage',
+    'mapperbase'
 ];
 
 var vanillaWoodTypes = ['oak', 'birch', 'spruce', 'jungle', 'acacia', 'dark_oak'];

--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -13,42 +13,23 @@ function unificationBlacklistEntry(material, type) {
 }
 
 function compareIndices(a, b) {
-    var aVal = 2147483647;
-    var bVal = 2147483647;
+    if (a == b) return 0; // iff a == b, they'll be found at the same position in modPriorities
 
-    for (let i = 0; i < modPriorities.length; i++) {
-        if (modPriorities[i] == a) {
-            aVal = i;
-            break;
-        }
+    for (let mod of modPriorities) {
+        if (mod == a) return -1; // if a comes before b, then idx(a) < idx(b), so -1
+        if (mod == b) return 1; // if a comes after b, then idx(a) > idx(b), so 1
     }
 
-    for (let i = 0; i < modPriorities.length; i++) {
-        if (modPriorities[i] == b) {
-            bVal = i;
-            break;
-        }
-    }
-    if (aVal == 2147483647) {
-        console.error('Mod not accounted for in unification! Mod: ' + a);
-    }
-
-    if (bVal == 2147483647) {
-        console.error('Mod not accounted for in unification! Mod: ' + b);
-    }
-
-    if (aVal > bVal) return 1;
-    if (aVal == bVal) return 0;
-    if (aVal < bVal) return -1;
+    console.error('Neither ' + a + ' nor ' + b + ' were accounted for in mod unification!');
+    return 0;
 }
 
 function getPreferredItemInTag(tag) {
-    var prefItem = tag.stacks
-        .stream()
-        .sorted(function (a, b) {
-            return compareIndices(a.mod, b.mod);
-        })
-        .findFirst()
-        .orElse(item.of('minecraft:air'));
-    return prefItem;
+    const firstStack = wrapJsArray(tag.stacks).sort((a, b) => compareIndices(a.mod, b.mod))[0];
+    //console.info('preferred item for tag ' + tag + ': ' + firstStack);
+    return firstStack || item.of('minecraft:air');
+}
+
+function wrapJsArray(a) {
+    return utils.listOf(a).toArray();
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/functions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/functions.js
@@ -12,7 +12,7 @@ function unificationBlacklistEntry(material, type) {
     return { material: material, type: type };
 }
 
-function compareIndices(a, b) {
+function compareIndices(a, b, tag) {
     if (a == b) return 0; // iff a == b, they'll be found at the same position in modPriorities
 
     for (let mod of modPriorities) {
@@ -20,16 +20,16 @@ function compareIndices(a, b) {
         if (mod == b) return 1; // if a comes after b, then idx(a) > idx(b), so 1
     }
 
-    console.error('Neither ' + a + ' nor ' + b + ' were accounted for in mod unification!');
+    console.error('[' + a + ', ' + b + '] were both unaccounted for in mod unification' + (tag ? ' for ' + tag : '!'));
     return 0;
 }
 
 function getPreferredItemInTag(tag) {
-    const firstStack = wrapJsArray(tag.stacks).sort((a, b) => compareIndices(a.mod, b.mod))[0];
-    //console.info('preferred item for tag ' + tag + ': ' + firstStack);
-    return firstStack || item.of('minecraft:air');
+    const pref = wrapArray(tag.stacks).sort(({ mod: a }, { mod: b }) => compareIndices(a, b, tag))[0] || item.of(air);
+    // console.info('Preferred item: ' + tag + ' => ' + pref);
+    return pref;
 }
 
-function wrapJsArray(a) {
+function wrapArray(a) {
     return utils.listOf(a).toArray();
 }


### PR DESCRIPTION
This mostly gets rid of the Java stream calls in `getPreferredItemInTag` and slightly optimises the `compareIndices` method so it doesn't loop through the list twice like it currently does.

Should be fine but may need additional testing (worked in my worlds without errors)

Also a general TODO: Start using ES6 syntax where possible, minimise pollution of the global scope by wrapping things in wrapper objects where possible, and stop using Java code or utils.listOf if we can avoid it (since we don't NEED to use it in most places anymore)

(Edit: force-pushed because the commit wasn't verified for some reason, plus I messed up some string formatting)