### PR TITLE
Typo in Induction Smelter recipes causing recipes to fail to load

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
@@ -46,7 +46,7 @@ events.listen('recipes', function (event) {
                 outputs: ['minecraft:netherite_ingot']
             },
             {
-                inputs: ['#forge:ingots/iron', '#forge:dusts/coal_coke', 1],
+                inputs: ['#forge:ingots/iron', '#forge:dusts/coal_coke'],
                 outputs: ['emendatusenigmatica:steel_ingot']
             },
             {


### PR DESCRIPTION
One is the loneliest number that there ever was.