### PR TITLE
missed saw recipes and a typo

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/cutting.js
@@ -7,53 +7,34 @@ events.listen('recipes', function (event) {
             return;
         }
 
-        if (modID == 'undergarden') {
-            data = {
-                recipes: [
-                    {
-                        input: variant.logBlock,
-                        output: variant.plankBlock,
-                        count: 5,
-                        time: 100
-                    },
-                    {
-                        input: variant.woodBlock,
-                        output: variant.plankBlock,
-                        count: 5,
-                        time: 100
-                    }
-                ]
-            };
-        } else {
-            data = {
-                recipes: [
-                    {
-                        input: variant.logBlock,
-                        output: variant.logBlockStripped,
-                        count: 1,
-                        time: 50
-                    },
-                    {
-                        input: variant.woodBlock,
-                        output: variant.woodBlockStripped,
-                        count: 1,
-                        time: 50
-                    },
-                    {
-                        input: variant.logBlockStripped,
-                        output: variant.plankBlock,
-                        count: 5,
-                        time: 100
-                    },
-                    {
-                        input: variant.woodBlockStripped,
-                        output: variant.plankBlock,
-                        count: 5,
-                        time: 100
-                    }
-                ]
-            };
-        }
+        data = {
+            recipes: [
+                {
+                    input: variant.logBlock,
+                    output: variant.logBlockStripped,
+                    count: 1,
+                    time: 50
+                },
+                {
+                    input: variant.woodBlock,
+                    output: variant.woodBlockStripped,
+                    count: 1,
+                    time: 50
+                },
+                {
+                    input: variant.logBlockStripped,
+                    output: variant.plankBlock,
+                    count: 5,
+                    time: 100
+                },
+                {
+                    input: variant.woodBlockStripped,
+                    output: variant.plankBlock,
+                    count: 5,
+                    time: 100
+                }
+            ]
+        };
 
         data.recipes.forEach((recipe) => {
             event.recipes.create.cutting({

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/sawmill.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/sawmill.js
@@ -1,0 +1,50 @@
+events.listen('recipes', function (event) {
+    global.woodVariants.forEach((variant) => {
+        var modID = variant.logBlock.split(':')[0];
+
+        // mod blacklist
+        if (modID == 'minecraft') {
+            return;
+        }
+
+        event.recipes.immersiveengineering.sawmill({
+            type: 'immersiveengineering:sawmill',
+            input: {
+                item: variant.logBlockStripped
+            },
+            result: {
+                item: variant.plankBlock,
+                count: 6
+            },
+            //secondaries: [{ output: { tag: 'forge:dusts/wood' }, stripping: false }], // This doesn't work?
+            energy: 800
+        });
+
+        event.recipes.immersiveengineering.sawmill({
+            type: 'immersiveengineering:sawmill', //Why you no work, secondaries?
+            /*secondaries: [
+                { output: { tag: 'forge:dusts/wood' }, stripping: true },
+                { output: { tag: 'forge:dusts/wood' }, stripping: false }
+            ],*/ result: {
+                item: variant.plankBlock,
+                count: 6
+            },
+            energy: 1600,
+            input: [
+                {
+                    item: variant.logBlock
+                },
+                {
+                    item: variant.woodBlock
+                }
+            ],
+            stripped: {
+                item: variant.logBlockStripped
+            }
+        });
+    });
+});
+
+/*
+item: 'emendatusenigmatica:wood_dust'
+ */

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/insolator_simplefarming_trees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/insolator_simplefarming_trees.js
@@ -38,7 +38,7 @@ events.listen('recipes', (event) => {
             },
             {
                 input: 'simplefarming:olive_sapling',
-                outputs: ['simplefarming:fruit_log', 'simplefarming:olive_sapling', 'simplefarming:olivesr'],
+                outputs: ['simplefarming:fruit_log', 'simplefarming:olive_sapling', 'simplefarming:olives'],
                 chances: [6.0, 1.1, 0.5],
                 energy_mod: 3.0,
                 water_mod: 3.0

--- a/kubejs/server_scripts/enigmatica/kubejs/global_constants.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/global_constants.js
@@ -196,18 +196,6 @@ woodVariantsToConstruct.forEach((variant) => {
 
     //BlockStripped Exceptions
     switch (logType) {
-        case 'smogstem':
-            logBlockStripped = 'minecraft:air';
-            woodBlockStripped = 'minecraft:air';
-            break;
-        case 'wigglewood':
-            logBlockStripped = 'minecraft:air';
-            woodBlockStripped = 'minecraft:air';
-            break;
-        case 'grongle':
-            logBlockStripped = 'minecraft:air';
-            woodBlockStripped = 'minecraft:air';
-            break;
         case 'withering_oak':
             logBlockStripped = 'minecraft:stripped_oak_log';
             woodBlockStripped = 'minecraft:stripped_oak_wood';


### PR DESCRIPTION
Simple Farming Insolator recipes: typo :(

Added Immersive Engineering Saw Mill recipes, but not happy with them. For whatever reason, no matter how I try to add the secondaries (for sawdust output) it just fails to load the recipe entirely.

Good enough for now, I guess. I hope we don't need to do this with datapacks.

undergarden added stripped varieties, so removed exception handling for that.