### PR TITLE
Fix for Create Processing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/create/crushed_ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/create/crushed_ores.js
@@ -9,5 +9,6 @@ events.listen('item.tags', function (event) {
     event.get('create:crushed_ores/gold').add('create:crushed_gold_ore');
     event.get('create:crushed_ores/copper').add('create:crushed_copper_ore');
     event.get('create:crushed_ores/iron').add('create:crushed_iron_ore');
+    event.get('create:crushed_ores/zinc').add('create:crushed_zinc_ore');
     event.get('create:crushed_ores/brass').add('create:crushed_brass');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
@@ -524,15 +524,8 @@ function create_ore_processing_with_secondary_outputs(event, material) {
         return;
     }
 
-    /*
-    if (tagIsEmpty('#create:crushed_ores/' + material)) {
-        return;
-    }*/
-
     var secondary;
     var processingTime;
-
-    console.info('Adding Material to Create Ore Processing :' + material);
 
     switch (material) {
         case 'iron':

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/additions.js
@@ -517,12 +517,22 @@ function immersiveengineering_hammer_crafting_plates(event, material) {
 }
 
 function create_ore_processing_with_secondary_outputs(event, material) {
-    if (tagIsEmpty('#create:crushed_ores/' + material)) {
+    var primaryTag = ingredient.of('#create:crushed_ores/' + material);
+    var primaryItem = getPreferredItemInTag(primaryTag).id;
+
+    if (primaryItem == air) {
         return;
     }
 
+    /*
+    if (tagIsEmpty('#create:crushed_ores/' + material)) {
+        return;
+    }*/
+
     var secondary;
     var processingTime;
+
+    console.info('Adding Material to Create Ore Processing :' + material);
 
     switch (material) {
         case 'iron':
@@ -565,9 +575,32 @@ function create_ore_processing_with_secondary_outputs(event, material) {
             secondary = 'gold';
             processingTime = 350;
             break;
+        case 'iesnium':
+            secondary = 'iesnium';
+            processingTime = 350;
+            break;
+        case 'cloggrum':
+            secondary = 'cloggrum';
+            processingTime = 350;
+            break;
+        case 'froststeel':
+            secondary = 'froststeel';
+            processingTime = 350;
+            break;
+        case 'regalium':
+            secondary = 'regalium';
+            processingTime = 350;
+            break;
+        case 'utherium':
+            secondary = 'utherium';
+            processingTime = 350;
+            break;
         default:
             return;
     }
+
+    var secondaryTag = ingredient.of('#create:crushed_ores/' + secondary);
+    var secondaryItem = getPreferredItemInTag(secondaryTag).id;
 
     event.recipes.create.milling({
         type: 'create:milling',
@@ -578,15 +611,15 @@ function create_ore_processing_with_secondary_outputs(event, material) {
         ],
         results: [
             {
-                item: 'create:crushed_' + material + '_ore'
+                item: primaryItem
             },
             {
-                item: 'create:crushed_' + material + '_ore',
+                item: primaryItem,
                 chance: 0.25,
                 count: 2
             },
             {
-                item: 'create:crushed_' + secondary + '_ore',
+                item: secondaryItem,
                 chance: 0.05,
                 count: 2
             }
@@ -603,15 +636,15 @@ function create_ore_processing_with_secondary_outputs(event, material) {
         ],
         results: [
             {
-                item: 'create:crushed_' + material + '_ore'
+                item: primaryItem
             },
             {
-                item: 'create:crushed_' + material + '_ore',
+                item: primaryItem,
                 chance: 0.6,
                 count: 2
             },
             {
-                item: 'create:crushed_' + secondary + '_ore',
+                item: secondaryItem,
                 chance: 0.1,
                 count: 2
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/global_constants.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/global_constants.js
@@ -97,7 +97,11 @@ const materialsToUnify = [
     'certus_quartz',
     'charged_certus_quartz',
     'iesnium',
-    'dimensional'
+    'dimensional',
+    'cloggrum',
+    'froststeel',
+    'regalium',
+    'utherium'
 ];
 
 global.materialsToUnify = materialsToUnify;


### PR DESCRIPTION
Zinc wasn't working due to a missing tag. Fixed
Moved create tags out of forge folder, into create folder.

Refactor Additions.js to use preferredItemInTag lookups to suppport the following:

buffed Iesnium from Occultism was added to the Create ore processing list, extra material being silver.

buffed undergarden ores in Create processing as well. No special secondaries here. just that bonus applied to the primary.

Materials with duplicates as a result of Jaopca:
Aluminum
cloggrum
froststeel
iesnium
lead
nickel
osmium
regalium
silver
tin
uranium
utherium