### PR TITLE
Fix for missing Create Gearshift recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -112,7 +112,7 @@ events.listen('recipes', function (event) {
     });
 
     event.remove({
-        output: '/\\w+:\\w+_gear/',
+        output: '/\\w+:\\w+_gear$/',
         type: 'minecraft:crafting_shaped'
     });
 


### PR DESCRIPTION
`$` at the end makes the filter require `_gear` to appear at the end of the string in order to match. Will no longer match on `_gearshift`. Still matches the intended gear recipe removals.

Fixes #893