### PR TITLE
quest-loot-tables

### DIFF
--- a/kubejs/data/enigmatica/loot_tables/chests/quest_miners_delight.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_miners_delight.json
@@ -1,0 +1,226 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 12,
+      "entries": [
+        {
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:iron_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 12,
+                "max": 20
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:gold_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8,
+                "max": 16
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:diamond_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2,
+                "max": 8
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:emerald_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8,
+                "max": 16
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:lapis_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8,
+                "max": 16
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:redstone_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 12,
+                "max": 20
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:copper_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 12,
+                "max": 20
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:aluminum_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2,
+                "max": 8
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:lead_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2,
+                "max": 8
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:nickel_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8,
+                "max": 16
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:uranium_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 2,
+                "max": 8
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:osmium_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 12,
+                "max": 20
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:tin_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8,
+                "max": 16
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 10,
+          "name": "emendatusenigmatica:silver_chunk",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 8,
+                "max": 16
+              }
+            }
+          ]
+        },
+		{
+          "type": "minecraft:item",
+		  "weight": 5,
+          "name": "pneumaticcraft:reinforced_chest"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 3,
+          "name": "mekanismtools:refined_obsidian_paxel",
+          "functions": [
+            {
+              "function": "minecraft:enchant_with_levels",
+              "levels": {
+                "min": 20,
+                "max": 40
+              },
+              "treasure": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_sorcerers_delight.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_sorcerers_delight.json
@@ -1,0 +1,27 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": {
+        "min": 1,
+        "max": 2
+      },
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:book",
+          "functions": [
+            {
+              "function": "minecraft:enchant_with_levels",
+              "levels": {
+                "min": 29,
+                "max": 50
+              },
+              "treasure": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
These are the quest loot tables for Miner's Delight and Sorcerer's Delight that will replace the FTB quest loot boxes in place. Primarily this is to allow random enchanted items in these General Quest rewards.

To call them the quest reward needs to be set to Command and the following inserted:

/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_sorcerers_delight

/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_miners_delight

This will drop the items on the player, as discussed, using the loot/give command instead can potentially lead to items being lost if the player doesn't have enough room in their inventory.