### PR TITLE
Mekanism Power Rebalancing - Ethylene is more expensive and slower to make. Fission/Fusion reduced in efficiency

### DIFF
--- a/config/Mekanism/general.toml
+++ b/config/Mekanism/general.toml
@@ -70,7 +70,7 @@
 		#Disables Forge Energy (FE,RF,IF,uF,CF) power integration. Requires world restart (server-side option in SMP).
 		blacklistForge = false
 		#Maximum Joules per mB of Steam. Also affects Thermoelectric Boiler.
-		maxEnergyPerSteam = "10"
+		maxEnergyPerSteam = "2"
 		#Conversion multiplier from Forge Energy to Joules (FE * JoulePerForgeEnergy = Joules)
 		JoulePerForgeEnergy = "2.5000"
 		#Conversion multiplier from EU to Joules (EU * JoulePerEU = Joules)
@@ -142,7 +142,7 @@
 		radioactiveWasteBarrelProcessTicks = 1200
 		#Number of mB of gas that decay every radioactiveWasteBarrelProcessTicks ticks when stored in a Radioactive Waste Barrel. Set to zero to disable decay all together. (Gases in the mekanism:waste_barrel_decay_blacklist tag will not decay).
 		#Range: 0 ~ 9223372036854775807
-		radioactiveWasteBarrelDecayAmount = 1
+		radioactiveWasteBarrelDecayAmount = 100
 		#Radiation sources are multiplied by this constant roughly once per second to represent their emission decay. At the default rate, it takes roughly 10 days to remove a 1,000 Sv/h (crazy high) source.
 		sourceDecayRate = 0.9995
 		#Defines the minimum severity radiation dosage severity (scale of 0 to 1) for which negative effects can take place. Set to 1 to disable negative effects completely.

--- a/config/Mekanism/generators.toml
+++ b/config/Mekanism/generators.toml
@@ -4,7 +4,7 @@
 	#Peak output for the Advanced Solar Generator. Note: It can go higher than this value in some extreme environments.
 	advancedSolarGeneration = "300"
 	#Affects the Injection Rate, Max Temp, and Ignition Temp.
-	energyPerFusionFuel = "10000000"
+	energyPerFusionFuel = "550000"
 	#Amount of energy in Joules the Bio Generator produces per tick.
 	bioGeneration = "350"
 	#Peak output for the Solar Generator. Note: It can go higher than this value in some extreme environments.
@@ -17,11 +17,11 @@
 		#The list of dimension ids that the Wind Generator will not generate power in.
 		windGenerationDimBlacklist = []
 		#The maximum Y value that affects the Wind Generators Power generation.
-		windGenerationMaxY = 255
+		windGenerationMaxY = 90
 		#Maximum base generation value of the Wind Generator.
-		windGenerationMax = "480"
+		windGenerationMax = "300"
 		#The minimum Y value that affects the Wind Generators Power generation.
-		windGenerationMinY = 24
+		windGenerationMinY = 40
 
 	#Turbine Settings
 	[generators.turbine]

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -76,6 +76,7 @@ events.listen('recipes', function (event) {
         'mapperbase:iron_rod',
 
         'mekanism:crushing/stone/to_cobblestone',
+        'mekanism:reaction/substrate/water_hydrogen',
 
         'morevanillalib:obsidian_shard',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/reaction.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/reaction.js
@@ -1,0 +1,15 @@
+events.listen('recipes', function (event) {
+    var energyMultiplier = 3,
+        durationMultiplier = 20;
+
+    event.custom({
+        type: 'mekanism:reaction',
+        itemInput: { amount: 2, ingredient: { tag: 'forge:fuels/bio' } },
+        fluidInput: { amount: 10, tag: 'minecraft:water' },
+        gasInput: { amount: 100, gas: 'mekanism:hydrogen' },
+        energyRequired: 200 * energyMultiplier,
+        duration: 100 * durationMultiplier,
+        itemOutput: { item: 'mekanism:substrate' },
+        gasOutput: { gas: 'mekanism:ethene', amount: 100 }
+    });
+});


### PR DESCRIPTION
More info in the commits themselves. 
#861