### PR TITLE
disabled quark bone to bonemeal smelt recipe

### DIFF
--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -373,7 +373,7 @@
 		#Can Rotten Flesh and Poisonous Potatoes be composted?
 		"Compostable Toxins" = true
 		#Can bones be smelted down to bone meal?
-		"Bone Meal Utility" = true
+		"Bone Meal Utility" = false
 		#Can any wool color be dyed?
 		"Dye Any Wool" = false
 		#Can Coral be crafted into dye?


### PR DESCRIPTION
fixes #759 , there are numerous other ways to turn bones to bonemeal so not needed