### PR TITLE
IE and TS Ore Updates (add missing secondaries)

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
@@ -1,34 +1,59 @@
 events.listen('recipes', (event) => {
     var data = {
         recipes: [
-            { input: 'thermal:blizz_rod', primary: 'thermal:blizz_powder', secondary: 'minecraft:snowball' },
+            {
+                input: 'thermal:blizz_rod',
+                output: item.of('thermal:blizz_powder', 4),
+                secondary: [item.of('minecraft:snowball').chance(0.5)]
+            },
             {
                 input: 'thermal:blitz_rod',
-                primary: 'thermal:blitz_powder',
-                secondary: 'emendatusenigmatica:potassium_nitrate_gem'
+                output: item.of('thermal:blitz_powder', 4),
+                secondary: [item.of('emendatusenigmatica:potassium_nitrate_gem').chance(0.5)]
             },
-            { input: 'thermal:basalz_rod', primary: 'thermal:basalz_powder', secondary: 'thermal:slag' }
+            {
+                input: 'thermal:basalz_rod',
+                output: item.of('thermal:basalz_powder', 4),
+                secondary: [item.of('thermal:slag').chance(0.5)]
+            },
+            {
+                input: '#forge:ores/nickel',
+                output: item.of('emendatusenigmatica:nickel_dust', 2),
+                secondary: [item.of('emendatusenigmatica:iron_dust').chance(0.1)]
+            },
+            {
+                input: '#forge:ores/gold',
+                output: item.of('emendatusenigmatica:gold_dust', 2),
+                secondary: [item.of('emendatusenigmatica:zinc_dust').chance(0.1)]
+            },
+            {
+                input: '#forge:ores/aluminum',
+                output: item.of('emendatusenigmatica:aluminum_dust', 2),
+                secondary: [item.of('emendatusenigmatica:iron_dust').chance(0.1)]
+            },
+            {
+                input: '#forge:ores/osmium',
+                output: item.of('emendatusenigmatica:osmium_dust', 2),
+                secondary: [item.of('emendatusenigmatica:tin_dust').chance(0.1)]
+            },
+            {
+                input: '#forge:ores/tin',
+                output: item.of('emendatusenigmatica:tin_dust', 2),
+                secondary: [item.of('emendatusenigmatica:osmium_dust').chance(0.1)]
+            },
+            {
+                input: '#forge:ores/zinc',
+                output: item.of('emendatusenigmatica:zinc_dust', 2),
+                secondary: [item.of('emendatusenigmatica:gold_dust').chance(0.1)]
+            }
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.recipes.immersiveengineering.crusher({
-            type: 'immersiveengineering:crusher',
-            secondaries: [
-                {
-                    chance: 0.5,
-                    output: {
-                        item: recipe.secondary
-                    }
-                }
-            ],
-            result: {
-                item: recipe.primary,
-                count: 4
-            },
-            input: {
-                item: recipe.input
-            },
-            energy: 1600
+        event.remove({
+            input: recipe.input,
+            mod: 'immersiveengineering',
+            type: 'immersiveengineering:crusher'
         });
+        event.recipes.immersiveengineering.crusher(recipe.output, recipe.input, recipe.secondary);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
@@ -1,0 +1,60 @@
+events.listen('recipes', function (event) {
+    var data = {
+        recipes: [
+            {
+                input: '#forge:ores/nickel',
+                experience: 0.2,
+                outputs: [
+                    item.of('emendatusenigmatica:nickel_dust', 2),
+                    item.of('emendatusenigmatica:iron_dust').chance(0.1),
+                    item.of('minecraft:gravel').chance(0.2)
+                ]
+            },
+            {
+                input: '#forge:ores/aluminum',
+                experience: 0.2,
+                outputs: [
+                    item.of('emendatusenigmatica:aluminum_dust', 2),
+                    item.of('emendatusenigmatica:iron_dust').chance(0.1),
+                    item.of('minecraft:gravel').chance(0.2)
+                ]
+            },
+            {
+                input: '#forge:ores/uranium',
+                experience: 0.2,
+                outputs: [
+                    item.of('emendatusenigmatica:uranium_dust', 2),
+                    item.of('emendatusenigmatica:lead_dust').chance(0.1),
+                    item.of('minecraft:gravel').chance(0.2)
+                ]
+            },
+            {
+                input: '#forge:ores/osmium',
+                experience: 0.2,
+                outputs: [
+                    item.of('emendatusenigmatica:osmium_dust', 2),
+                    item.of('emendatusenigmatica:tin_dust').chance(0.1),
+                    item.of('minecraft:gravel').chance(0.2)
+                ]
+            },
+            {
+                input: '#forge:ores/zinc',
+                experience: 0.2,
+                outputs: [
+                    item.of('emendatusenigmatica:zinc_dust', 2),
+                    item.of('emendatusenigmatica:gold_dust').chance(0.1),
+                    item.of('minecraft:gravel').chance(0.2)
+                ]
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.remove({
+            input: recipe.input,
+            mod: 'thermal',
+            type: 'thermal:pulverizer'
+        });
+        event.recipes.thermal.pulverizer(recipe.outputs, recipe.input).experience(recipe.experience);
+    });
+});


### PR DESCRIPTION
This brings the Immersive Crusher and Thermal Pulverizer in line with the changes to Create in #725

In the case of the Pulverizer, it already has Cinnabar and Apatite as secondaries for Gold and Tin respectively, so I've opted to keep those as they're generally more important for the mod.

Jaopca is adding duplicates, however, and frankly it confuses me. I can't remove them with KJS and my attempts to work with the config either remove the recipes I'm adding, or otherwise do nothing at all. Any guidance would be appreciated :D

I've tried adding `["aluminum", "uranium", "zinc"]` to the various blacklists and just can't make them go away.