### PR TITLE
Dustrial Decor crafting fixes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_output.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_output.js
@@ -7,4 +7,6 @@ events.listen('recipes', function (event) {
     event.replaceOutput({ mod: 'bloodmagic' }, 'bloodmagic:goldfragment', '#mekanism:clumps/gold');
     event.replaceOutput({ mod: 'bloodmagic' }, 'bloodmagic:irongravel', '#mekanism:dirty_dusts/iron');
     event.replaceOutput({ mod: 'bloodmagic' }, 'bloodmagic:goldgravel', '#mekanism:dirty_dusts/gold');
+    event.replaceOutput({ mod: 'dustrial_decor' }, 'minecraft:iron_ingot', 'dustrial_decor:rusty_iron_ingot');
+    event.replaceOutput({ mod: 'dustrial_decor' }, 'minecraft:iron_nugget', 'dustrial_decor:rusty_iron_nugget');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
@@ -30,15 +30,15 @@ events.listen('recipes', (event) => {
                 output: item.of('byg:black_sand', 4)
             },
             {
-                inputs: [item.of('byg:black_sandstone', 1), item.of('thermal:press_unpacking_die')],
+                inputs: [item.of('biomesoplenty:black_sandstone', 1), item.of('thermal:press_unpacking_die')],
                 output: item.of('biomesoplenty:black_sand', 4)
             },
             {
-                inputs: [item.of('byg:orange_sandstone', 1), item.of('thermal:press_unpacking_die')],
+                inputs: [item.of('biomesoplenty:orange_sandstone', 1), item.of('thermal:press_unpacking_die')],
                 output: item.of('biomesoplenty:orange_sand', 4)
             },
             {
-                inputs: [item.of('byg:white_sandstone', 1), item.of('thermal:press_unpacking_die')],
+                inputs: [item.of('biomesoplenty:white_sandstone', 1), item.of('thermal:press_unpacking_die')],
                 output: item.of('biomesoplenty:white_sand', 4)
             }
         ]


### PR DESCRIPTION
Dustrial Decor had several recipes broken since rusty iron was un-craftable. Fixed.

Also fixes error introduced in #922 with sand unpacking.