### PR TITLE
Create Missing recipes for grinding ingots and gems to dust.

### DIFF
--- a/kubejs/data/bloodmagic/recipes/alchemytable/sand_coal.json
+++ b/kubejs/data/bloodmagic/recipes/alchemytable/sand_coal.json
@@ -10,7 +10,7 @@
     ],
     "output": {
         "item": "emendatusenigmatica:coal_dust",
-        "count": 4
+        "count": 2
     },
     "syphon": 400,
     "ticks": 200,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/crushing.js
@@ -1,0 +1,13 @@
+events.listen('recipes', (event) => {
+    var data = {
+        recipes: [
+            {
+                outputs: [Item.of('emendatusenigmatica:obsidian_dust'), Item.of('minecraft:obsidian').withChance(0.75)],
+                input: 'minecraft:obsidian'
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        event.recipes.create.crushing(recipe.outputs, recipe.input);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/gems.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/gems.js
@@ -13,6 +13,7 @@ events.listen('item.tags', function (event) {
     event.get(gems_ender).add('minecraft:ender_pearl');
     event.get('forge:gems/dimensional').add('rftoolsbase:dimensionalshard');
     event.get('forge:gems/mana').add('ars_nouveau:mana_gem');
+    event.get('forge:gems/charcoal').add('minecraft:charcoal');
     event.get('forge:gems/bitumen').add('mapperbase:raw_bitumen').add('immersivepetroleum:bitumen');
 
     event.get('forge:gems/mana_gem').remove('ars_nouveau:mana_gem');


### PR DESCRIPTION
Blood Magic - Coal Dust dupe loop closed. 2 coal made 4 coal dust, which could then be enriched to 4 coal

Add Charcoal to Gems tag to allow dusts to be made more easily in other machines.

Add missing Gem crushing recipes to BM ARC

Add missing Ingot crushing recipes to IE Crusher

Add missing Ingot and Gem crushing recipes for Mekanism Crusher

Add missing Ingot and Gem crushing recipes for Pedestals Crusher

Added Ingot and Gem milling recipes to create an alternate means to dusts with Create.

Added missing Ingot and Gem pulverizing to Thermal

re-added Create's obsidian crushing recipe which was previously lost.

resolves #906