### PR TITLE
Thermal Dynamos Rebalance Attempt

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
@@ -1,55 +1,67 @@
 events.listen('recipes', (event) => {
     event.remove({ type: 'thermal:compression_fuel' });
-    var multiplier = 1;
+    var multiplier = 10;
     var data = {
         recipes: [
             {
                 fluid: 'pneumaticcraft:diesel',
-                energy: 125000
+                energy: 125000,
+                amount: 250
             },
             {
                 fluid: 'pneumaticcraft:biodiesel',
-                energy: 125000
+                energy: 125000,
+                amount: 250
             },
             {
                 fluid: 'immersiveengineering:biodiesel',
-                energy: 125000
+                energy: 125000,
+                amount: 250
             },
             {
                 fluid: 'pneumaticcraft:kerosene',
-                energy: 137500
+                energy: 137500,
+                amount: 250
             },
             {
                 fluid: 'pneumaticcraft:gasoline',
-                energy: 187500
+                energy: 187500,
+                amount: 250
             },
             {
                 fluid: 'pneumaticcraft:lpg',
-                energy: 225000
+                energy: 225000,
+                amount: 250
             },
             {
                 fluid: 'mekanism:ethene',
-                energy: 225000
+                energy: 225000,
+                amount: 250
             },
             {
                 fluid: 'pneumaticcraft:ethanol',
-                energy: 50000
+                energy: 50000,
+                amount: 500
             },
             {
                 fluid: 'mekanismgenerators:bioethanol',
-                energy: 50000
+                energy: 50000,
+                amount: 500
             },
             {
                 fluid: 'immersiveengineering:ethanol',
-                energy: 50000
+                energy: 50000,
+                amount: 500
             },
             {
                 fluid: 'industrialforegoing:biofuel',
-                energy: 100000
+                energy: 64000,
+                amount: 1000
             },
             {
                 fluid: 'thermal:tree_oil',
-                energy: 100000
+                energy: 100000,
+                amount: 250
             }
         ]
     };
@@ -57,7 +69,7 @@ events.listen('recipes', (event) => {
         event.recipes.thermal.compression_fuel({
             ingredient: {
                 fluid: recipe.fluid,
-                amount: 1000
+                amount: recipe.amount
             },
             energy: recipe.energy * multiplier
         });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/lapidary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/lapidary.js
@@ -1,6 +1,6 @@
 events.listen('recipes', (event) => {
     event.remove({ type: 'thermal:lapidary_fuel' });
-    var multiplier = 1;
+    var multiplier = 40;
     var data = {
         recipes: [
             {
@@ -14,14 +14,6 @@ events.listen('recipes', (event) => {
             {
                 gem: 'forge:gems/quartz',
                 energy: 40000
-            },
-            {
-                gem: 'forge:gems/ruby',
-                energy: 125000
-            },
-            {
-                gem: 'forge:gems/sapphire',
-                energy: 125000
             },
             {
                 gem: 'forge:gems/diamond',
@@ -46,7 +38,7 @@ events.listen('recipes', (event) => {
             ingredient: {
                 tag: recipe.gem
             },
-            energy: recipe.energy
+            energy: recipe.energy * multiplier
         });
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/numismatic.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/numismatic.js
@@ -1,0 +1,72 @@
+events.listen('recipes', (event) => {
+    event.remove({ type: 'thermal:numismatic_fuel' });
+    var multiplier = 40;
+    var data = {
+        recipes: [
+            {
+                coin: 'forge:coins/gold',
+                energy: 64000
+            },
+            {
+                coin: 'forge:coins/invar',
+                energy: 48000
+            },
+            {
+                coin: 'forge:coins/iron',
+                energy: 32000
+            },
+            {
+                coin: 'forge:coins/enderium',
+                energy: 160000
+            },
+            {
+                coin: 'forge:coins/lead',
+                energy: 48000
+            },
+            {
+                coin: 'forge:coins/lumium',
+                energy: 80000
+            },
+            {
+                coin: 'forge:coins/nickel',
+                energy: 64000
+            },
+            {
+                coin: 'forge:coins/signalum',
+                energy: 80000
+            },
+            {
+                coin: 'forge:coins/silver',
+                energy: 48000
+            },
+            {
+                coin: 'forge:coins/tin',
+                energy: 32000
+            },
+            {
+                coin: 'forge:coins/bronze',
+                energy: 40000
+            },
+            {
+                coin: 'forge:coins/constantan',
+                energy: 56000
+            },
+            {
+                coin: 'forge:coins/copper',
+                energy: 32000
+            },
+            {
+                coin: 'forge:coins/electrum',
+                energy: 60000
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        event.recipes.thermal.numismatic_fuel({
+            ingredient: {
+                tag: recipe.coin
+            },
+            energy: recipe.energy * multiplier
+        });
+    });
+});


### PR DESCRIPTION
Dynamos proved to be pretty underwhelming with default values. In game, I had 4 arboreal extractors going and couldn't supply enough fuel to keep a single compression dynamo running. Needless to say, it wasn't even sufficient to keep a small RS system online.

I have yet to find any config that would allow us to change the base rf/t generation, so dynamos are still capped at 640/rf/t at 73% fuel efficiency, or or 160rf/t at 133% efficiency.

These changes let a single fully upgraded arboreal extractor run approximately 11 dynamos at high efficiency, generating about 1.7k rf/t. It's not going to beat out Ethylene, but I think it makes these much more viable for early game instead of relying on solar or wind. Mind, the starter dynamo with no upgrades only manages 40rf/t per dynamo, and fuel generation would be much slower at that point as well. Generating this tree oil also required phyto-grow in the tree extractor. 

Similarly, lapidary generators get a massive boost, as do numismatics, considering they burn rare items for fuel. Still low output, but much more efficient in their burn rate.

Magmatic and Stirling remain at their default rates as that's really quite sufficient to get started and encourages upgrading to something a little more involved to run.

As a bit of a test, I set up a compression dynamo with 1 bucket of tree oil in it. This ended up giving the expected roughly 4 million RF total, but at a slow rate of 160rf/t. At the max rate of 640 rf/t, I'd expect somewhere around 2.9 million rf.

Lastly, since sapphire and ruby are disabled throughout the pack, this also removes them as possible fuels for the lapidary dynamo.