### PR TITLE
NaturesAura Summoning Compat

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
@@ -1,0 +1,151 @@
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "ars_nouveau:mana_gem"
+            },
+            {
+                "item": "naturesaura:gold_leaf"
+            }
+        ],
+        "entity": "ars_nouveau:carbuncle",
+        "aura": 100000,
+        "time": 100
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "ars_nouveau:mana_gem"
+            },
+            {
+                "item": "naturesaura:ancient_sapling"
+            }
+        ],
+        "entity": "ars_nouveau:sylph",
+        "aura": 100000,
+        "time": 100
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "minecraft:cod"
+            },
+            {
+                "item": "minecraft:iron_bars"
+            }
+        ],
+        "entity": "quark:crab",
+		"aura": 30000,
+		"time": 40
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "minecraft:spider_eye"
+            },
+            {
+                "item": "minecraft:lily_pad"
+            }
+        ],
+        "entity": "quark:frog",
+		"aura": 30000,
+		"time": 40
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "minecraft:leatherb"
+            },
+            {
+                "item": "minecraft:coal"
+            }
+        ],
+        "entity": "quark:foxhound",
+        "aura": 150000,
+        "time": 120
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "thermal:blitz_rod"
+            },
+            {
+                "item": "thermal:blitz_powder"
+            }
+        ],
+        "entity": "thermal:blitz",
+        "aura": 150000,
+        "time": 120
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "thermal:blizz_rod"
+            },
+            {
+                "item": "thermal:blizz_powder"
+            }
+        ],
+        "entity": "thermal:blizz",
+        "aura": 150000,
+		"time": 120
+    });
+});
+
+events.listen('recipes', function(event) {
+    event.recipes.naturesaura.animal_spawner({
+        "type": "naturesaura:animal_spawner",
+        "ingredients": [{
+                "item": "naturesaura:birth_spirit"
+            },
+            {
+                "item": "thermal:basalz_rod"
+            },
+            {
+                "item": "thermal:basalz_powder"
+            }
+        ],
+        "entity": "thermal:basalz",
+        "aura": 150000,
+        "time": 120
+    });
+});


### PR DESCRIPTION
ArsNouveau: Added Sylphs and Carbuncles. Both are used for automation aspects of ArsNouveau (carbuncles transport items similar to Rats, Sylphs slowly produce 'natural' items like logs and flowers). In order to obtain them, one must find them in the wild and perform a special action nearby. If more are desired, then more must be found. This ritual helps with the fact that they spawn very rarely, but does not diminish the need for the 'special action' once summoned in this way.

While adding these, I thought I'd toss in a few more for good measure.

Quark: Crabs, Frogs, and Foxhounds. These are also exceptionally rare in the world, so I thought it would be nice to have an alternate means of obtaining them. Once a few are obtained, they can of course be bred through normal means.

Thermal: I've added all of the elementals here. The recipe for spawning them is just as costly as summoning blaze through this ritual and realistically would not be very feasible for making a self sustaining summoner without a good looting sword.

A few more I considered, but figured I'd hold off on for now: Pillagers, Vindicators, Evokers, and Ravagers. Could be an interesting way of gaining access to them. Also the various new nether mobs (piglins, hoglins, piglin brutes). If you're OK with them, I can work out suitable recipes and add them in. At a very minimum, I'd suggest keeping the carbuncles and sylphs, however, since they're exceptionally rare in the world.

One note, there is a minor issue with this, but I've reported it here: https://github.com/Ellpeck/NaturesAura/issues/156