### PR TITLE
Create Ore Processing Revamp

### DIFF
--- a/config/jaopca/modules/thermal_expansion.toml
+++ b/config/jaopca/modules/thermal_expansion.toml
@@ -1,5 +1,5 @@
 
 [general]
 	#The material blacklist of this module.
-	materialBlacklist = []
+	materialBlacklist = [aluminum]
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -62,7 +62,9 @@ events.listen('recipes', function (event) {
         'mapperbase:steel_rod_from_blasting',
         'mapperbase:steel_rod',
 
-        'morevanillalib:obsidian_shard'
+        'morevanillalib:obsidian_shard',
+        'thermal:machine/plugins/create/pulverizer_create_zinc_ore',
+        'thermal:machine/plugins/mekanism/pulverizer_mek_osmium_ore'
     ];
 
     outputRemovals.forEach((removal) => {
@@ -113,6 +115,18 @@ events.listen('recipes', function (event) {
     event.remove({
         output: '/emendatusenigmatica:\\w+_gear/',
         mod: 'immersiveengineering'
+    });
+
+    event.remove({
+        input: '#forge:ores',
+        mod: 'create',
+        type: 'create:milling'
+    });
+
+    event.remove({
+        input: '#forge:ores',
+        mod: 'create',
+        type: 'create:crushing'
     });
 
     beamRecipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/crushed_ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/crushed_ores.js
@@ -1,0 +1,14 @@
+events.listen('item.tags', function (event) {
+    event.get('create:crushed_ores/nickel').add('create:crushed_nickel_ore');
+    event.get('create:crushed_ores/uranium').add('create:crushed_uranium_ore');
+    event.get('create:crushed_ores/aluminum').add('create:crushed_aluminum_ore');
+    event.get('create:crushed_ores/lead').add('create:crushed_lead_ore');
+    event.get('create:crushed_ores/tin').add('create:crushed_tin_ore');
+    event.get('create:crushed_ores/silver').add('create:crushed_silver_ore');
+    event.get('create:crushed_ores/osmium').add('create:crushed_osmium_ore');
+    event.get('create:crushed_ores/brass').add('create:crushed_brass_ore');
+    event.get('create:crushed_ores/gold').add('create:crushed_gold_ore');
+    event.get('create:crushed_ores/copper').add('create:crushed_copper_ore');
+    event.get('create:crushed_ores/iron').add('create:crushed_iron_ore');
+    event.get('create:crushed_ores/brass').add('create:crushed_brass');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
@@ -10,6 +10,8 @@ events.listen('recipes', function (event) {
         thermal_press_rods(event, material);
         thermal_press_wires(event, material);
         gear_unification(event, material);
+        create_ore_processing_with_secondary_outputs(event, material);
+        create_gem_processing(event, material);
     });
 });
 
@@ -560,4 +562,147 @@ function immersiveengineering_hammer_crafting_plates(event, material) {
             ]
         });
     }
+}
+
+function create_ore_processing_with_secondary_outputs(event, material) {
+    var secondary;
+    var processingTime;
+    if (tagIsEmpty('#create:crushed_ores/' + material)) {
+        return;
+    }
+
+    switch (material) {
+        case 'iron':
+            secondary = 'nickel';
+            processingTime = 400;
+            break;
+        case 'nickel':
+            secondary = 'iron';
+            processingTime = 350;
+            break;
+        case 'gold':
+            secondary = 'zinc';
+            processingTime = 300;
+            break;
+        case 'copper':
+            secondary = 'gold';
+            processingTime = 350;
+            break;
+        case 'aluminum':
+            secondary = 'iron';
+            processingTime = 300;
+            break;
+        case 'silver':
+            secondary = 'lead';
+            processingTime = 300;
+            break;
+        case 'uranium':
+            secondary = 'lead';
+            processingTime = 400;
+            break;
+        case 'osmium':
+            secondary = 'tin';
+            processingTime = 400;
+            break;
+        case 'tin':
+            secondary = 'osmium';
+            processingTime = 350;
+            break;
+        case 'zinc':
+            secondary = 'gold';
+            processingTime = 350;
+            break;
+        default:
+            return;
+    }
+
+    event.recipes.create.milling({
+        type: 'create:milling',
+        ingredients: [
+            {
+                tag: 'forge:ores/' + material
+            }
+        ],
+        results: [
+            {
+                item: 'create:crushed_' + material + '_ore'
+            },
+            {
+                item: 'create:crushed_' + material + '_ore',
+                chance: 0.25,
+                count: 2
+            },
+            {
+                item: 'create:crushed_' + secondary + '_ore',
+                chance: 0.05,
+                count: 2
+            }
+        ],
+        processingTime: processingTime
+    });
+
+    event.recipes.create.crushing({
+        type: 'create:crushing',
+        ingredients: [
+            {
+                tag: 'forge:ores/' + material
+            }
+        ],
+        results: [
+            {
+                item: 'create:crushed_' + material + '_ore'
+            },
+            {
+                item: 'create:crushed_' + material + '_ore',
+                chance: 0.6,
+                count: 2
+            },
+            {
+                item: 'create:crushed_' + secondary + '_ore',
+                chance: 0.1,
+                count: 2
+            },
+            {
+                item: 'minecraft:cobblestone',
+                chance: 0.125
+            }
+        ],
+        processingTime: processingTime
+    });
+}
+
+function create_gem_processing(event, material) {
+    if (tagIsEmpty('#forge:gems/' + material)) {
+        return;
+    }
+
+    var gemTag = ingredient.of('#forge:gems/' + material);
+    var gem = getPreferredItemInTag(gemTag).id;
+
+    var processingTime = 500;
+
+    event.recipes.create.crushing({
+        type: 'create:crushing',
+        ingredients: [
+            {
+                tag: 'forge:ores/' + material
+            }
+        ],
+        results: [
+            {
+                item: gem,
+                count: 2
+            },
+            {
+                item: gem,
+                chance: 0.25,
+                count: 2
+            },
+            {
+                item: 'minecraft:cobblestone',
+                chance: 0.125
+            }
+        ],
+        processingTime: processingTime
+    });
 }


### PR DESCRIPTION
Jaopca Config - blacklist aluminum from Thermal as it was creating a duplicate processing recipe.

Tagged Create's ores for easy checks

re-did all create ore processing to match #725

added gem processing to crusher (was missing for some reason, even prior to my blanket removal of ore? create has default recipes for diamond and emerald)

Fixing of Secondaries for other mods can be done at a later date.