### PR TITLE
Honey Unification

### DIFF
--- a/kubejs/client_scripts/item_modifiers/constants.js
+++ b/kubejs/client_scripts/item_modifiers/constants.js
@@ -6,6 +6,7 @@ var itemsToHide = [
     'bloodmagic:coalsand',
     'bloodmagic:saltpeter',
     'bloodmagic:sulfur',
+    'create:honey_bucket',
     'immersiveengineering:dust_saltpeter',
     'immersiveengineering:dust_wood',
     'mapperbase:bitumen_ore',

--- a/kubejs/client_scripts/item_modifiers/jei_hide.js
+++ b/kubejs/client_scripts/item_modifiers/jei_hide.js
@@ -86,5 +86,6 @@ events.listen('jei.hide.items', (event) => {
 });
 
 onEvent('jei.hide.fluids', (event) => {
-    event.hide(['create:honey', 'cofh_core:honey']);
+    event.hide('cofh_core:honey');
+    event.hide('create:honey');
 });

--- a/kubejs/client_scripts/item_modifiers/jei_hide.js
+++ b/kubejs/client_scripts/item_modifiers/jei_hide.js
@@ -84,3 +84,7 @@ events.listen('jei.hide.items', (event) => {
         event.hide(regexExpression);
     });
 });
+
+onEvent('jei.hide.fluids', (event) => {
+    event.hide(['create:honey', 'cofh_core:honey']);
+});

--- a/kubejs/data/create/recipes/emptying/honey_bottle.json
+++ b/kubejs/data/create/recipes/emptying/honey_bottle.json
@@ -1,0 +1,17 @@
+{
+    "type": "create:emptying",
+    "ingredients": [
+        {
+            "item": "minecraft:honey_bottle"
+        }
+    ],
+    "results": [
+        {
+            "item": "minecraft:glass_bottle"
+        },
+        {
+            "fluid": "resourcefulbees:honey",
+            "amount": 250
+        }
+    ]
+}

--- a/kubejs/data/create/recipes/filling/honey_bottle.json
+++ b/kubejs/data/create/recipes/filling/honey_bottle.json
@@ -1,0 +1,17 @@
+{
+    "type": "create:filling",
+    "ingredients": [
+        {
+            "item": "minecraft:glass_bottle"
+        },
+        {
+            "fluid": "resourcefulbees:honey",
+            "amount": 250
+        }
+    ],
+    "results": [
+        {
+            "item": "minecraft:honey_bottle"
+        }
+    ]
+}

--- a/kubejs/data/thermal/recipes/machine/bottler/bottler_honey_bottle.json
+++ b/kubejs/data/thermal/recipes/machine/bottler/bottler_honey_bottle.json
@@ -1,0 +1,17 @@
+{
+    "type": "thermal:bottler",
+    "ingredient": [
+        {
+            "item": "minecraft:glass_bottle"
+        },
+        {
+            "fluid": "resourcefulbees:honey",
+            "amount": 250
+        }
+    ],
+    "result": [
+        {
+            "item": "minecraft:honey_bottle"
+        }
+    ]
+}

--- a/kubejs/data/thermal/recipes/machine/chiller/chiller_honey_to_honey_block.json
+++ b/kubejs/data/thermal/recipes/machine/chiller/chiller_honey_to_honey_block.json
@@ -1,0 +1,13 @@
+{
+    "type": "thermal:chiller",
+    "ingredient": {
+        "fluid": "resourcefulbees:honey",
+        "amount": 1000
+    },
+    "result": [
+        {
+            "item": "minecraft:honey_block"
+        }
+    ],
+    "energy": 2000
+}

