### PR TITLE
PNC Fuels

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
@@ -1,0 +1,34 @@
+events.listen('recipes', (event) => {
+    event.remove({ type: 'thermal:compression_fuel' });
+    var data = {
+        recipes: [
+            {
+                fluid: 'mekanismgenerators:bioethanol',
+                air: 400,
+                rate: 1
+            },
+            {
+                fluid: 'industrialforegoing:biofuel',
+                air: 400,
+                rate: 1
+            },
+            {
+                fluid: 'thermal:tree_oil',
+                air: 700,
+                rate: 0.5
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        event.recipes.pneumaticcraft.fuel_quality({
+            type: "pneumaticcraft:fuel_quality",
+            fluid: {
+              type: "pneumaticcraft:fluid",
+              fluid: recipe.fluid,
+              amount: 1000
+            },
+            air_per_bucket: recipe.air * 1000,
+            burn_rate: recipe.rate
+          });
+    });
+});


### PR DESCRIPTION
With the last update to PNC, we can now add fuels through datapacks.

Added Mekanims Bioethanol (equivalent to current IF and PNC ethanol)
Added IF Biofuel (equivalent to above ethanol)
Added Thermal Tree Oil which give moderate air at a very slow burn rate. Slightly more air than ethanol, but worse than biodiesel.