### PR TITLE
Remove carriage returns from setup.sh

### DIFF
--- a/development/setup.sh
+++ b/development/setup.sh
@@ -8,4 +8,4 @@ echo "java -jar InstanceSync.jar" >> .git/hooks/post-merge
 echo "Done setting up hooks"
 echo "Running InstanceSync"
 
-java -jar InstanceSync.jar
+/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -jar InstanceSync.jar


### PR DESCRIPTION
I get these errors when I follow the Linux installation instructions:

```
$ bash setup.sh
setup.sh: line 2: $'\r': command not found
setup.sh: line 3: cd: $'..\r': No such file or directory
setup.sh: line 4: $'\r': command not found
setup.sh: line 7: $'\r': command not found
```

This patch fixes those by changing CRLF line endings to LF.
