### PR TITLE
Update Apoth Over Enchanting

### DIFF
--- a/config/apotheosis/enchantments.cfg
+++ b/config/apotheosis/enchantments.cfg
@@ -45,7 +45,7 @@
 
 "apotheosis:bane_of_illagers" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=10
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -75,7 +75,7 @@
 
 "apotheosis:capturing" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -105,7 +105,7 @@
 
 "apotheosis:depth_miner" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=11
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -120,7 +120,7 @@
 
 "apotheosis:hell_infusion" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=12
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -135,7 +135,7 @@
 
 "apotheosis:icy_thorns" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 4]
-    I:"Max Level"=6
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -150,7 +150,7 @@
 
 "apotheosis:knowledge" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 4]
-    I:"Max Level"=8
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -194,7 +194,7 @@
 
 
 "apotheosis:mounted_strike" {
-    I:"Max Level"=15
+    I:"Max Level"=7
     S:"Max Power Function"=
     I:"Min Level"=1
     S:"Min Power Function"=
@@ -203,7 +203,7 @@
 
 "apotheosis:natures_blessing" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=12
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -233,7 +233,7 @@
 
 "apotheosis:rebounding" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 6]
-    I:"Max Level"=17
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -248,7 +248,7 @@
 
 "apotheosis:reflective" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=9
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -293,7 +293,7 @@
 
 "apotheosis:shield_bash" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -308,7 +308,7 @@
 
 "apotheosis:splitting" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=15
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -366,50 +366,6 @@
 }
 
 
-"ars_nouveau:mana_boost" {
-    # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 3]
-    I:"Max Level"=3
-
-    # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
-
-    # The min level of this enchantment. [range: 1 ~ 127, default: 1]
-    I:"Min Level"=1
-
-    # A function to determine the min enchanting power. [default: ]
-    S:"Min Power Function"=
-}
-
-
-"ars_nouveau:mana_regen" {
-    # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 3]
-    I:"Max Level"=3
-
-    # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
-
-    # The min level of this enchantment. [range: 1 ~ 127, default: 1]
-    I:"Min Level"=1
-
-    # A function to determine the min enchanting power. [default: ]
-    S:"Min Power Function"=
-}
-
-
-"ars_nouveau:reactive" {
-    # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 3]
-    I:"Max Level"=3
-
-    # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
-    S:"Max Power Function"=
-
-    # The min level of this enchantment. [range: 1 ~ 127, default: 1]
-    I:"Min Level"=1
-
-    # A function to determine the min enchanting power. [default: ]
-    S:"Min Power Function"=
-}
-
 
 "astralsorcery:night_vision" {
     # The max level of this enchantment - normally 1. [range: 1 ~ 127, default: 1]
@@ -459,7 +415,7 @@
 
 "cofh_core:holding" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 11]
-    I:"Max Level"=11
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -593,7 +549,7 @@
 
 "ensorcellation:angler" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=18
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -623,7 +579,7 @@
 
 "ensorcellation:cavalier" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=13
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -668,7 +624,7 @@
 
 "ensorcellation:damage_ender" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=19
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -683,7 +639,7 @@
 
 "ensorcellation:damage_illager" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=19
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -698,7 +654,7 @@
 
 "ensorcellation:damage_villager" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=19
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -713,7 +669,7 @@
 
 "ensorcellation:displacement" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -728,7 +684,7 @@
 
 "ensorcellation:excavating" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 4]
-    I:"Max Level"=5
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -743,7 +699,7 @@
 
 "ensorcellation:exp_boost" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=14
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -758,7 +714,7 @@
 
 "ensorcellation:fire_rebuke" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 6]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -773,7 +729,7 @@
 
 "ensorcellation:frost_aspect" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -788,7 +744,7 @@
 
 "ensorcellation:frost_rebuke" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 6]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -803,7 +759,7 @@
 
 "ensorcellation:furrowing" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=14
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -818,7 +774,7 @@
 
 "ensorcellation:gourmand" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -833,7 +789,7 @@
 
 "ensorcellation:hunter" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=14
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -863,7 +819,7 @@
 
 "ensorcellation:leech" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -878,7 +834,7 @@
 
 "ensorcellation:magic_edge" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -893,7 +849,7 @@
 
 "ensorcellation:magic_protection" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=21
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -908,7 +864,7 @@
 
 "ensorcellation:phalanx" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=26
