### PR TITLE
Occultism progression fixes

### DIFF
--- a/kubejs/data/farmingforblockheads/farmingforblockheads_compat/occultism_saplings.json
+++ b/kubejs/data/farmingforblockheads/farmingforblockheads_compat/occultism_saplings.json
@@ -1,0 +1,18 @@
+{
+    "modId": "quark",
+    "group": {
+        "name": "Occultism Saplings",
+        "enabledByDefault": true,
+        "defaultPayment": {
+            "item": "occultism:spirit_attuned_gem"
+        },
+        "defaultCategory": "farmingforblockheads:saplings"
+    },
+    "customEntries": [
+        {
+            "output": {
+                "item": "occultism:otherworld_sapling_natural"
+            }
+        }
+    ]
+}

--- a/kubejs/data/occultism/recipes/spirit_trade/4x_stone_to_otherstone.json
+++ b/kubejs/data/occultism/recipes/spirit_trade/4x_stone_to_otherstone.json
@@ -1,0 +1,11 @@
+{
+    "type": "occultism:spirit_trade",
+    "ingredients": [
+        {
+            "item": "minecraft:stone"
+        }
+    ],
+    "result": {
+        "item": "occultism:otherstone"
+    }
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/spirit_fire.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/spirit_fire.js
@@ -1,0 +1,24 @@
+events.listen('recipes', (event) => {
+    data = {
+        recipes: [
+            {
+                input: 'forge:stone',
+                result: 'occultism:otherstone'
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.custom({
+            type: 'occultism:spirit_fire',
+            ingredient: [
+                {
+                    tag: recipe.input
+                }
+            ],
+            result: {
+                item: recipe.result
+            }
+        });
+    });
+});


### PR DESCRIPTION
#829: Spirit Fire recipe for converting stone to otherstone
Unstable saplings available in Market for 1 Spirit Attuned Gem

#779: Otherstone trader recipe set to 1 stone for 1 otherstone. This removes the Create recipe conflict. Prior change pretty much removes the need for this recipe at all, however.