### PR TITLE
Proposed new Flux Networks recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -60,6 +60,9 @@ events.listen('recipes', function (event) {
         'eidolon:tallow',
         'engineersdecor:dependent/slag_brick_block_recipe',
 
+        'fluxnetworks:fluxcontroller',
+        'fluxnetworks:fluxcore',
+
         'immersiveengineering:crafting/stick_steel',
         'immersiveengineering:crafting/stick_aluminum',
         'immersiveengineering:crafting/stick_iron',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -55,6 +55,17 @@ events.listen('recipes', function (event) {
         ingredient.of('#forge:dusts/obsidian')
     );
 
+    event.replaceInput(
+        { id: 'fluxnetworks:fluxconfigurator' },
+        'minecraft:ender_eye',
+        'powah:ender_core'
+    );
+
+    event.replaceInput(
+        { id: 'fluxnetworks:fluxpoint' },
+        'minecraft:redstone_block',
+        'powah:ender_gate_nitro'
+    );
     colors.forEach((color) => {
         var dyeTag = `#forge:dyes/${color}`;
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -375,6 +375,17 @@ events.listen('recipes', function (event) {
         shapedRecipe(item.of('quark:white_candle', 2), ['B', 'A', 'A'], {
             A: '#forge:wax',
             B: '#forge:string'
+        }),
+        shapedRecipe(item.of('fluxnetworks:flux_controller', 1), ['ABA', 'CDC', 'AAA'], {
+            A: 'fluxnetworks:flux_block',
+            B: 'fluxnetworks:flux_core',
+            C: 'fluxnetworks:flux_dust',
+            D: 'powah:player_transmitter_nitro'
+        }),
+        shapedRecipe(item.of('fluxnetworks:flux_core', 8), ['ABA', 'BCB', 'ABA'], {
+            A: 'fluxnetworks:flux_dust',
+            B: '#forge:obsidian',
+            C: 'powah:ender_core'
         })
     ];
 


### PR DESCRIPTION
Here's the reasoning behind these: Flux Networks is mostly in the pack to be a direct endgame extension of Powah, since everything it does pretty much invalidates the stuff powah does. As such, it's positioned as a sort of "final upgrade tier" to Powah's items, requiring progression through the whole mod.
Hopefully this doesn't feel too gated for a non expert pack, but I would say it's fair to have them as an upgrade of sorts and treat them basically as part of powah itself instead of a standalone mod, because of how close the features offered are. 
Here are the recipes:
![2021-02-06_18 27 50](https://user-images.githubusercontent.com/62080872/107125683-b036a680-68ab-11eb-95a0-983e47ba6799.png)
![2021-02-06_18 38 54](https://user-images.githubusercontent.com/62080872/107125684-b167d380-68ab-11eb-805f-10922bad6205.png)
Replaced ender eyes with powah ender cores just for fun (flux core recipe now makes twice as much to make up for that)
![2021-02-06_18 31 21](https://user-images.githubusercontent.com/62080872/107125701-c0e71c80-68ab-11eb-938d-a37015c873e7.png)
Flux Point is basically a max tier ender gate, their functionalities are basically identical and as such it's positioned as an upgrade to the nitro tier gate.
![2021-02-06_18 28 09](https://user-images.githubusercontent.com/62080872/107125734-d52b1980-68ab-11eb-8174-e0ea294fd095.png)
The same can be said for the controller, since it allows for wireless charging, and thus is positioned as an upgrade to the nitro player transmitter

Other recipes (flux plugs in particular) are untouched, since they're basically useless without their counterparts and don't really need more balancing.