### PR TITLE
Create Empty Placeholders for Removed Scripts

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/milling_flowers.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/milling_flowers.js
@@ -1,0 +1,1 @@
+//TODO: Remove in 0.4.0

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/enriching_byg_flowers.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/enriching_byg_flowers.js
@@ -1,0 +1,1 @@
+//TODO: Remove in 0.4.0

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_crushing.js
@@ -1,0 +1,1 @@
+//TODO: Remove in 0.4.0

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_crushing_flowers.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_crushing_flowers.js
@@ -1,0 +1,1 @@
+//TODO: Remove in 0.4.0

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/centrifuge_flowers.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/centrifuge_flowers.js
@@ -1,0 +1,1 @@
+//TODO: Remove in 0.4.0


### PR DESCRIPTION
Scripts are not always removed properly. Empy placeholders created to work around the issue.