### PR TITLE
Creosote Unification

### DIFF
--- a/kubejs/data/thermal/recipes/machine/pyrolyzer/pyrolyzer_coal.json
+++ b/kubejs/data/thermal/recipes/machine/pyrolyzer/pyrolyzer_coal.json
@@ -12,7 +12,7 @@
             "chance": 0.25
         },
         {
-            "fluid": "thermal:creosote",
+            "fluid": "immersiveengineering:creosote",
             "amount": 250
         }
     ],

--- a/kubejs/data/thermal/recipes/machine/pyrolyzer/pyrolyzer_logs.json
+++ b/kubejs/data/thermal/recipes/machine/pyrolyzer/pyrolyzer_logs.json
@@ -1,0 +1,16 @@
+{
+    "type": "thermal:pyrolyzer",
+    "ingredient": {
+        "tag": "minecraft:logs"
+    },
+    "result": [
+        {
+            "item": "minecraft:charcoal"
+        },
+        {
+            "fluid": "immersiveengineering:creosote",
+            "amount": 125
+        }
+    ],
+    "experience": 0.15
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/interactio/item_fluid_transform.js
@@ -1,1 +1,29 @@
-events.listen('recipes', function (event) {});
+events.listen('recipes', function (event) {
+    event.custom({
+        type: 'interactio:item_fluid_transform',
+        inputs: [
+            {
+                tag: 'minecraft:planks',
+                count: 1,
+                return_chance: 0
+            }
+        ],
+        fluid: {
+            fluid: 'immersiveengineering:creosote'
+        },
+        output: {
+            entries: [
+                {
+                    result: {
+                        item: 'immersiveengineering:treated_wood_horizontal',
+                        count: 1
+                    },
+                    weight: 1
+                }
+            ],
+            empty_weight: 0,
+            rolls: 1
+        },
+        consume_fluid: 0.125
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/compression.js
@@ -64,6 +64,10 @@ events.listen('recipes', (event) => {
                 energy: 20000
             },
             {
+                fluid: 'immersiveengineering:creosote',
+                energy: 20000
+            },
+            {
                 fluid: 'thermal:refined_fuel',
                 energy: 1500000
             }


### PR DESCRIPTION
Thermal Machines now make Immersive Creosote. Thermal Creosote should no longer be obtainable, though it can still be burned as fuel to get rid of it.

Added Immersive Creosote to Compression Dynamo, as it was previously missing.

Added In World Crafting as alternate for making treated wood just for fun. It will, on average, use the same amount of creosote, but since it's percentage based, promotes large batches since a small batch may very well end up producing less.

Resolves #988