### PR TITLE
Essence Update

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber_essence_conversion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber_essence_conversion.js
@@ -1,0 +1,17 @@
+events.listen('recipes', (event) => {
+    event.recipes.industrialforegoing.dissolution_chamber({
+        input: [
+            {
+                item: 'minecraft:glass_pane'
+            }
+        ],
+        inputFluid: '{ FluidName: "pneumaticcraft:memory_essence", Amount: 1000 }',
+        processingTime: 100,
+        output: {
+            item: 'minecraft:glass_pane',
+            count: 1
+        },
+        outputFluid: '{FluidName:"industrialforegoing:essence",Amount:1000}',
+        type: 'industrialforegoing:dissolution_chamber'
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/thermo_plant_essence_conversion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/thermo_plant_essence_conversion.js
@@ -1,0 +1,16 @@
+events.listen('recipes', (event) => {
+    event.recipes.pneumaticcraft.thermo_plant({
+        type: 'pneumaticcraft:thermo_plant',
+        fluid_input: {
+            type: 'pneumaticcraft:fluid',
+            fluid: 'industrialforegoing:essence',
+            amount: 1000
+        },
+        fluid_output: {
+            fluid: 'pneumaticcraft:memory_essence',
+            amount: 1000
+        },
+        pressure: 1.0,
+        exothermic: false
+    });
+});


### PR DESCRIPTION
Using the dissolution chamber for essence conversion turns out to be a little wonky. It requires item input/output. So.. glass panes act as a re-usable catalyst here.