### PR TITLE
Tree Updates

### DIFF
--- a/kubejs/data/botanytrees/recipes/byg/brown_zelkova.json
+++ b/kubejs/data/botanytrees/recipes/byg/brown_zelkova.json
@@ -1,0 +1,49 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:brown_zelkova_sapling"
+    }
+  ],
+  "seed": {
+    "item": "byg:brown_zelkova_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "byg:brown_zelkova_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.50,
+      "output": {
+        "item": "byg:zelkova_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "byg:brown_zelkova_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    }
+  ]
+}

--- a/kubejs/data/botanytrees/recipes/quark/red_blossom_sapling.json
+++ b/kubejs/data/botanytrees/recipes/quark/red_blossom_sapling.json
@@ -3,26 +3,26 @@
     "conditions": [
         {
             "type": "forge:mod_loaded",
-            "modid": "byg"
+            "modid": "quark"
         },
         {
             "type": "forge:item_exists",
-            "item": "byg:zelkova_sapling"
+            "item": "quark:red_blossom_sapling"
         }
     ],
     "seed": {
-        "item": "byg:zelkova_sapling"
+        "item": "quark:red_blossom_sapling"
     },
     "categories": ["dirt"],
     "growthTicks": 2400,
     "display": {
-        "block": "byg:zelkova_sapling"
+        "block": "quark:red_blossom_sapling"
     },
     "results": [
         {
             "chance": 0.5,
             "output": {
-                "item": "byg:zelkova_log"
+                "item": "minecraft:spruce_log"
             },
             "minRolls": 1,
             "maxRolls": 1
@@ -38,7 +38,7 @@
         {
             "chance": 0.05,
             "output": {
-                "item": "byg:zelkova_sapling"
+                "item": "quark:red_blossom_sapling"
             },
             "minRolls": 1,
             "maxRolls": 1

--- a/kubejs/data/botanytrees/recipes/undergarden/smogstem_sapling.json
+++ b/kubejs/data/botanytrees/recipes/undergarden/smogstem_sapling.json
@@ -3,26 +3,26 @@
     "conditions": [
         {
             "type": "forge:mod_loaded",
-            "modid": "byg"
+            "modid": "undergarden"
         },
         {
             "type": "forge:item_exists",
-            "item": "byg:zelkova_sapling"
+            "item": "undergarden:smogstem_sapling"
         }
     ],
     "seed": {
-        "item": "byg:zelkova_sapling"
+        "item": "undergarden:smogstem_sapling"
     },
     "categories": ["dirt"],
     "growthTicks": 2400,
     "display": {
-        "block": "byg:zelkova_sapling"
+        "block": "undergarden:smogstem_sapling"
     },
     "results": [
         {
             "chance": 0.5,
             "output": {
-                "item": "byg:zelkova_log"
+                "item": "undergarden:smogstem_log"
             },
             "minRolls": 1,
             "maxRolls": 1
@@ -30,7 +30,7 @@
         {
             "chance": 0.1,
             "output": {
-                "item": "minecraft:stick"
+                "item": "undergarden:twistytwig"
             },
             "minRolls": 1,
             "maxRolls": 2
@@ -38,7 +38,7 @@
         {
             "chance": 0.05,
             "output": {
-                "item": "byg:zelkova_sapling"
+                "item": "undergarden:smogstem_sapling"
             },
             "minRolls": 1,
             "maxRolls": 1

--- a/kubejs/data/botanytrees/recipes/undergarden/wigglewood_sapling.json
+++ b/kubejs/data/botanytrees/recipes/undergarden/wigglewood_sapling.json
@@ -3,26 +3,26 @@
     "conditions": [
         {
             "type": "forge:mod_loaded",
-            "modid": "byg"
+            "modid": "undergarden"
         },
         {
             "type": "forge:item_exists",
-            "item": "byg:zelkova_sapling"
+            "item": "undergarden:wigglewood_sapling"
         }
     ],
     "seed": {
-        "item": "byg:zelkova_sapling"
+        "item": "undergarden:wigglewood_sapling"
     },
     "categories": ["dirt"],
     "growthTicks": 2400,
     "display": {
-        "block": "byg:zelkova_sapling"
+        "block": "undergarden:wigglewood_sapling"
     },
     "results": [
         {
             "chance": 0.5,
             "output": {
-                "item": "byg:zelkova_log"
+                "item": "undergarden:wigglewood_log"
             },
             "minRolls": 1,
             "maxRolls": 1
@@ -30,7 +30,7 @@
         {
             "chance": 0.1,
             "output": {
-                "item": "minecraft:stick"
+                "item": "undergarden:twistytwig"
             },
             "minRolls": 1,
             "maxRolls": 2
@@ -38,7 +38,7 @@
         {
             "chance": 0.05,
             "output": {
-                "item": "byg:zelkova_sapling"
+                "item": "undergarden:wigglewood_sapling"
             },
             "minRolls": 1,
             "maxRolls": 1

--- a/kubejs/data/farmingforblockheads/farmingforblockheads_compat/quark_saplings.json
+++ b/kubejs/data/farmingforblockheads/farmingforblockheads_compat/quark_saplings.json
@@ -1,38 +1,43 @@
 {
-  "modId": "quark",
-  "group": {
-    "name": "Quark Saplings",
-    "enabledByDefault": true,
-    "defaultPayment": {
-      "item": "minecraft:emerald"
+    "modId": "quark",
+    "group": {
+        "name": "Quark Saplings",
+        "enabledByDefault": true,
+        "defaultPayment": {
+            "item": "minecraft:emerald"
+        },
+        "defaultCategory": "farmingforblockheads:saplings"
     },
-    "defaultCategory": "farmingforblockheads:saplings"
-  },
-  "customEntries": [
-    {
-      "output": {
-        "item": "quark:blue_blossom_sapling"
-      }
-    },
-    {
-      "output": {
-        "item": "quark:lavender_blossom_sapling"
-      }
-    },
-    {
-      "output": {
-        "item": "quark:orange_blossom_sapling"
-      }
-    },
-    {
-      "output": {
-        "item": "quark:pink_blossom_sapling"
-      }
-    },
-    {
-      "output": {
-        "item": "quark:yellow_blossom_sapling"
-      }
-    }
-  ]
+    "customEntries": [
+        {
+            "output": {
+                "item": "quark:blue_blossom_sapling"
+            }
+        },
+        {
+            "output": {
+                "item": "quark:lavender_blossom_sapling"
+            }
+        },
+        {
+            "output": {
+                "item": "quark:orange_blossom_sapling"
+            }
+        },
+        {
+            "output": {
+                "item": "quark:pink_blossom_sapling"
+            }
+        },
+        {
+            "output": {
+                "item": "quark:yellow_blossom_sapling"
+            }
+        },
+        {
+            "output": {
+                "item": "quark:red_blossom_sapling"
+            }
+        }
+    ]
 }

--- a/kubejs/data/farmingforblockheads/farmingforblockheads_compat/undergarden_saplings.json
+++ b/kubejs/data/farmingforblockheads/farmingforblockheads_compat/undergarden_saplings.json
@@ -1,0 +1,23 @@
+{
+    "modId": "undergarden",
+    "group": {
+        "name": "Undergarden Saplings",
+        "enabledByDefault": true,
+        "defaultPayment": {
+            "item": "undergarden:regalium_ingot"
+        },
+        "defaultCategory": "farmingforblockheads:saplings"
+    },
+    "customEntries": [
+        {
+            "output": {
+                "item": "undergarden:smogstem_sapling"
+            }
+        },
+        {
+            "output": {
+                "item": "undergarden:wigglewood_sapling"
+            }
+        }
+    ]
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_apple_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_apple_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:apple_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:apple_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "minecraft:apple",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_apricot_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_apricot_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:apricot_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:apricot_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "simplefarming:apricot",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_banana_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_banana_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:banana_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:banana_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "simplefarming:banana",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_blue_blossom_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_blue_blossom_sapling.json
@@ -1,0 +1,18 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "quark:blue_blossom_sapling"
+    },
+    "result": [
+        {
+            "item": "minecraft:spruce_log",
+            "chance": 6.0
+        },
+        {
+            "item": "quark:blue_blossom_sapling",
+            "chance": 1.1
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_cherry_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_cherry_sapling.json
@@ -1,0 +1,22 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "simplefarming:cherry_sapling"
+    },
+    "result": [
+        {
+            "item": "simplefarming:fruit_log",
+            "chance": 6.0
+        },
+        {
+            "item": "simplefarming:cherry_sapling",
+            "chance": 1.1
+        },
+        {
+            "item": "simplefarming:cherries",
+            "chance": 2.0
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_lavender_blossom_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_lavender_blossom_sapling.json
@@ -1,0 +1,18 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "quark:lavender_blossom_sapling"
+    },
+    "result": [
+        {
+            "item": "minecraft:spruce_log",
+            "chance": 6.0
+        },
+        {
+            "item": "quark:lavender_blossom_sapling",
+            "chance": 1.1
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_mango_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_mango_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:mango_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:mango_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "simplefarming:mango",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_olive_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_olive_sapling.json
@@ -1,0 +1,22 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "simplefarming:olive_sapling"
+    },
+    "result": [
+        {
+            "item": "simplefarming:fruit_log",
+            "chance": 6.0
+        },
+        {
+            "item": "simplefarming:olive_sapling",
+            "chance": 1.1
+        },
+        {
+            "item": "simplefarming:olives",
+            "chance": 2.0
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_orange_blossom_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_orange_blossom_sapling.json
@@ -1,0 +1,18 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "quark:orange_blossom_sapling"
+    },
+    "result": [
+        {
+            "item": "minecraft:spruce_log",
+            "chance": 6.0
+        },
+        {
+            "item": "quark:orange_blossom_sapling",
+            "chance": 1.1
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_orange_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_orange_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:orange_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:orange_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "simplefarming:orange",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_pear_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_pear_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:pear_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:pear_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "simplefarming:pear",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_pink_blossom_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_pink_blossom_sapling.json
@@ -1,0 +1,18 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "quark:pink_blossom_sapling"
+    },
+    "result": [
+        {
+            "item": "minecraft:spruce_log",
+            "chance": 6.0
+        },
+        {
+            "item": "quark:pink_blossom_sapling",
+            "chance": 1.1
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_plum_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_plum_sapling.json
@@ -1,0 +1,22 @@
+{
+  "type": "thermal:insolator",
+  "ingredient": {
+    "item": "simplefarming:plum_sapling"
+  },
+  "result": [
+    {
+      "item": "simplefarming:fruit_log",
+      "chance": 6.0
+    },
+    {
+      "item": "simplefarming:plum_sapling",
+      "chance": 1.1
+    },
+    {
+      "item": "simplefarming:plum",
+      "chance": 2.0
+    }
+  ],
+  "energy_mod": 3.0,
+  "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_red_blossom_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_red_blossom_sapling.json
@@ -1,0 +1,18 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "quark:red_blossom_sapling"
+    },
+    "result": [
+        {
+            "item": "minecraft:spruce_log",
+            "chance": 6.0
+        },
+        {
+            "item": "quark:red_blossom_sapling",
+            "chance": 1.1
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/data/thermal/recipes/machine/insolator_yellow_blossom_sapling.json
+++ b/kubejs/data/thermal/recipes/machine/insolator_yellow_blossom_sapling.json
@@ -1,0 +1,18 @@
+{
+    "type": "thermal:insolator",
+    "ingredient": {
+        "item": "quark:yellow_blossom_sapling"
+    },
+    "result": [
+        {
+            "item": "minecraft:spruce_log",
+            "chance": 6.0
+        },
+        {
+            "item": "quark:yellow_blossom_sapling",
+            "chance": 1.1
+        }
+    ],
+    "energy_mod": 3.0,
+    "water_mod": 3.0
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/insolator.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/insolator.js
@@ -365,149 +365,22 @@ events.listen('recipes', (event) => {
                 waterModifier: 3.0
             },
             {
-                input: 'quark:yellow_blossom_sapling',
+                input: 'undergarden:smogstem_sapling',
                 outputs: [
-                    item.of('minecraft:spruce_log').chance(6.0),
-                    item.of('quark:yellow_blossom_sapling').chance(1.1)
+                    item.of('undergarden:smogstem_log').chance(6.0),
+                    item.of('undergarden:smogstem_sapling').chance(1.1)
                 ],
-                energy_mod: 3.0,
-                water_mod: 3.0
+                energyModifier: 3.0,
+                waterModifier: 3.0
             },
             {
-                input: 'quark:pink_blossom_sapling',
+                input: 'undergarden:wigglewood_sapling',
                 outputs: [
-                    item.of('minecraft:spruce_log').chance(6.0),
-                    item.of('quark:pink_blossom_sapling').chance(1.1)
+                    item.of('undergarden:wigglewood_log').chance(6.0),
+                    item.of('undergarden:wigglewood_sapling').chance(1.1)
                 ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'quark:orange_blossom_sapling',
-                outputs: [
-                    item.of('minecraft:spruce_log').chance(6.0),
-                    item.of('quark:orange_blossom_sapling').chance(1.1)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'quark:lavender_blossom_sapling',
-                outputs: [
-                    item.of('minecraft:spruce_log').chance(6.0),
-                    item.of('quark:lavender_blossom_sapling').chance(1.1)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'quark:blue_blossom_sapling',
-                outputs: [
-                    item.of('minecraft:spruce_log').chance(6.0),
-                    item.of('quark:blue_blossom_sapling').chance(1.1)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'quark:red_blossom_sapling',
-                outputs: [
-                    item.of('minecraft:spruce_log').chance(6.0),
-                    item.of('quark:red_blossom_sapling').chance(1.1)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:apple_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:apple_sapling').chance(1.1),
-                    item.of('minecraft:apple').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:apricot_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:apricot_sapling').chance(1.1),
-                    item.of('simplefarming:apricot').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:banana_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:banana_sapling').chance(1.1),
-                    item.of('simplefarming:banana').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:cherry_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:cherry_sapling').chance(1.1),
-                    item.of('simplefarming:cherries').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:mango_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:mango_sapling').chance(1.1),
-                    item.of('simplefarming:mango').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:olive_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:olive_sapling').chance(1.1),
-                    item.of('simplefarming:olives').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:orange_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:orange_sapling').chance(1.1),
-                    item.of('simplefarming:orange').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:pear_sapling',
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:pear_sapling').chance(1.1),
-                    item.of('simplefarming:pear').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
-            },
-            {
-                input: 'simplefarming:plum_sapling',
-                outputs: ['simplefarming:fruit_log', 'simplefarming:plum_sapling', 'simplefarming:plum'],
-                outputs: [
-                    item.of('simplefarming:fruit_log').chance(6.0),
-                    item.of('simplefarming:plum_sapling').chance(1.1),
-                    item.of('simplefarming:plum').chance(2.0)
-                ],
-                energy_mod: 3.0,
-                water_mod: 3.0
+                energyModifier: 3.0,
+                waterModifier: 3.0
             }
         ]
     };


### PR DESCRIPTION
Quark and Simple Farming trees moved to data packs because they were both failing to load with kjs

additions to market - undergarden saplings cost regalium, in keeping with the mod's own 'villager' trade system.
additions to botany pots