### PR TITLE
Create Empty Placeholders for Removed Scripts

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -1,0 +1,1 @@
+//TODO: Remove in 0.4.0


### PR DESCRIPTION
Scripts are not always removed properly. Empy placeholders created to work around the issue.