### PR TITLE
Oil and Bitumen Unification

### DIFF
--- a/kubejs/data/immersivepetroleum/recipes/distillationtower/oilcracking.json
+++ b/kubejs/data/immersivepetroleum/recipes/distillationtower/oilcracking.json
@@ -1,0 +1,28 @@
+{
+    "type": "immersivepetroleum:distillation",
+    "byproducts": [
+        {
+            "item": "emendatusenigmatica:bitumen_gem",
+            "chance": "0.07"
+        }
+    ],
+    "results": [
+        {
+            "fluid": "immersivepetroleum:lubricant",
+            "amount": 9
+        },
+        {
+            "fluid": "immersivepetroleum:diesel",
+            "amount": 27
+        },
+        {
+            "fluid": "immersivepetroleum:gasoline",
+            "amount": 39
+        }
+    ],
+    "input": {
+        "tag": "forge:crude_oil",
+        "amount": 75
+    },
+    "energy": 2048
+}

--- a/kubejs/data/immersivepetroleum/recipes/reservoirs/oil.json
+++ b/kubejs/data/immersivepetroleum/recipes/reservoirs/oil.json
@@ -1,0 +1,17 @@
+{
+    "type": "immersivepetroleum:reservoirs",
+    "fluid": "pneumaticcraft:oil",
+    "fluidminimum": 2500000,
+    "fluidcapacity": 15000000,
+    "fluidtrace": 6,
+    "weight": 40,
+    "dimension": {
+        "whitelist": [],
+        "blacklist": ["minecraft:the_end"]
+    },
+    "biome": {
+        "whitelist": [],
+        "blacklist": []
+    },
+    "name": "oil"
+}

--- a/kubejs/data/thermal/recipes/machine/centrifuge/centrifuge_oil_sand.json
+++ b/kubejs/data/thermal/recipes/machine/centrifuge/centrifuge_oil_sand.json
@@ -1,0 +1,26 @@
+{
+  "type": "thermal:centrifuge",
+  "ingredient": {
+    "item": "thermal:oil_sand"
+  },
+  "result": [
+    {
+      "item": "minecraft:sand",
+      "chance": 0.75,
+      "locked": true
+    },
+    {
+      "item": "thermal:bitumen",
+      "chance": 1.5
+    },
+    {
+      "item": "thermal:tar",
+      "chance": 1.0
+    },
+    {
+      "fluid": "thermal:crude_oil",
+      "amount": 100
+    }
+  ],
+  "energy": 20000
+}

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -78,7 +78,10 @@ events.listen('recipes', function (event) {
 
         'quark:building/crafting/tallow_from_block',
 
+        'thermal:machine/refinery/refinery_crude_oil',
         'thermal:machine/centrifuge/centrifuge_honeycomb',
+        'thermal:machine/centrifuge/centrifuge_oil_red_sand',
+        'thermal:machine/centrifuge/centrifuge_oil_sand',
         'thermal:machine/plugins/create/pulverizer_create_zinc_ore',
         'thermal:machine/plugins/mekanism/pulverizer_mek_osmium_ore'
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -8,6 +8,7 @@ events.listen('recipes', function (event) {
     event.replaceInput({}, 'thermal:bitumen', '#forge:gems/bitumen');
     event.replaceInput({}, 'thermal:coal_coke', '#forge:gems/coal_coke');
     event.replaceInput({}, 'mapperbase:raw_bitumen', '#forge:gems/bitumen');
+    event.replaceInput({}, 'mapperbase:bitumen_ore', '#forge:ores/bitumen');
     event.replaceInput({}, 'rftoolsbase:dimensionalshard', '#forge:gems/dimensional');
     event.replaceInput({}, '#forge:fillet_knife', '#forge:tools/knife');
     event.replaceInput({}, '#farmersdelight:tools/knife', '#forge:tools/knife');

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/centrifuge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/centrifuge.js
@@ -1,0 +1,11 @@
+events.listen('recipes', (event) => {
+    event.recipes.thermal.centrifuge(
+        [
+            Item.of('minecraft:gravel').withChance(0.75),
+            Item.of('emendatusenigmatica:bitumen_gem').withChance(1.5),
+            Item.of('thermal:tar').withCount(1),
+            fluid.of('pneumaticcraft:oil', 100)
+        ],
+        '#forge:ores/bitumen'
+    );
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/forge/fluids.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/forge/fluids.js
@@ -1,0 +1,3 @@
+events.listen('fluid.tags', function (event) {
+    event.get('forge:crude_oil').add(['immersivepetroleum:oil', 'pneumaticcraft:oil', 'thermal:crude_oil']);
+});


### PR DESCRIPTION
Thermal and IP crude oil should no longer be obtainable. 

The IP Pumpjack will now pump up PNC oil. 

Thermal oil, previously obtained by unobtainable bitumous sands, has had its recipe replaced with a similar EE ore/chunk to oil recipe in the centrifuge.

PNC oil now works as the input for any oil recipe.