+    I:"Max Level"=2
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -938,7 +894,7 @@
 
 "ensorcellation:quick_draw" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=7
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -953,7 +909,7 @@
 
 "ensorcellation:reach" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=14
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -998,7 +954,7 @@
 
 "ensorcellation:trueshot" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 6]
-    I:"Max Level"=12
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1013,7 +969,7 @@
 
 "ensorcellation:vitality" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=15
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1043,7 +999,7 @@
 
 "ensorcellation:vorpal" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1088,7 +1044,7 @@
 
 "farmersdelight:backstabbing" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=7
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1103,7 +1059,7 @@
 
 "gunswithoutroses:bullseye" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=8
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1118,7 +1074,7 @@
 
 "gunswithoutroses:impact" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=9
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1133,7 +1089,7 @@
 
 "gunswithoutroses:preserving" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=7
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1418,7 +1374,7 @@
 
 "minecraft:bane_of_arthropods" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=20
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1448,7 +1404,7 @@
 
 "minecraft:blast_protection" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=21
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1478,7 +1434,7 @@
 
 "minecraft:depth_strider" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=16
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1493,7 +1449,7 @@
 
 "minecraft:efficiency" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=13
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1508,7 +1464,7 @@
 
 "minecraft:feather_falling" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=28
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1523,7 +1479,7 @@
 
 "minecraft:fire_aspect" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1538,7 +1494,7 @@
 
 "minecraft:fire_protection" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=21
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1568,7 +1524,7 @@
 
 "minecraft:fortune" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1583,7 +1539,7 @@
 
 "minecraft:frost_walker" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 6]
-    I:"Max Level"=16
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1598,7 +1554,7 @@
 
 "minecraft:impaling" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=20
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1628,7 +1584,7 @@
 
 "minecraft:knockback" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1643,7 +1599,7 @@
 
 "minecraft:looting" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1673,7 +1629,7 @@
 
 "minecraft:luck_of_the_sea" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1688,7 +1644,7 @@
 
 "minecraft:lure" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=13
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1733,7 +1689,7 @@
 
 "minecraft:piercing" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=4
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1748,7 +1704,7 @@
 
 "minecraft:power" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=17
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1763,7 +1719,7 @@
 
 "minecraft:projectile_protection" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=29
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1778,7 +1734,7 @@
 
 "minecraft:protection" {
     # The max level of this enchantment - normally 4. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=16
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1793,7 +1749,7 @@
 
 "minecraft:punch" {
     # The max level of this enchantment - normally 2. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=8
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1823,7 +1779,7 @@
 
 "minecraft:respiration" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=15
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1853,7 +1809,7 @@
 
 "minecraft:sharpness" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=15
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1883,7 +1839,7 @@
 
 "minecraft:smite" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 10]
-    I:"Max Level"=20
+    I:"Max Level"=7
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1898,7 +1854,7 @@
 
 "minecraft:soul_speed" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 7]
-    I:"Max Level"=7
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1913,7 +1869,7 @@
 
 "minecraft:sweeping" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=18
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1928,7 +1884,7 @@
 
 "minecraft:thorns" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 5]
-    I:"Max Level"=13
+    I:"Max Level"=3
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -1943,7 +1899,7 @@
 
 "minecraft:unbreaking" {
     # The max level of this enchantment - normally 3. [range: 1 ~ 127, default: 8]
-    I:"Max Level"=13
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -2018,7 +1974,7 @@
 
 "pedestals:upgradearea" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=9
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -2033,7 +1989,7 @@
 
 "pedestals:upgradecapacity" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=9
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -2048,7 +2004,7 @@
 
 "pedestals:upgraderange" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=9
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=
@@ -2063,7 +2019,7 @@
 
 "pedestals:upgradespeed" {
     # The max level of this enchantment - normally 5. [range: 1 ~ 127, default: 9]
-    I:"Max Level"=9
+    I:"Max Level"=5
 
     # A function to determine the max enchanting power.  The variable "x" is level.  See: https://github.com/uklimaschewski/EvalEx#usage-examples [default: ]
     S:"Max Power Function"=


### PR DESCRIPTION
Brings Apoth enchanting down to more reasonable levels.

Major nerf to damage enchants, protection, and especially looting/fortune.

These are all still better than vanilla, and Apoth removes the mutually exclusive limit anyway so you can have all prots on one armor piece, and all damage enchants on one sword. Killer weapons and armor are still possible, just not quite as over the top.