### PR TITLE
Loot table remake

### DIFF
--- a/kubejs/data/enigmatica/loot_tables/chests/quest_alchemists_delight.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_alchemists_delight.json
@@ -1,0 +1,109 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:end_city_finder",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:fortress_finder",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:ender_eye",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:speed\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:haste\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:absorption\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:resistance\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:fire_resistance\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:regen_weak\"}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_ars_noueau_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_ars_noueau_loot_rare.json
@@ -1,0 +1,102 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "ars_nouveau:mana_gem",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "ars_nouveau:mythical_clay",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "ars_nouveau:marvelous_clay",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "ars_nouveau:magic_clay",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:enchanted_book",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{StoredEnchantments:[{lvl:2,id:\"ars_nouveau:mana_regen\"}]}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:enchanted_book",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{StoredEnchantments:[{lvl:2,id:\"ars_nouveau:mana_boost\"}]}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:enchanted_book",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{StoredEnchantments:[{lvl:1,id:\"minecraft:mending\"}]}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:potion",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"ars_nouveau:mana_regen_potion_long\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 3
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_blacksmiths_delight.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_blacksmiths_delight.json
@@ -1,0 +1,295 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_bow",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"bow/riser\":\"bow/extended_rest\",RepairCost:0,\"bow/long_stave_material\":\"long_stave/elementium\",display:{Name:'{\"text\":\"Stardust Bow\"}'},AS_Amulet_Holder:[890568276,-155696308,-1076725423,-1360458671],\"bow/extended_rest_material\":\"extended_rest/refined_obsidian\",\"bow/stave\":\"bow/long_stave\",honing_progress:132,HideFlags:1,\"bow/stave:stave_grip/wrap_leather\":1,\"bow/stave/settle_progress\":723,\"bow/basic_string_material\":\"basic_string/string\",\"bow/string\":\"bow/basic_string\",id:\"9d01e581-9cf7-46d5-b35b-7a121530ef08\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_bow",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"bow/riser\":\"bow/extended_rest\",RepairCost:0,Enchantments:[{lvl:2,id:\"ensorcellation:quick_draw\"}],display:{Name:'{\"text\":\"Magewrath\"}'},AS_Amulet_Holder:[890568276,-155696308,-1076725423,-1360458671],\"bow/straight_stave_material\":\"straight_stave/steel\",\"bow/extended_rest_material\":\"extended_rest/gold\",\"bow/stave\":\"bow/straight_stave\",honing_progress:144,\"quark:RuneAttached\":1,HideFlags:1,\"quark:RuneColor\":{id:\"quark:black_rune\",Count:1},\"bow/basic_string_material\":\"basic_string/hemp\",\"bow/stave:enchantment/ensorcellation_quick_draw\":2,\"bow/string\":\"bow/basic_string\",id:\"8c7d2f8b-81fd-4df8-affd-b6612454ac0e\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_bow",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"bow/stabilizer_material\":\"stabilizer/lumium\",\"bow/riser\":\"bow/stabilizer\",RepairCost:0,\"bow/recurve_stave_material\":\"recurve_stave/lumium\",display:{Name:'{\"text\":\"Dreamstone Bow\"}'},AS_Amulet_Holder:[890568276,-155696308,-1076725423,-1360458671],\"bow/stave\":\"bow/recurve_stave\",honing_progress:176,HideFlags:1,\"bow/basic_string_material\":\"basic_string/dragon_sinew\",\"bow/string\":\"bow/basic_string\",id:\"31c0af18-639a-4a5e-9f37-547674ad058d\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_bow",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"bow/riser\":\"bow/extended_rest\",RepairCost:0,\"bow/recurve_stave_material\":\"recurve_stave/netherite\",Enchantments:[{lvl:1,id:\"minecraft:flame\"}],display:{Name:'{\"text\":\"Kridershot\"}'},AS_Amulet_Holder:[890568276,-155696308,-1076725423,-1360458671],\"bow/extended_rest_material\":\"extended_rest/netherite\",\"bow/stave\":\"bow/recurve_stave\",honing_progress:116,\"quark:RuneAttached\":1,HideFlags:1,\"bow/stave/settle_progress\":959,\"quark:RuneColor\":{id:\"quark:black_rune\",Count:1},\"bow/basic_string_material\":\"basic_string/weeping_vine\",\"bow/string\":\"bow/basic_string\",\"bow/stave:enchantment/flame\":1,id:\"c69a8d4a-15ea-46d7-8666-975967052d58\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_double",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"double/handle:basic_handle/wrap_leather\":1,display:{Name:'{\"text\":\"Hadean Sickle\"}'},\"double/binding\":\"double/binding\",\"double/sickle_left_material\":\"sickle/signalum\",\"double/basic_handle_material\":\"basic_handle/bone\",\"double/binding_material\":\"double_binding/leather\",\"double/butt_right_material\":\"butt/signalum\",honing_progress:490,\"double/handle\":\"double/basic_handle\",HideFlags:1,\"double/head_left\":\"double/sickle_left\",\"double/head_right\":\"double/butt_right\",id:\"95406621-4d52-44d7-aa63-bb9288599409\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_double",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"double/handle:basic_handle/wrap_leather\":1,display:{Name:'{\"text\":\"Heartseeker\"}'},\"double/binding\":\"double/binding\",\"double/basic_handle_material\":\"basic_handle/bronze\",\"double/butt_right_material\":\"butt/elementium\",\"double/binding_material\":\"double_binding/leather\",honing_progress:357,\"double/basic_axe_left_material\":\"basic_axe/elementium\",\"double/handle\":\"double/basic_handle\",HideFlags:1,\"double/head_left\":\"double/basic_axe_left\",\"double/head_right\":\"double/butt_right\",\"double/handle:workable\":1,id:\"ff386023-cab6-42c0-b811-8f5fbd974e71\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_double",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"double/handle:basic_handle/wrap_leather\":1,display:{Name:'{\"text\":\"The Crow Bar:tm:\"}'},\"double/binding\":\"double/binding\",\"double/basic_handle_material\":\"basic_handle/forged_beam\",\"double/claw_left_material\":\"claw/compressed_iron\",\"double/binding_material\":\"double_binding/bolt\",\"double/butt_right_material\":\"butt/compressed_iron\",honing_progress:420,\"double/handle\":\"double/basic_handle\",HideFlags:1,\"double/head_left\":\"double/claw_left\",\"double/head_right\":\"double/butt_right\",id:\"4b53fd6c-b49f-4964-b2d2-ea81b0591c35\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_double",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,display:{Name:'{\"text\":\"Hammer Arm\"}'},\"double/binding\":\"double/binding\",\"double/basic_handle_material\":\"basic_handle/bronze\",honing_available:1,\"double/binding_material\":\"double_binding/string\",honing_progress:-25,\"double/handle\":\"double/basic_handle\",HideFlags:1,\"double/head_left\":\"double/basic_hammer_left\",\"double/head_right\":\"double/basic_hammer_right\",\"double/handle:workable\":1,id:\"105041cd-9eb0-4112-a06a-287e45d5cac3\",Damage:0,\"double/basic_hammer_right_material\":\"basic_hammer/iron\",\"double/basic_hammer_left_material\":\"basic_hammer/iron\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_double",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"double/adze_right_material\":\"adze/energized_steel\",\"double/handle:basic_handle/wrap_leather\":1,display:{Name:'{\"text\":\"Digmaster 5000\"}'},\"double/binding\":\"double/binding\",\"double/basic_handle_material\":\"basic_handle/forged_beam\",\"double/binding_material\":\"double_binding/leather\",honing_progress:490,\"double/handle\":\"double/basic_handle\",HideFlags:1,\"double/head_left\":\"double/basic_pickaxe_left\",\"double/head_right\":\"double/adze_right\",id:\"52f59607-4be6-4854-8396-6554afe8488f\",Damage:0,\"double/basic_pickaxe_left_material\":\"basic_pickaxe/energized_steel\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_double",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"double/basic_axe_right_material\":\"basic_axe/steel\",RepairCost:0,\"double/handle:basic_handle/wrap_leather\":1,display:{Name:'{\"text\":\"Rune Master\"}'},Enchantments:[{lvl:3,id:\"minecraft:looting\"}],\"double/binding\":\"double/binding\",\"double/basic_handle_material\":\"basic_handle/alfsteel\",\"double/binding_material\":\"double_binding/bolt\",\"double/basic_axe_left_material\":\"basic_axe/steel\",honing_progress:490,\"double/handle\":\"double/basic_handle\",\"quark:RuneAttached\":1,\"double/head_left\":\"double/basic_axe_left\",HideFlags:1,\"double/head_right\":\"double/basic_axe_right\",\"quark:RuneColor\":{id:\"quark:black_rune\",Count:1},id:\"c4b17fff-740e-4bec-8a28-7a18e4aca8d3\",\"double/head_left:enchantment/looting\":3,Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_shield",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"shield/plate\":\"shield/buckler\",RepairCost:0,BlockEntityTag:{Patterns:[{Pattern:\"flo\",Color:7}],Base:8},display:{Name:'{\"text\":\"Force Reactive Disk\"}'},\"shield/buckler_material\":\"buckler/hop_graphite\",honing_progress:144,HideFlags:1,\"shield/straps_material\":\"straps/hemp\",\"shield/plate:shield/banner\":0,\"shield/plate:shield/trim_leather\":0,id:\"39c2fb7a-77b5-44db-9396-0b8d39d29485\",Damage:0,\"shield/grip\":\"shield/straps\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_shield",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"shield/plate\":\"shield/tower\",\"shield/plate:shield/studs_gold\":0,RepairCost:0,\"shield/basic_grip_material\":\"basic_grip/netherite\",BlockEntityTag:{Base:1},display:{Name:'{\"text\":\"Aegis\"}'},\"shield/sturdy_boss_material\":\"sturdy_boss/gold\",honing_progress:208,HideFlags:1,\"shield/plate:shield/banner\":0,\"shield/boss\":\"shield/sturdy_boss\",id:\"1763c627-bbe6-4cb5-8d5d-0621f3a1f0a4\",Damage:0,\"shield/tower_material\":\"tower/signalum\",\"shield/grip\":\"shield/basic_grip\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_shield",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"shield/plate\":\"shield/buckler\",\"shield/plate:shield/studs_gold\":0,RepairCost:0,\"shield/basic_grip_material\":\"basic_grip/iron\",display:{Name:'{\"text\":\"Visceratuant\"}'},\"shield/sturdy_boss_material\":\"sturdy_boss/gold\",\"shield/buckler_material\":\"buckler/steel\",honing_progress:208,HideFlags:1,\"shield/boss\":\"shield/sturdy_boss\",\"shield/plate:shield/aerodynamic_trim_copper\":0,id:\"3dff82eb-06ce-44ae-979d-8dc68c2c8c06\",Damage:0,\"shield/grip\":\"shield/basic_grip\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_single",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{cooledStrength:1.0,RepairCost:0,\"single/binding_material\":\"single_binding/bolt\",display:{Name:'{\"text\":\"Razortine\"}'},\"single/handle:basic_handle/wrap_leather\":1,\"single/binding\":\"single/binding\",\"single/handle\":\"single/long_handle\",\"single/head/settle_progress\":288,\"single/long_handle_material\":\"long_handle/blaze_rod\",\"single/head:spearhead/tempered\":1,honing_progress:162,\"single/handle/settle_progress\":274,HideFlags:1,\"single/head:spearhead/serrated\":1,\"single/head\":\"single/trident\",id:\"9c868715-e8ad-499f-97e4-e82a47771922\",Damage:0,\"single/trident_material\":\"trident/trident\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_single",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"single/binding_material\":\"single_binding/leather\",display:{Name:'{\"text\":\"Sharpened Spoon\"}'},\"single/binding\":\"single/binding\",\"single/handle\":\"single/long_handle\",\"single/long_handle_material\":\"long_handle/aluminum\",\"single/head:spearhead/tempered\":1,honing_progress:208,HideFlags:1,\"single/handle:basic_handle/wrap_string\":1,\"single/head:spearhead/serrated\":1,\"single/head\":\"single/spearhead\",id:\"71526190-2f29-49d5-870f-17a71faa25fb\",Damage:0,\"single/spearhead_material\":\"spearhead/aluminum\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_single",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"single/binding_material\":\"single_binding/dragon_sinew\",display:{Name:'{\"text\":\"Spirit Lance\"}'},Enchantments:[{lvl:3,id:\"ensorcellation:magic_edge\"}],\"single/binding\":\"single/binding\",\"single/handle\":\"single/long_handle\",\"single/long_handle_material\":\"long_handle/brass\",\"single/head:spearhead/tempered\":1,honing_progress:240,\"quark:RuneAttached\":1,HideFlags:1,\"single/handle:basic_handle/wrap_string\":1,\"single/head:enchantment/ensorcellation_magic_edge\":3,\"quark:RuneColor\":{id:\"quark:gray_rune\",Count:64},\"single/head:spearhead/serrated\":1,\"single/head\":\"single/spearhead\",id:\"4cad9407-b464-4207-a3e8-5885f1b7ca91\",Damage:0,\"single/spearhead_material\":\"spearhead/spirited\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_single",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"single/binding_material\":\"single_binding/leather\",display:{Name:'{\"text\":\"Mastadon Rib\"}'},\"single/handle:basic_handle/wrap_leather\":1,\"single/binding\":\"single/binding\",\"single/handle\":\"single/long_handle\",\"single/long_handle_material\":\"long_handle/bone\",\"single/head:spearhead/tempered\":1,honing_progress:176,HideFlags:1,\"single/head:spearhead/serrated\":1,\"single/head\":\"single/spearhead\",id:\"b0d2f51e-e8b4-4a93-ba45-96e560f1457a\",Damage:0,\"single/spearhead_material\":\"spearhead/bone\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"sword/wide_guard_material\":\"wide_guard/silver\",RepairCost:0,\"sword/guard\":\"sword/wide_guard\",\"sword/reinforced_fuller_material\":\"reinforced_fuller/silver\",display:{Name:'{\"text\":\"Radiant Blade\"}'},\"sword/blade\":\"sword/basic_blade\",\"sword/basic_blade_material\":\"basic_blade/lumium\",\"sword/pommel\":\"sword/counterweight\",honing_progress:500,\"sword/fuller\":\"sword/reinforced_fuller\",\"sword/basic_hilt_material\":\"basic_hilt/steel\",HideFlags:1,\"sword/counterweight_material\":\"counterweight/bronze\",\"sword/hilt\":\"sword/basic_hilt\",id:\"0f0a0b5f-dac9-47e7-8a16-ec83559fb05b\",\"sword/blade:blade/hooked\":1,Damage:0,\"sword/blade:blade/tempered\":1}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"sword/forefinger_ring_material\":\"forefinger_ring/gold\",RepairCost:0,\"sword/guard\":\"sword/forefinger_ring\",\"sword/grip_loop_material\":\"grip_loop/gold\",\"sword/short_blade_material\":\"short_blade/steel\",\"sword/reinforced_fuller_material\":\"reinforced_fuller/steel\",display:{Name:'{\"text\":\"Blackbog’s Sharp\"}'},\"sword/blade\":\"sword/short_blade\",\"sword/pommel\":\"sword/grip_loop\",\"sword/blade/settle_progress\":340,honing_progress:545,\"sword/basic_hilt_material\":\"basic_hilt/brass\",\"sword/fuller\":\"sword/reinforced_fuller\",HideFlags:1,\"sword/hilt\":\"sword/basic_hilt\",\"sword/hilt/settle_progress\":321,id:\"a9c6052a-80c9-4dd8-8efb-f50709ae4ec5\",\"sword/blade:blade/hooked\":1,Damage:0,\"sword/blade:blade/tempered\":1}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{cooledStrength:1.0,RepairCost:0,\"sword/guard\":\"sword/binding\",display:{Name:'{\"text\":\"Gunther’s Rift\"}'},Enchantments:[{lvl:3,id:\"ensorcellation:damage_villager\"}],\"sword/binding_material\":\"sword_binding/phantom_membrane\",\"sword/blade\":\"sword/basic_blade\",\"sword/basic_blade_material\":\"basic_blade/dimensional_shard\",\"sword/hilt:basic_hilt/wrap_string\":1,\"sword/pommel\":\"sword/counterweight\",honing_progress:337,\"sword/basic_hilt_material\":\"basic_hilt/enderium\",\"quark:RuneAttached\":1,HideFlags:1,\"sword/counterweight_material\":\"counterweight/enderium\",\"quark:RuneColor\":{id:\"quark:black_rune\",Count:64},\"sword/hilt\":\"sword/basic_hilt\",\"sword/blade:enchantment/ensorcellation_damage_villager\":3,id:\"74eaacdc-5da6-41dc-81eb-7f309020c602\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"sword/reinforced_fuller_material\":\"reinforced_fuller/netherite\",display:{Name:'{\"text\":\"Dinoblade\"}'},\"sword/blade\":\"sword/heavy_blade\",\"sword/pommel\":\"sword/counterweight\",\"sword/heavy_blade_material\":\"heavy_blade/obsidian\",honing_progress:435,\"sword/basic_hilt_material\":\"basic_hilt/bone\",\"sword/fuller\":\"sword/reinforced_fuller\",HideFlags:1,\"sword/counterweight_material\":\"counterweight/blackstone\",\"sword/hilt\":\"sword/basic_hilt\",id:\"ffcecc68-e97d-411b-86a7-f707e615c50b\",Damage:0,\"sword/blade:arrested\":0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"sword/guard\":\"sword/binding\",\"sword/reinforced_fuller_material\":\"reinforced_fuller/silver\",Enchantments:[{lvl:3,id:\"ensorcellation:magic_edge\"}],display:{Name:'{\"text\":\"Zanmato\"}'},\"sword/binding_material\":\"sword_binding/bolt\",\"sword/blade\":\"sword/basic_blade\",\"sword/basic_blade_material\":\"basic_blade/refined_obsidian\",\"sword/pommel\":\"sword/counterweight\",\"sword/blade:enchantment/ensorcellation_magic_edge\":3,honing_progress:500,\"sword/hilt:basic_hilt/wrap_leather\":1,\"sword/fuller\":\"sword/reinforced_fuller\",\"sword/basic_hilt_material\":\"basic_hilt/steel\",\"quark:RuneAttached\":1,HideFlags:1,\"sword/counterweight_material\":\"counterweight/bronze\",\"quark:RuneColor\":{id:\"quark:black_rune\",Count:63},\"sword/hilt\":\"sword/basic_hilt\",id:\"e9e2addf-223d-420e-8d6f-5119efd164cf\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,display:{Name:'{\"text\":\"Muramasa\"}'},\"sword/short_blade_material\":\"short_blade/neptunium\",\"sword/blade\":\"sword/short_blade\",\"sword/pommel\":\"sword/counterweight\",\"sword/hilt:workable\":1,honing_progress:265,\"sword/hilt:basic_hilt/wrap_leather\":1,\"sword/basic_hilt_material\":\"basic_hilt/bronze\",HideFlags:1,\"sword/counterweight_material\":\"counterweight/neptunium\",\"sword/hilt\":\"sword/basic_hilt\",id:\"a9556be5-96cd-4a15-9713-0910ae637ca8\",Damage:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{cooledStrength:1.0,RepairCost:0,\"sword/guard\":\"sword/binding\",display:{Name:'{\"text\":\"Masamune\"}'},\"sword/binding_material\":\"sword_binding/leather\",\"sword/blade\":\"sword/basic_blade\",\"sword/basic_blade_material\":\"basic_blade/neptunium\",\"sword/pommel\":\"sword/counterweight\",\"sword/hilt:workable\":1,\"sword/blade/settle_progress\":1190,honing_progress:384,\"sword/basic_hilt_material\":\"basic_hilt/bronze\",HideFlags:1,\"sword/counterweight_material\":\"counterweight/neptunium\",\"sword/blade:blade/serrated\":1,\"sword/hilt\":\"sword/basic_hilt\",\"sword/hilt/settle_progress\":268,id:\"3b95febe-cec6-4f5f-9430-e7622afbee02\",\"sword/blade:blade/hooked\":1,Damage:0,\"sword/blade:blade/tempered\":1}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"sword/guard\":\"sword/binding\",\"sword/grip_loop_material\":\"grip_loop/string\",\"sword/short_blade_material\":\"short_blade/emerald\",\"sword/reinforced_fuller_material\":\"reinforced_fuller/lead\",display:{Name:'{\"text\":\"Jagged Crystal Shard\"}'},\"sword/binding_material\":\"sword_binding/bolt\",\"sword/blade\":\"sword/short_blade\",\"sword/hilt:basic_hilt/wrap_string\":1,\"sword/pommel\":\"sword/grip_loop\",honing_progress:370,\"sword/basic_hilt_material\":\"basic_hilt/oak\",\"sword/fuller\":\"sword/reinforced_fuller\",HideFlags:1,\"sword/hilt\":\"sword/basic_hilt\",id:\"3c45d7b6-bacd-4e57-809c-80d249d4d819\",Damage:0,\"sword/blade:arrested\":0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "tetra:modular_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{RepairCost:0,\"sword/forefinger_ring_material\":\"forefinger_ring/gold\",\"sword/guard\":\"sword/forefinger_ring\",display:{Name:'{\"text\":\"Zweihander\"}'},\"sword/blade\":\"sword/basic_blade\",\"sword/basic_blade_material\":\"basic_blade/iron\",\"sword/pommel\":\"sword/counterweight\",\"sword/blade/settle_progress\":342,honing_progress:600,\"sword/basic_hilt_material\":\"basic_hilt/netherite\",HideFlags:1,\"sword/blade:blade/serrated\":1,\"sword/counterweight_material\":\"counterweight/gold\",\"sword/hilt\":\"sword/basic_hilt\",\"sword/hilt/settle_progress\":548,\"sword/blade:blade/hooked\":1,id:\"3f559918-ade0-4508-ad8a-469836a6ca04\",Damage:0,\"sword/blade:blade/tempered\":1}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_blood_magic_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_blood_magic_loot_epic.json
@@ -1,0 +1,109 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:speedrune",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:sacrificerune",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:selfsacrificerune",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:altarcapacityrune",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:bettercapacityrune",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:ritualstone",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 24
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:stonebrickpath",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 12
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:woodbrickpath",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 12
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:wornstonebrickpath",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 12
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_blood_magic_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_blood_magic_loot_rare.json
@@ -1,0 +1,54 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:basiccuttingfluid",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Damage: 0,Enchantments: [{lvl: 5,id:\"minecraft:unbreaking\"}]}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:primitive_explosive_cell",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Damage: 0,Enchantments: [{lvl: 5,id:\"minecraft:unbreaking\"}]}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:primitive_crystalline_resonator",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Damage: 0,Enchantments: [{lvl: 5,id:\"minecraft:unbreaking\"}]}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "bloodmagic:lavacrystal",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_botania_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_botania_loot_epic.json
@@ -1,0 +1,219 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:medumone",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:agricarnation",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:tangleberrie",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:exoflame",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:gourmaryllis",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_water",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_fire",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_earth",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_air",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_spring",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_summer",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_autumn",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_winter",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:spectrolus",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:flask",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:overgrowth_seed",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:spark",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:jaded_amaranthus",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:munchdew",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_botania_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_botania_loot_legendary.json
@@ -1,0 +1,241 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 3,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:light_relay",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:overgrowth_seed",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:resistance\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:bloodthirst\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:brew_flask",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{brewKey:\"botania:emptiness\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rannuncarpus",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:spectranthemum",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:elementium_ingot",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:pixie_dust",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:dragonstone",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:red_string",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rafflowsia",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_lust",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_gluttony",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_greed",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_sloth",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:heisei_dream",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_wrath",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_envy",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:rune_pride",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:blacker_lotus",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_botania_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_botania_loot_rare.json
@@ -1,0 +1,252 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:manasteel_ingot",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:livingrock",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:manaweave_cloth",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_four_leaf_clover",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_blue_butterfly",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_groucho_glasses",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cacophonium",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:mana_pearl",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:livingwood",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:vine_ball",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:grass_seeds",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_unicorn_horn",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_thick_eyebrows",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_puffy_scarf",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:mana_diamond",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:goddess_charm",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:incense_stick",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:mana_ring",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mana: 500000}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_black_bowtie",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_eerie_mask",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "botania:cosmetic_engineer_goggles",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "botania:solegnolia",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_farmers_delight.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_farmers_delight.json
@@ -1,0 +1,87 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:oreo_cookie",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "simplefarming:sushi",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "farmersdelight:pasta_with_mutton_chop",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "farmersdelight:squid_ink_pasta",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "simplefarming:vegetable_curry",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "farmersdelight:fish_stew",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "pneumaticcraft:cod_n_chips",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_immersive_engineering_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_immersive_engineering_loot_epic.json
@@ -1,0 +1,98 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:basic_fluid_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{FluidTanks:[{Tank:0,stored:{FluidName:\"immersiveengineering:ethanol\",Amount:14000}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:shader_bag_rare",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:shader_bag_epic",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:coke",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:capacitor_hv",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:dragons_breath",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:homing",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:generator",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_immersive_engineering_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_immersive_engineering_loot_rare.json
@@ -1,0 +1,98 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "emendatusenigmatica:steel_ingot",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:dynamo",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:hemp_fabric",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:shader_bag_uncommon",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:coal_coke",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:casull",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:heavy_engineering",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "immersiveengineering:wirecoil_copper_ins",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_industrial_foregoing_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_industrial_foregoing_loot_epic.json
@@ -1,0 +1,109 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:basic_fluid_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{FluidTanks:[{Tank:0,stored:{FluidName:\"industrialforegoing:latex\",Amount:14000}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:pink_slime",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:machine_frame_advanced",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:efficiency_addon_2",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{TitaniumAugment:{Efficiency:0.8}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:speed_addon_2",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{TitaniumAugment:{Speed:3.0}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:mob_imprisonment_tool",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:mechanical_dirt",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:basic_fluid_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{FluidTanks:[{Tank:0,stored:{FluidName:\"industrialforegoing:essence\",Amount:14000}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:fertilizer",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 64
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_industrial_foregoing_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_industrial_foregoing_loot_rare.json
@@ -1,0 +1,92 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:machine_frame_pity",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:machine_frame_simple"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:conveyor",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:dark_glass",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:dryrubber",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:dryrubber",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:efficiency_addon_1",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{TitaniumAugment:{Efficiency:0.9}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "industrialforegoing:speed_addon_1",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{TitaniumAugment:{Speed:2.0}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_epic.json
@@ -1,0 +1,92 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_chemical_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:carbon\",amount:5120}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_chemical_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:redstone\",amount:5120}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:upgrade_speed",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:upgrade_energy",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_universal_cable",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_mechanical_pipe",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_pressurized_tube",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:ultimate_tier_installer"
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_legendary.json
@@ -1,0 +1,76 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 3,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:reprocessed_fissile_fragment",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 24
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:quantum_entangloporter",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:upgrade_speed",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:upgrade_energy",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:ultimate_induction_cell",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:pellet_polonium",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_rare.json
@@ -1,0 +1,125 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_chemical_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:fungi\",amount:128000}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_chemical_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:bio\",amount:128000}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_chemical_tank",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:ethene\",amount:16000}}]}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:upgrade_speed",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:upgrade_energy",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:steel_casing",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:dynamic_tank",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 28
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:basic_pressurized_tube",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:basic_universal_cable",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:basic_mechanical_pipe",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:elite_tier_installer"
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_natures_aura_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_natures_aura_loot_epic.json
@@ -1,0 +1,52 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_euphoria"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_terror"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_rage"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_grief"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:sky_ingot",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:tainted_gold",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_natures_aura_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_natures_aura_loot_rare.json
@@ -1,0 +1,68 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:pickup_stopper"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:infused_iron",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:gold_powder",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_joy"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_fear"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_anger"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:token_sorrow"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "naturesaura:ancient_log",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_epic.json
@@ -1,0 +1,54 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "pneumaticcraft:speed_upgrade",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "pneumaticcraft:advanced_pcb",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "pneumaticcraft:volume_upgrade",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "pneumaticcraft:advanced_pressure_tube",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_legendary.json
@@ -1,0 +1,42 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 3,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "pneumaticcraft:programming_puzzle",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "pneumaticcraft:drone",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{\"pneumaticcraft:air\": 120000}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 3,
+                    "name": "pneumaticcraft:printed_circuit_board"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "pneumaticcraft:smart_chest"
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_rare.json
@@ -1,0 +1,65 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "pneumaticcraft:pressure_tube",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "pneumaticcraft:logistics_core",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "pneumaticcraft:reinforced_brick_tile",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "pneumaticcraft:omnidirectional_hopper",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "pneumaticcraft:liquid_hopper",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_powah_loot.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_powah_loot.json
@@ -1,0 +1,207 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 250,
+                    "name": "powah:uraninite",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 250,
+                    "name": "emendatusenigmatica:uranium_ingot",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 250,
+                    "name": "minecraft:ice",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 250,
+                    "name": "minecraft:blue_ice",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 100,
+                    "name": "powah:dry_ice",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 250,
+                    "name": "powah:energy_cell_basic"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 50,
+                    "name": "powah:energy_cell_blazing"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 100,
+                    "name": "powah:charged_snowball",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 100,
+                    "name": "powah:energy_hopper_hardened"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 150,
+                    "name": "powah:energy_cable_hardened",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 25,
+                    "name": "powah:crystal_nitro",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 4,
+                                "max": 8
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 40,
+                    "name": "powah:ender_gate_blazing"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 75,
+                    "name": "powah:niotic_crystal_block",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 150,
+                    "name": "powah:player_aerial_pearl"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 150,
+                    "name": "powah:furnator_hardened"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 75,
+                    "name": "powah:energizing_rod_nitro"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 20,
+                    "name": "powah:reactor_nitro",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 10
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 300,
+                    "name": "powah:dielectric_paste",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 250,
+                    "name": "powah:dielectric_casing",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 100,
+                    "name": "powah:energy_discharger_blazing"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 150,
+                    "name": "powah:steel_energized",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 10
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 50,
+                    "name": "powah:crystal_spirited",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 6
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_refined_storage_loot.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_refined_storage_loot.json
@@ -1,0 +1,108 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:speed_upgrade",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:processor_binding",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:basic_processor",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:improved_processor",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:advanced_processor",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:1k_storage_part",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:storage_housing",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:quartz_enriched_iron",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:exporter"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "refinedstorage:importer"
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_epic.json
@@ -1,0 +1,120 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:iron_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.03776067512895905,Operation:1,UUID:[-1207541730,-1263776829,-1439313122,-2011209013],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"iron\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[287125043,-76594110,-1156608721,2013250607],Age:0,TicksSincePollination:14,AngerTime:0,Motion:[-0.061626914871871934,0.14485856115182605,0.061626914871871934],Health:10.0,HasNectar:0,Color:\"#ffcc99\",LeftHanded:0,Air:300,OnGround:0,Rotation:[45.0,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.89120923709993,83.65707319191107,-115.89120923709993],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:gold_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.04988226533241591,Operation:1,UUID:[-1544817110,-1553904909,-1974379402,1770924971],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"gold\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1656555906,-1850521131,-2114768571,2015954931],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#FFDC00\",LeftHanded:0,Air:300,OnGround:1,Rotation:[18.148878,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:slimy_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.013606562186442081,Operation:1,UUID:[-1798378031,-782940862,-1646942087,-1274928609],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"slimy\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2106735075,-1393999531,-1464116735,-631421951],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#73c262\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-76.92932,-39.664703],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:redstone_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.02171583473853723,Operation:1,UUID:[1341026862,-1320991644,-1721502208,1785350270],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"redstone\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[1116904453,419972642,-1399259999,90032775],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#aa0f01\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-0.7652893,-40.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:nether_quartz_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.004435865221507377,Operation:1,UUID:[2069761863,-1974450039,-1332587149,788772581],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"nether_quartz\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[766701581,1367687438,-1783737777,2024356951],Age:0,TicksSincePollination:13,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#D4CABA\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-141.63295,-38.18873],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:blaze_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.11251533095718043,Operation:1,UUID:[-1723845324,-487832759,-1907845729,-1118786055],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"blaze\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-581167871,-1550433063,-1854939199,-53356043],Age:0,TicksSincePollination:12,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#ff4500\",LeftHanded:0,Air:300,OnGround:1,Rotation:[95.94287,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:obsidian_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.013314845678952851,Operation:1,UUID:[1896959653,-1267908223,-1664980160,1417694414],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"obsidian\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1279081246,1715486971,-1582167596,-1825003670],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#663399\",LeftHanded:1,Air:300,OnGround:1,Rotation:[-104.97218,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:pigman_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.019736818079820487,Operation:1,UUID:[597960220,-327661581,-1267830748,1772569299],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"pigman\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2018514627,2068793738,-1729941754,393700331],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#885956\",LeftHanded:1,Air:300,OnGround:1,Rotation:[-14.275696,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:lapis_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.030548682081909265,Operation:1,UUID:[430561632,-1286320175,-1190363091,-2117531770],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"lapis\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[8849479,844778002,-1866845089,-2019090232],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#345ec3\",LeftHanded:0,Air:300,OnGround:1,Rotation:[114.32849,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:centrifuge_casing",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_legendary.json
@@ -1,0 +1,120 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:ghast_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[537258484,7094555,-1441412745,1102607046],Amount:-0.009925729547141894,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"ghast\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-983703877,-1900002981,-1219349477,-1711482654],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#faebd7\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-19.179138,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:ender_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[821445019,1958495190,-1996088730,-1038027832],Amount:0.008588706823919592,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"ender\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-745806510,-902936683,-1367788183,1399644643],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[0.063647862602854,0.15372139312507307,0.06364766875955409],Health:10.0,HasNectar:0,Color:\"#339786\",LeftHanded:0,Air:300,OnGround:0,Rotation:[315.00046,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.1787399633461,83.8139317532715,-115.82126674597329],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:tin_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1369032286,407978403,-1651282659,-2128219219],Amount:0.04451874101147999,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"tin\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[1987057706,-1210429701,-1421859662,-1468921959],Age:0,TicksSincePollination:11,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#7ec0ee\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-34.404938,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:osmium_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[268952999,1196050605,-1841934870,1445589286],Amount:-0.02712855125824559,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"osmium\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1540871553,-125415947,-1889461126,-1182135107],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[-0.03405229083276834,0.011368005735397585,0.03405229083276834],Health:10.0,HasNectar:0,Color:\"#aeeeee\",LeftHanded:0,Air:300,OnGround:0,Rotation:[45.0,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.43763317421703,82.51160000562668,-116.43763317421703],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:silver_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-965996428,1310149543,-1904655739,-264983298],Amount:-0.05082876772775438,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"silver\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1113070170,-1376760993,-1500700483,-1148813167],Age:0,TicksSincePollination:13,AngerTime:0,Motion:[-0.06990507889141243,0.08741105109931153,0.0413646223817017],Health:10.0,HasNectar:0,Color:\"#c6e2ff\",LeftHanded:0,Air:300,OnGround:0,Rotation:[66.61311,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.00434864959759,82.90944818986426,-116.13834389340269],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:copper_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1737091899,-1932572034,-2050963869,-2050341085],Amount:-0.05996216689580944,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"copper\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1667226298,944524704,-1411285709,1012706218],Age:0,TicksSincePollination:14,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#a0522d\",LeftHanded:0,Air:300,OnGround:1,Rotation:[143.01979,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:diamond_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-2032909478,-962247125,-1315128254,589700555],Amount:-0.09306339330855018,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"diamond\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2019018022,-1627241578,-1831587440,242505593],Age:0,TicksSincePollination:20,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#00ffff\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-89.75772,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:nickel_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1282900993,-1457961216,-2038247564,363623167],Amount:-0.10027345262904151,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"nickel\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:1.0E-7},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1967587529,-832354529,-1685608283,475571344],Age:0,TicksSincePollination:17,AngerTime:0,Motion:[-0.060319048313708365,0.03420263421554696,0.0],Health:10.0,HasNectar:0,Color:\"#eed8ae\",LeftHanded:0,Air:300,OnGround:0,Rotation:[90.000595,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.28559810779034,82.56986865805014,-116.49999154392948],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:lead_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[732767861,-1012710449,-2082914600,-981904681],Amount:0.021544288630234165,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"lead\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1485550679,2027571857,-1232127303,1077253812],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#483d8b\",LeftHanded:0,Air:300,OnGround:1,Rotation:[15.37689,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:emerald_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1484871407,-1549188744,-1375894161,1813609911],Amount:0.07240741837451369,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"emerald\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-907487775,-904051415,-2136428292,-1854446217],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#18eb09\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-41.74118,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_rare.json
@@ -1,0 +1,131 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:coal_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1502084261,404045911,-2036350325,-1382479013],Amount:0.009820156640921557,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"coal\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-530298486,997411316,-1615973353,516174548],Age:0,TicksSincePollination:14,AngerTime:0,Motion:[0.06781557272384404,0.16427450739521868,-0.06781585349882853],Health:10.0,HasNectar:0,Color:\"#303030\",LeftHanded:0,Air:300,OnGround:0,Rotation:[225.00081,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.26535201841719,84.18627668990302,-119.26536074810575],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:rgbee_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1879255474,-341487687,-1958102753,1067334919],Amount:-0.07617916294406485,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"rgbee\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1760308052,1083983260,-1158210155,-1121206146],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[-0.05567068597973056,0.07719494815674387,-0.05567068597973056],Health:10.0,HasNectar:0,Color:\"rainbow\",LeftHanded:0,Air:300,OnGround:0,Rotation:[135.0,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.12346572287262,82.8202532414989,-118.87653427712738],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:skeleton_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":200},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[632314797,1649036610,-1916246567,-2081020520],Amount:0.010503948595751936,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:1.0,Name:\"forge:swim_speed\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"skeleton\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:1.0E-7},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1200750323,-643807998,-1661475736,-2139815504],Age:0,TicksSincePollination:212,AngerTime:0,Motion:[0.04169481601608948,-0.025363391244413436,-0.07531976444622393],Health:10.0,HasNectar:0,Color:\"#F6F2E6\",LeftHanded:0,Air:300,OnGround:0,Rotation:[195.44348,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[85.2699248070104,83.91637306064253,-115.58410403080899],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:zombie_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.0936862303490246,Operation:1,UUID:[-312680417,-1419164042,-1527043506,-1765698721],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"zombie\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2040481035,945045742,-1214201871,-1569838191],Age:0,TicksSincePollination:23,AngerTime:0,Motion:[0.04977567304691388,0.056133012261532944,0.049773433040176],Health:10.0,HasNectar:0,Color:\"#2F4E32\",LeftHanded:0,Air:300,OnGround:0,Rotation:[315.00055,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.7572860797814,82.67334987529985,-118.24273130840417],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:clay_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.07599753525026656,Operation:1,UUID:[-249541829,-1915793692,-1681318223,1393815701],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"clay\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-511091075,-1393343214,-1556101410,-1503293438],Age:0,TicksSincePollination:20,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#fffaf0\",LeftHanded:0,Air:300,OnGround:1,Rotation:[100.90365,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-117.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:creeper_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.030389709675037565,Operation:1,UUID:[509519592,-315143884,-1193781020,-1429426110],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"creeper\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-234873933,-157857309,-1277655463,-1602572860],Age:0,TicksSincePollination:13,AngerTime:0,Motion:[-0.07873024048655934,0.07719494815674387,0.0],Health:10.0,HasNectar:0,Color:\"#0C9F0A\",LeftHanded:0,Air:300,OnGround:0,Rotation:[90.0009,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.96750010947478,82.8202532414989,-118.49999154392948],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:glass_bottle",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:shears",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:comparator",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:dropper",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:observer",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_scavengers_delight.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_scavengers_delight.json
@@ -1,0 +1,158 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 2,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:paper",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:leather",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:book",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "simplefarming:kenaf_fiber",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:glass",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:terracotta",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:brick",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:nether_brick",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:gunpowder",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:honeycomb",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:honey_bottle",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:ender_pearl",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "apotheosis:prismatic_web",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "minecraft:heart_of_the_sea"
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_thermal_series_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_thermal_series_loot_epic.json
@@ -1,0 +1,40 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:rf_coil_xfer_augment"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:machine_speed_augment"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:machine_output_augment"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:dynamo_output_augment"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:dynamo_fuel_augment"
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:upgrade_augment_3"
+                }
+            ]
+        }
+    ]
+}

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_thermal_series_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_thermal_series_loot_rare.json
@@ -1,0 +1,48 @@
+{
+    "type": "minecraft:chest",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:machine_frame",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:rubber",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:obsidian_glass",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "thermal:upgrade_augment_2"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Loot tables for all current quests.

For future reference, the following two sites were of enormous help:

https://amaury.carrade.eu/minecraft/loot_tables
This allows for building the loot tables right in the page and intelligently escapes double quotes in NBT strings

https://gaming.stackexchange.com/questions/334946/minecraft-1-13-displayname-nbt-tag
For all of the named Tetra items, the first site was having trouble. I had to wrap the display name in single quotes like so:

from this: `display:{Name:\"{\"text\":\"Blackbog's Sharp\"}\"}`

to this: `display:{Name:'{\"text\":\"Blackbog’s Sharp\"}'}`

And that also required using a curly apostrophe for possessives as a plain single quote was breaking the outside wrapping.