### PR TITLE
Fix industrial foregoing sludge refiner cost 1000FE/t

### DIFF
--- a/config/industrialforegoing/machine-resource-production.toml
+++ b/config/industrialforegoing/machine-resource-production.toml
@@ -21,7 +21,7 @@
 
 	[MachineResourceProductionConfig.SludgeRefinerConfig]
 		#Amount of Power Consumed per Tick - Default: [40FE]
-		powerPerTick = 1000
+		powerPerTick = 40
 		#Max Stored Power [FE] - Default: [10000 FE]
 		maxStoredPower = 10000
 		#Max Amount of Stored Fluid [Sludge] - Default: [8000mB]


### PR DESCRIPTION
See issue https://github.com/InnovativeOnlineIndustries/Industrial-Foregoing/issues/873

Machine will eat your RF but do nothing until you provide 1000FE/t

To reproduce this bug: simply put an sludge refiner with some sludge plus a stirling engine. you will see machine eats all RF an do nothing.

It has been fixed in code, however the config still uses wrong value.