### PR TITLE
Liquid Fuel Pass

### DIFF
--- a/config/industrialforegoing/machine-generator.toml
+++ b/config/industrialforegoing/machine-generator.toml
@@ -21,7 +21,7 @@
 
 	[MachineGeneratorConfig.BiofuelGeneratorConfig]
 		#Amount of Power Produced per Tick - Default: [400FE]
-		powerPerTick = 160
+		powerPerTick = 250
 		#Max Stored Power [FE] - Default: [10000 FE]
 		maxStoredPower = 1000000
 		#Amount of FE/t extracted from the Biofuel Generator

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
@@ -1,4 +1,5 @@
 events.listen('recipes', (event) => {
+    var multiplier = 1000;
     var data = {
         recipes: [
             {
@@ -13,8 +14,18 @@ events.listen('recipes', (event) => {
             },
             {
                 fluid: 'thermal:tree_oil',
-                air: 700,
+                air: 100,
                 rate: 0.5
+            },
+            {
+                fluid: 'thermal:creosote',
+                air: 20,
+                rate: 0.25
+            },
+            {
+                fluid: 'thermal:refined_fuel',
+                air: 1500,
+                rate: 1.5
             }
         ]
     };
@@ -26,7 +37,7 @@ events.listen('recipes', (event) => {
                 fluid: recipe.fluid,
                 amount: 1000
             },
-            air_per_bucket: recipe.air * 1000,
+            air_per_bucket: recipe.air * multiplier,
             burn_rate: recipe.rate
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
@@ -5,63 +5,72 @@ events.listen('recipes', (event) => {
         recipes: [
             {
                 fluid: 'pneumaticcraft:diesel',
-                energy: 500000
+                energy: 1000000
             },
             {
                 fluid: 'immersivepetroleum:diesel',
-                energy: 500000
+                energy: 1000000
             },
             {
                 fluid: 'pneumaticcraft:biodiesel',
-                energy: 500000
+                energy: 1000000
             },
             {
                 fluid: 'immersiveengineering:biodiesel',
-                energy: 500000
+                energy: 1000000
             },
             {
                 fluid: 'pneumaticcraft:kerosene',
-                energy: 550000
+                energy: 1100000
             },
             {
                 fluid: 'pneumaticcraft:gasoline',
-                energy: 750000
+                energy: 1500000
             },
             {
                 fluid: 'immersivepetroleum:gasoline',
-                energy: 750000
+                energy: 1500000
             },
             {
                 fluid: 'pneumaticcraft:lpg',
-                energy: 900000
+                energy: 1800000
             },
             {
                 fluid: 'mekanism:ethene',
-                energy: 900000
+                energy: 1800000
             },
             {
                 fluid: 'pneumaticcraft:ethanol',
-                energy: 100000
+                energy: 400000
             },
             {
                 fluid: 'mekanismgenerators:bioethanol',
-                energy: 100000
+                energy: 400000
             },
             {
                 fluid: 'immersiveengineering:ethanol',
-                energy: 100000
+                energy: 400000
             },
             {
                 fluid: 'industrialforegoing:biofuel',
-                energy: 64000
+                energy: 100000
             },
             {
                 fluid: 'thermal:tree_oil',
                 energy: 100000
+            },
+            {
+                fluid: 'thermal:creosote',
+                energy: 20000
+            },
+            {
+                fluid: 'thermal:refined_fuel',
+                energy: 1500000
             }
         ]
     };
     data.recipes.forEach((recipe) => {
+        //event.recipes.thermal.compression_fuel(recipe.fluid).energy(recipe.energy * multiplier);
         event.recipes.thermal.compression_fuel({
             type: 'thermal.compression_fuel',
             ingredient: {


### PR DESCRIPTION
Added Refined Fuel to PNC and Thermal Compression dynamo. Base Thermal configs put this at about equivalent to PNC gasoline. Therefore, many other fuels need tweaking to reset ratios. Many fuels, therefore, got buffed in the compression dynamo.

Added Creosote to PNC and Thermal. Weak fuel. Good for a little boost if there's excess.

Bumped up IF's biofuel in it's generator, bringing it in line with tree oil in the compression dynamo.

Fixes #872