--- a/kubejs/data/thermal/recipes/machine/crucible/crucible_honey_block_to_honey.json
+++ b/kubejs/data/thermal/recipes/machine/crucible/crucible_honey_block_to_honey.json
@@ -1,0 +1,13 @@
+{
+    "type": "thermal:crucible",
+    "ingredient": {
+        "item": "minecraft:honey_block"
+    },
+    "result": [
+        {
+            "fluid": "resourcefulbees:honey",
+            "amount": 1000
+        }
+    ],
+    "energy": 2000
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -56,6 +56,7 @@ events.listen('recipes', function (event) {
 
         'create:mechanical_crafting/integrated_circuit',
         'create:pressing/lapis_block',
+        'create:fill_minecraft_bucket_with_create_honey',
 
         'engineersdecor:dependent/slag_brick_block_recipe',
 
@@ -75,6 +76,7 @@ events.listen('recipes', function (event) {
 
         'morevanillalib:obsidian_shard',
 
+        'thermal:machine/centrifuge/centrifuge_honeycomb',
         'thermal:machine/plugins/create/pulverizer_create_zinc_ore',
         'thermal:machine/plugins/mekanism/pulverizer_mek_osmium_ore'
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/emptying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/emptying.js
@@ -1,0 +1,12 @@
+events.listen('recipes', (event) => {
+    honeyVarieties.forEach((honeyVariety) => {
+        if (honeyVariety == 'resourcefulbees:honey') {
+            return;
+        }
+
+        event.recipes.create.emptying(
+            [fluid.of(honeyVariety, 250), item.of('minecraft:glass_bottle')],
+            item.of(honeyVariety + '_bottle')
+        );
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/filling.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/filling.js
@@ -1,0 +1,12 @@
+events.listen('recipes', (event) => {
+    honeyVarieties.forEach((honeyVariety) => {
+        if (honeyVariety == 'resourcefulbees:honey') {
+            return;
+        }
+
+        event.recipes.create.filling(item.of(honeyVariety + '_bottle'), [
+            fluid.of(honeyVariety, 250),
+            item.of('minecraft:glass_bottle')
+        ]);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/heat_frame_cooling.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/heat_frame_cooling.js
@@ -1,0 +1,23 @@
+events.listen('recipes', (event) => {
+    honeyVarieties.forEach((honeyVariety) => {
+        var output = honeyVariety + '_block';
+
+        if (honeyVariety == 'resourcefulbees:honey') {
+            output = 'minecraft:honey_block';
+        }
+
+        event.custom({
+            type: 'pneumaticcraft:heat_frame_cooling',
+            input: {
+                type: 'pneumaticcraft:fluid',
+                tag: honeyVariety,
+                amount: 1000
+            },
+            max_temp: 273,
+            result: {
+                item: output
+            }
+        });
+        //event.recipes.thermal.chiller(item.of(honeyVariety + '_block'), fluid.of(honeyVariety, 1000));
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/chiller.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/chiller.js
@@ -1,0 +1,8 @@
+events.listen('recipes', (event) => {
+    honeyVarieties.forEach((honeyVariety) => {
+        if (honeyVariety == 'resourcefulbees:honey') {
+            return;
+        }
+        event.recipes.thermal.chiller(item.of(honeyVariety + '_block'), fluid.of(honeyVariety, 1000));
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/crucible.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/crucible.js
@@ -1,0 +1,8 @@
+events.listen('recipes', (event) => {
+    honeyVarieties.forEach((honeyVariety) => {
+        if (honeyVariety == 'resourcefulbees:honey') {
+            return;
+        }
+        event.recipes.thermal.crucible(fluid.of(honeyVariety, 1000), item.of(honeyVariety + '_block'));
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/fluids.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/fluids.js
@@ -1,0 +1,3 @@
+events.listen('block.tags', function (event) {
+    event.get('forge:honey').remove('create:honey');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/minecraft/fluids.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/minecraft/fluids.js
@@ -1,0 +1,3 @@
+events.listen('block.tags', function (event) {
+    event.get('minecraft:water').remove(['create:honey', 'create:chocolate']);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/minecraft/fluids.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/minecraft/fluids.js
@@ -1,0 +1,12 @@
+events.listen('fluid.tags', function (event) {
+    event
+        .get('minecraft:water')
+        .remove([
+            'create:honey',
+            'create:flowing_honey',
+            'create:chocolate',
+            'create:flowing_chocolate',
+            'undergarden:virulent_mix_source',
+            'undergarden:virulent_mix_flowing'
+        ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/resourcefulbees/honey.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/resourcefulbees/honey.js
@@ -1,0 +1,5 @@
+events.listen('fluid.tags', function (event) {
+    honeyVarieties.forEach((honeyVariety) => {
+        event.get(honeyVariety).add(honeyVariety);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/constants.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants.js
@@ -273,3 +273,32 @@ const generatableStone = [
     'create:limestone'
 ];
 const generatableBasalt = [];
+
+const honeyVarieties = [
+    'resourcefulbees:blaze_honey',
+    'resourcefulbees:brass_honey',
+    'resourcefulbees:bronze_honey',
+    'resourcefulbees:catnip_honey',
+    'resourcefulbees:coal_honey',
+    'resourcefulbees:constantan_honey',
+    'resourcefulbees:diamond_honey',
+    'resourcefulbees:electrum_honey',
+    'resourcefulbees:emerald_honey',
+    'resourcefulbees:enderium_honey',
+    'resourcefulbees:glowstone_honey',
+    'resourcefulbees:gold_honey',
+    'resourcefulbees:honey',
+    'resourcefulbees:icy_honey',
+    'resourcefulbees:invar_honey',
+    'resourcefulbees:iron_honey',
+    'resourcefulbees:lapis_honey',
+    'resourcefulbees:lumium_honey',
+    'resourcefulbees:netherite_honey',
+    'resourcefulbees:obsidian_honey',
+    'resourcefulbees:rainbow_honey',
+    'resourcefulbees:redstone_honey',
+    'resourcefulbees:signalum_honey',
+    'resourcefulbees:steel_honey',
+    'resourcefulbees:water_honey',
+    'resourcefulbees:wither_honey'
+];


### PR DESCRIPTION
Magma Crucible now melts honey blocks to resourceful bees honey.
Blast Chiller now freezes resourceful bee honey to honey blocks.

Centrifugal Separator no longer processes vanilla honeycomb, that's a job for Resourceful Bees.

Hide COFH and Create Honey in JEI

Create Filling and Emptying now use Resourceful Bees Honey

Fixed the 'everything is water' issue with Undergarden and Create fluids!!! (this does mean you can no longer swim in these. like PNC oil, you simply sink like a rock)

Todo: Create bottling recipes for all resourceful bees honey could be cool. Fluid > Honey Bottle. Interactio filling recipes as well.

At the same time, crucible/chiller recipes for all honey types could be neat too since Resourceful Bees doesn't handle those quite so elegantly.