### PR TITLE
Added extrastorage to mekanism cardboardModBlacklist

### DIFF
--- a/config/Mekanism/general.toml
+++ b/config/Mekanism/general.toml
@@ -7,7 +7,7 @@
 	#Peak processing rate for the Solar Neutron Activator. Note: It can go higher than this value in some extreme environments.
 	maxSolarNeutronActivatorRate = 64
 	#Any mod ids added to this list will not be able to have any of their blocks, picked up by the cardboard box. For example: ["mekanism"]
-	cardboardModBlacklist = ["refinedstorage", "tetra", "storagedrawers", "lootr"]
+	cardboardModBlacklist = ["refinedstorage", "tetra", "storagedrawers", "lootr", "extrastorage"]
 	#Disable to make the anchor upgrade not do anything.
 	allowChunkloading = true
 	#How much heat energy is created from one Joule of regular energy in the Resistive Heater.


### PR DESCRIPTION
prevent using cardboard box to blocks of extra storage mod. 
fixes https://github.com/NillerMedDild/Enigmatica6/issues/1070