### PR TITLE
Ore Processing Unification

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
@@ -1,0 +1,27 @@
+events.listen('recipes', event => {
+    event.remove({id: 'bloodmagic:alchemytable/sand_coal'});
+    event.remove({id: 'bloodmagic:alchemytable/sand_gold'});
+    event.remove({id: 'bloodmagic:alchemytable/sand_iron'});
+
+	event.recipes.bloodmagic.alchemytable({
+	type: "bloodmagic:alchemytable",
+	input: [
+		{
+		  item: "minecraft:coal"
+		},
+		{
+		  item: "minecraft:coal"
+		},
+		{
+		  item: "minecraft:flint"
+		}
+		],
+	output: {
+		item: "emendatusenigmatica:coal_dust",
+		count: 4
+		},
+	syphon: 400,
+	ticks: 200,
+	upgradeLevel: 1
+	})	
+  })

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/arc.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/arc.js
@@ -1,0 +1,14 @@
+events.listen('recipes', event => {
+    event.remove({id: 'bloodmagic:arc/fragmentsgold'});
+    event.remove({id: 'bloodmagic:arc/fragmentsiron'});
+    event.remove({id: 'bloodmagic:arc/ore/dustgold'});
+    event.remove({id: 'bloodmagic:arc/ore/dustiron'});
+    event.remove({id: 'bloodmagic:arc/dustsfrom_gravel_gold'});
+    event.remove({id: 'bloodmagic:arc/dustsfrom_gravel_iron'});
+    event.remove({id: 'bloodmagic:arc/dustsfrom_ingot_gold'});
+    event.remove({id: 'bloodmagic:arc/dustsfrom_ingot_iron'});
+    event.remove({id: 'bloodmagic:arc/dustsfrom_ore_gold'});
+    event.remove({id: 'bloodmagic:arc/dustsfrom_ore_iron'});
+    event.remove({id: 'bloodmagic:arc/gravelsgold'});
+    event.remove({id: 'bloodmagic:arc/gravelsiron'});
+  })

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
@@ -77,7 +77,7 @@ function bloodmagic_ore_processing_arc(event, material) {
                 {
                     input: 'forge:ores/' + material,
                     output: gem,
-                    count: 2,
+                    count: 5,
                     bonus: [],
                     tool: 'bloodmagic:arc/cuttingfluid'
                 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
@@ -7,6 +7,8 @@ events.listen('recipes', function (event) {
         immersiveengineering_gem_ore_processing(event, material);
         //occultism_ore_ingot_crushing(event, material);
         immersiveengineering_hammer_crafting_plates(event, material);
+        bloodmagic_ore_processing_alchemy(event, material);
+        bloodmagic_ore_processing_arc(event, material);
     });
 });
 
@@ -49,6 +51,146 @@ function immersiveengineering_gem_ore_processing(event, material) {
     if (ore == air) {
         return;
     }
+}
+
+function bloodmagic_ore_processing_arc(event, material) {
+    var data;
+
+    var gemTag = ingredient.of('#forge:gems/' + material);
+    var gem = getPreferredItemInTag(gemTag).id;
+
+    var clumpTag = ingredient.of('#mekanism:clumps/' + material);
+    var clump = getPreferredItemInTag(clumpTag).id;
+
+    var dirtyDustTag = ingredient.of('#mekanism:dirty_dusts/' + material);
+    var dirtyDust = getPreferredItemInTag(dirtyDustTag).id;
+
+    var dustTag = ingredient.of('#forge:dusts/' + material);
+    var dust = getPreferredItemInTag(dustTag).id;    
+
+    var ingotTag = ingredient.of('#forge:ingots/' + material);
+    var ingot = getPreferredItemInTag(ingotTag).id;
+
+    if (gem != air) {
+        data = {
+            recipes : [
+                {
+                    input: 'forge:ores/' + material,
+                    output: gem,
+                    count: 2,
+                    bonus: [],
+                    tool: 'bloodmagic:arc/cuttingfluid'
+                }
+            ]
+        };
+    } else if (ingot != air) {
+        data = {
+            recipes : [
+                {
+                    input: 'forge:ores/' + material,
+                    output: clump,
+                    count: 3,
+                    bonus: [],
+                    tool: 'bloodmagic:arc/explosive'
+                },
+                {
+                    input: 'mekanism:clumps/' + material,
+                    output: dirtyDust,
+                    count: 1,
+                    bonus: [{chance: 0.05, type: {item: 'bloodmagic:corrupted_tinydust'}}, {chance: 0.01, type: {item: 'bloodmagic:corrupted_tinydust'}}],
+                    tool: 'bloodmagic:arc/resonator'
+                },
+                {
+                    input: 'mekanism:dirty_dust/' + material,
+                    output: dust,
+                    count: 1,
+                    bonus: [],
+                    tool: 'bloodmagic:arc/cuttingfluid'
+                }, 
+                {
+                    input: 'forge:ores/' + material,
+                    output: dust,
+                    count: 2,
+                    bonus: [],
+                    tool: 'bloodmagic:arc/cuttingfluid'
+                },                
+                {
+                    input: 'forge:ingots/' + material,
+                    output: dust,
+                    count: 1,
+                    bonus: [],
+                    tool: 'bloodmagic:arc/explosive'
+                }
+            ]
+        };
+    } else {
+        return;
+    }
+
+    data.recipes.forEach((recipe) => {
+        event.recipes.bloodmagic.arc({
+            type: 'bloodmagic:arc',
+            input: {
+                tag: recipe.input
+            },
+            tool: {
+                tag: recipe.tool
+            },
+            addedoutput: recipe.bonus,            
+            output: {
+                item: recipe.output,
+                count: recipe.count
+            },
+            consumeingredient: false
+        }); 
+    });
+}
+
+function bloodmagic_ore_processing_alchemy(event, material) {
+    var data;
+
+    var dustTag = ingredient.of('#forge:dusts/' + material);
+    var dust = getPreferredItemInTag(dustTag).id;    
+
+    var ingotTag = ingredient.of('#forge:ingots/' + material);
+    var ingot = getPreferredItemInTag(ingotTag).id;
+
+    if (ingot != air && ore != air) {
+        data = {
+            recipes : [
+                {
+                    input: 'forge:ores/' + material,
+                    output: dust,
+                    count: 2,
+                    bonus: [],
+                    tool: 'bloodmagic:arc/cuttingfluid'                    
+                }
+            ]
+        };
+    } else {
+        return;
+    }
+
+    data.recipes.forEach((recipe) => {
+        event.recipes.bloodmagic.alchemytable({
+            type: "bloodmagic:alchemytable",
+            input: [
+                {
+                tag: recipe.input
+                },
+                {
+                tag: recipe.tool
+                }
+            ],
+            output: {
+                item: recipe.output,
+                count: 2
+            },
+            syphon: 400,
+            ticks: 200,
+            upgradeLevel: 1
+        });
+    });
 }
 
 function enigmatica_ore_deposit_processing(event, material) {


### PR DESCRIPTION
Made BM use Mekanism Clumps, Dirty Dust, Dust as opposed to it's own Ore Fractures, Ore Gravel and Ore Sand.

Added recipes to allow BM to process (2x,3x) all ore types, as well as double gems.

Added Crushing recipes for all Ingots > Dust

Unified BM coal dust to EE coal dust