### PR TITLE
MythBotania generators - Disabled without breaking anything

### DIFF
--- a/kubejs/assets/mythicbotany/lang/en_us.json
+++ b/kubejs/assets/mythicbotany/lang/en_us.json
@@ -98,8 +98,8 @@
   "lexicon.mythicbotany.niflheim.page1": "The bearer may withstand the crushing power of ice and stone with this band and a chilling aura emanates from it, slowing all within reach.",
 
   "lexicon.mythicbotany.generating.title": "Generating Flora",
-  "lexicon.mythicbotany.generating.page1": "$(thing)Disabled by Enigmatia 6$(0)$(p)TNether Stars dropped near the Wither Aconite are slowly consumed to generate enormous quantities of mana.",
-  "lexicon.mythicbotany.generating.page2": "$(thing)Disabled by Enigmatia 6$(0)$(p)Perfectly at home in a downpour, it produces a small amount of mana in the rain and even more during a thunder storm.",
+  "lexicon.mythicbotany.generating.page1": "$(thing)Disabled by Enigmatia 6$(0)",
+  "lexicon.mythicbotany.generating.page2": "$(thing)Disabled by Enigmatia 6$(0)",
   "lexicon.mythicbotany.generating.page3": "At times, a Mana Spreader simply cannot keep up with mana as it's being produce. Generating Flora can instead be linked to a Mana Collector, allowing the mana to flow directly into a Spark network. A Spark and a Recessive Augment must be placed on the device.",
 
   "lexicon.mythicbotany.functional.title": "Functional Flora",

--- a/kubejs/data/mythicbotany/recipes/alfsteel_pylon.json
+++ b/kubejs/data/mythicbotany/recipes/alfsteel_pylon.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "mythicbotany:alfsteel_pylon",
+  "pattern": [
+    " n ",
+    "npn",
+    " g "
+  ],
+  "key": {
+    "n": {
+      "item": "mythicbotany:alfsteel_nugget"
+    },
+    "g": {
+      "item": "minecraft:ghast_tear"
+    },
+    "p": {
+      "item": "botania:gaia_pylon"
+    }
+  },
+  "result": {
+    "item": "mythicbotany:alfsteel_pylon"
+  }
+}

--- a/kubejs/data/mythicbotany/recipes/modified_gaia_pylon_with_alfsteel.json
+++ b/kubejs/data/mythicbotany/recipes/modified_gaia_pylon_with_alfsteel.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "mythicbotany:modified_gaia_pylon_with_alfsteel",
+  "pattern": [
+    " D ",
+    "EPE",
+    " D "
+  ],
+  "key": {
+    "P": {
+      "item": "botania:mana_pylon"
+    },
+    "D": {
+      "item": "botania:pixie_dust"
+    },
+    "E": {
+      "tag": "forge:ingots/elementium"
+    }
+  },
+  "result": {
+    "item": "botania:gaia_pylon"
+  }
+}

--- a/kubejs/data/mythicbotany/recipes/petal_apothecary/raindeletia.json
+++ b/kubejs/data/mythicbotany/recipes/petal_apothecary/raindeletia.json
@@ -1,0 +1,11 @@
+{
+  "type": "botania:petal_apothecary",
+  "output": {
+    "item": "minecraft:air"
+  },
+  "ingredients": [
+    {
+      "item": "minecraft:air"
+    }
+  ]
+}

--- a/kubejs/data/mythicbotany/recipes/petal_apothecary/wither_aconite.json
+++ b/kubejs/data/mythicbotany/recipes/petal_apothecary/wither_aconite.json
@@ -1,0 +1,11 @@
+{
+  "type": "botania:petal_apothecary",
+  "output": {
+    "item": "minecraft:air"
+  },
+  "ingredients": [
+    {
+      "item": "minecraft:air"
+    }
+  ]
+}

--- a/kubejs/data/mythicbotany/recipes/raindeletia_floating.json
+++ b/kubejs/data/mythicbotany/recipes/raindeletia_floating.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "mythicbotany:raindeletia_floating",
+  "ingredients": [
+    {
+      "item": "minecraft:air"
+    }
+  ],
+  "result": {
+    "item": "minecraft:air"
+  }
+}

--- a/kubejs/data/mythicbotany/recipes/wither_aconite_floating.json
+++ b/kubejs/data/mythicbotany/recipes/wither_aconite_floating.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "group": "mythicbotany:wither_aconite_floating",
+  "ingredients": [
+    {
+      "item": "minecraft:air"
+    }
+  ],
+  "result": {
+    "item": "minecraft:air"
+  }
+}


### PR DESCRIPTION
In case your JSON test doesn't work out:

Also reverted the pylons to default

I think the issue stems from how KubeJS is disabling the recipes. If I set a datapack to use more than one minecraft air as the ingredient, I get the same broken entries in patchouli, and I think kubejs is doing just that: replacing inputs with air.

So I've overwritten the recipe via the data pack method to disable it. There's also an extra note in patchouli stating it's been disabled intentionally.