### PR TITLE
Update occultism-server.toml

### DIFF
--- a/defaultconfigs/occultism-server.toml
+++ b/defaultconfigs/occultism-server.toml
@@ -2,13 +2,13 @@
 #Storage Settings
 [storage]
 	#The amount of slots the storage stabilizer tier 1 provides.
-	stabilizerTier1Slots = 128
+	stabilizerTier1Slots = 256
 	#The amount of slots the storage stabilizer tier 2 provides.
-	stabilizerTier2Slots = 256
+	stabilizerTier2Slots = 512
 	#The amount of slots the storage stabilizer tier 3 provides.
-	stabilizerTier3Slots = 512
+	stabilizerTier3Slots = 2048
 	#The amount of slots the storage stabilizer tier 4 provides.
-	stabilizerTier4Slots = 1024
+	stabilizerTier4Slots = 4096
 	#The amount of slots the storage actuator provides.
 	controllerBaseSlots = 128
 


### PR DESCRIPTION
Doubled the tier 1 and tier 2 stabilizer slots and quadrupled tier 3 and tier 4. This should put it more in line with both the difficulty in crafting these(the tier 3 and tier 4 each require a nether star and dragon egg respectively, and you can add 6 to each storage so it gets expensive pretty quick) and to make it a viable storage option for someone looking to stay on the magic side of things rather than just plonking down a big RS system.