### PR TITLE
Valid Apiary Block updates

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/resourcefulbees/valid_apiary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/resourcefulbees/valid_apiary.js
@@ -1,0 +1,13 @@
+events.listen('item.tags', function (event) {
+    var blocks = [
+        'minecraft:soul_sand',
+        'botania:bifrost_pane',
+        'botania:bifrost_perm',
+        'botania:elf_glass_pane',
+        'botania:mana_glass_pane',
+        'botania:elf_glass',
+        'botania:mana_glass'
+    ];
+
+    event.get('resourcefulbees:valid_apiary').add(blocks);
+});


### PR DESCRIPTION
Soul sand. Comes up on discord regularly how to plant wart in the apiary. Currently you'd place soulsand inside the structure, then wart. However, this is contrary to what the book explains to do with flowers/grass. In the book, it says to make the floor out of grass and place the flowers on that.

This allows soul sand to be part of the structure now, with just the wart inside. Makes things a bit roomier.

Also added botania glass for decoration purposes as requested on discord