### PR TITLE
Add custom values to names.cfg

### DIFF
--- a/config/apotheosis/names.cfg
+++ b/config/apotheosis/names.cfg
@@ -26,6 +26,9 @@ armors {
     # Repair Material: undergarden:cloggrum_ingot
     #  [default: ]
     S:CLOGGRUM <
+        Cloggrum
+        Mysterious
+        Deep
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -52,6 +55,9 @@ armors {
     # Repair Material: undergarden:froststeel_ingot
     #  [default: ]
     S:FROSTSTEEL <
+        Froststeel
+        Freezing
+        Cold
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -79,7 +85,6 @@ armors {
     #  [default: [Iron], [Steel], [Ferrous], [Rusty], [Wrought Iron]]
     S:IRON <
         Iron
-        Steel
         Ferrous
         Rusty
         Wrought Iron
@@ -101,6 +106,10 @@ armors {
     # Repair Material: botania:manasteel_ingot
     #  [default: ]
     S:MANASTEEL <
+        Manasteel
+        Magical
+        Bright Blue
+        Floral Iron
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -122,6 +131,10 @@ armors {
     # Repair Material: minecraft:iron_ingot
     #  [default: ]
     S:MINING <
+        Lamp-holding
+        Shining
+        Mining
+        Illuminating
      >
     S:NEGATITE <
      >
@@ -263,6 +276,11 @@ armors {
     # Repair Material: dustrial_decor:cardboard
     #  [default: ]
     S:dustrial_decor_cardboard_helmet <
+        Cardboard
+        Paper Thin
+        Useless
+        Soggy
+        Corrugated
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -347,6 +365,9 @@ armors {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_bronze_helmet <
+        Bronze
+        Gladiator
+        Brass
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -354,6 +375,10 @@ armors {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_lapis_lazuli_helmet <
+        Lapis
+        Blue
+        Enchanting
+        Azure
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -361,6 +386,8 @@ armors {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_osmium_helmet <
+        Osmium
+        Unrefined
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -368,6 +395,10 @@ armors {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_refined_glowstone_helmet <
+        Refined Glowstone
+        Glowing
+        Lit
+        Glassy
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -382,6 +413,10 @@ armors {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_steel_helmet <
+        Steel
+        Chrome
+        Carbon Steel
+        Hardened
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -508,6 +543,18 @@ entity {
         Sheep
         Squid
         Hell
+        Flab
+        Ort
+        Alli
+        Joe
+        Tastic
+        Spa
+        Tan
+        Kung
+        Fu
+        Kee
+        Sue
+        Um
      >
 
     # A list of full names, which are used in the generation of boss names. May be empty only if name parts is not empty. [default: [Albert], [Andrew], [Anderson], [Andy], [Allan], [Arthur], [Aaron], [Allison], [Arielle], [Amanda], [Anne], [Annie], [Amy], [Alana], [Brandon], [Brady], [Bernard], [Ben], [Benjamin], [Bob], [Bobette], [Brooke], [Brandy], [Beatrice], [Bea], [Bella], [Becky], [Carlton], [Carl], [Calvin], [Cameron], [Carson], [Chase], [Cassandra], [Cassie], [Cas], [Carol], [Carly], [Cherise], [Charlotte], [Cheryl], [Chasity], [Danny], [Drake], [Daniel], [Derrel], [David], [Dave], [Donovan], [Don], [Donald], [Drew], [Derrick], [Darla], [Donna], [Dora], [Danielle], [Edward], [Elliot], [Ed], [Edson], [Elton], [Eddison], [Earl], [Eric], [Ericson], [Eddie], [Ediovany], [Emma], [Elizabeth], [Eliza], [Esperanza], [Esper], [Esmeralda], [Emi], [Emily], [Elaine], [Fernando], [Ferdinand], [Fred], [Feddie], [Fredward], [Frank], [Franklin], [Felix], [Felicia], [Fran], [Greg], [Gregory], [George], [Gerald], [Gina], [Geraldine], [Gabby], [Hendrix], [Henry], [Hobbes], [Herbert], [Heath], [Henderson], [Helga], [Hera], [Helen], [Helena], [Hannah], [Ike], [Issac], [Israel], [Ismael], [Irlanda], [Isabelle], [Irene], [Irenia], [Jimmy], [Jim], [Justin], [Jacob], [Jake], [Jon], [Johnson], [Jonny], [Jonathan], [Josh], [Joshua], [Julian], [Jesus], [Jericho], [Jeb], [Jess], [Joan], [Jill], [Jillian], [Jessica], [Jennifer], [Jenny], [Jen], [Judy], [Kenneth], [Kenny], [Ken], [Keith], [Kevin], [Karen], [Kassandra], [Kassie], [Leonard], [Leo], [Leroy], [Lee], [Lenny], [Luke], [Lucas], [Liam], [Lorraine], [Latasha], [Lauren], [Laquisha], [Livia], [Lydia], [Lila], [Lilly], [Lillian], [Lilith], [Lana], [Mason], [Mike], [Mickey], [Mario], [Manny], [Mark], [Marcus], [Martin], [Marty], [Matthew], [Matt], [Max], [Maximillian], [Marth], [Mia], [Marriah], [Maddison], [Maddie], [Marissa], [Miranda], [Mary], [Martha], [Melonie], [Melody], [Mel], [Minnie], [Nathan], [Nathaniel], [Nate], [Ned], [Nick], [Norman], [Nicholas], [Natasha], [Nicki], [Nora], [Nelly], [Nina], [Orville], [Oliver], [Orlando], [Owen], [Olsen], [Odin], [Olaf], [Ortega], [Olivia], [Patrick], [Pat], [Paul], [Perry], [Pinnochio], [Patrice], [Patricia], [Pennie], [Petunia], [Patti], [Pernelle], [Quade], [Quincy], [Quentin], [Quinn], [Roberto], [Robbie], [Rob], [Robert], [Roy], [Roland], [Ronald], [Richard], [Rick], [Ricky], [Rose], [Rosa], [Rhonda], [Rebecca], [Roberta], [Sparky], [Shiloh], [Stephen], [Steve], [Saul], [Sheen], [Shane], [Sean], [Sampson], [Samuel], [Sammy], [Stefan], [Sasha], [Sam], [Susan], [Suzy], [Shelby], [Samantha], [Sheila], [Sharon], [Sally], [Stephanie], [Sandra], [Sandy], [Sage], [Tim], [Thomas], [Thompson], [Tyson], [Tyler], [Tom], [Tyrone], [Timmothy], [Tamara], [Tabby], [Tabitha], [Tessa], [Tiara], [Tyra], [Uriel], [Ursala], [Uma], [Victor], [Vincent], [Vince], [Vance], [Vinny], [Velma], [Victoria], [Veronica], [Wilson], [Wally], [Wallace], [Will], [Wilard], [William], [Wilhelm], [Xavier], [Xandra], [Young], [Yvonne], [Yolanda], [Zach], [Zachary]]
@@ -827,6 +874,22 @@ entity {
         Doctor
         Father
         Mother
+        Missus
+        Lord
+        King
+        Queen
+        Princess
+        Prince
+        Their Majesty,
+        Duke
+        Duchess
+        Senator
+        President
+        Prime Minister
+        Their Honor,
+        Master
+        Señor
+        Señora
      >
 
     # A list of suffixes, which are used in the generation of boss names. A suffix is always preceeded by "The". May be empty. [default: [Mighty], [Supreme], [Superior], [Ultimate], [Lame], [Wimpy], [Curious], [Sneaky], [Pathetic], [Crying], [Eagle], [Errant], [Unholy], [Questionable], [Mean], [Hungry], [Thirsty], [Feeble], [Wise], [Sage], [Magical], [Mythical], [Legendary], [Not Very Nice], [Jerk], [Doctor], [Misunderstood], [Angry], [Knight], [Bishop], [Godly], [Special], [Toasty], [Shiny], [Shimmering], [Light], [Dark], [Odd-Smelling], [Funky], [Rock Smasher], [Son of Herobrine], [Cracked], [Sticky], [§kAlien§r], [Baby], [Manly], [Rough], [Scary], [Undoubtable], [Honest], [Non-Suspicious], [Boring], [Odd], [Lazy], [Super], [Nifty], [Ogre Slayer], [Pig Thief], [Dirt Digger], [Really Cool], [Doominator], [... Something]]
@@ -1045,6 +1108,9 @@ tools {
     # Repair Material: undergarden:cloggrum_ingot
     #  [default: ]
     S:CLOGGRUM <
+        Cloggrum
+        Mysterious
+        Deep
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1106,6 +1172,9 @@ tools {
     # Repair Material: undergarden:froststeel_ingot
     #  [default: ]
     S:FROSTSTEEL <
+        Froststeel
+        Freezing
+        Cold
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1135,7 +1204,6 @@ tools {
     #  [default: [Iron], [Steel], [Ferrous], [Rusty], [Wrought Iron]]
     S:IRON <
         Iron
-        Steel
         Ferrous
         Rusty
         Wrought Iron
@@ -1181,6 +1249,10 @@ tools {
     # Repair Material: botania:manasteel_ingot
     #  [default: ]
     S:MANASTEEL <
+        Manasteel
+        Magical
+        Bright Blue
+        Floral Iron
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1405,6 +1477,9 @@ tools {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_bronze_pickaxe <
+        Bronze
+        Gladiator
+        Brass
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1412,6 +1487,10 @@ tools {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_lapis_lazuli_pickaxe <
+        Lapis
+        Blue
+        Enchanting
+        Azure
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1419,6 +1498,8 @@ tools {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_osmium_pickaxe <
+        Osmium
+        Unrefined
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1426,6 +1507,10 @@ tools {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_refined_glowstone_pickaxe <
+        Refined Glowstone
+        Glowing
+        Lit
+        Glassy
      >
 
     # A list of material-based prefix names for this material group. May be empty.
@@ -1440,6 +1525,10 @@ tools {
     # Repair Material: null
     #  [default: ]
     S:mekanismtools_steel_pickaxe <
+        Steel
+        Chrome
+        Carbon Steel
+        Hardened
      >
 
     # A list of material-based prefix names for this material group. May be empty.


### PR DESCRIPTION
Currently the Apotheosis bosses all have default equipment and names, excluding netherite which has been removed from being possible.

This proposed change adds a number of materials to the pool by giving them names, trying not to be overpowered and appreciating the current values for what non-bosses may spawn with. This also adds a bunch of prefixes to boss names to add a bunch of variety (I'm tired of every boss I meet having the prefix Doctor, for example) and new name-parts for some additional random names.

As a side effect, I believe this will allow some of the named materials to appear as affix dungeon loot, but this is in my opinion desirable - as long as the materials are not overpowered compared to existing affix dungeon loot.