### PR TITLE
Added processing recipes for Limesand to Silicon

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -126,6 +126,7 @@ var itemsToHide = [
     'quark:biotite',
     'quark:biotite_ore',
     'quark:tallow',
+    'refinedstorage:silicon',
     'thermal:coal_coke',
     'thermal:coal_coke_block',
     'thermal:ender_pearl_dust',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/splashing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/splashing.js
@@ -2,12 +2,16 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             {
-                output: 'buildinggadgets:construction_block_dense',
+                outputs: ['buildinggadgets:construction_block_dense'],
                 input: 'buildinggadgets:construction_block_powder'
+            },
+            {
+                outputs: [item.of('emendatusenigmatica:silicon_gem').chance(0.5), item.of('emendatusenigmatica:silicon_gem').chance(0.25)],
+                input: 'create:limesand'
             }
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.recipes.create.splashing(recipe.output, recipe.input);
+        event.recipes.create.splashing(recipe.outputs, recipe.input);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/crushing.js
@@ -32,6 +32,10 @@ events.listen('recipes', function (event) {
             {
                 input: 'buildinggadgets:construction_block_dense',
                 output: Item.of('buildinggadgets:construction_paste', 3)
+            },
+            {
+                input: item.of('create:limesand', 4),
+                output: item.of('emendatusenigmatica:silicon_gem')
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
@@ -113,6 +113,14 @@ events.listen('recipes', function (event) {
                     item.of('buildinggadgets:construction_paste', 2).chance(0.5)
                 ],
                 experience: 0.2
+            },
+            {
+                input: 'create:limesand',
+                outputs: [
+                    item.of('emendatusenigmatica:silicon_gem').chance(0.5),
+                    item.of('emendatusenigmatica:silicon_gem').chance(0.25)
+                ],
+                experience: 0.2
             }
         ]
     };


### PR DESCRIPTION
As suggested by https://github.com/NillerMedDild/Enigmatica6/issues/1257

I wasn't sure at first (and I'm still not entirely), but it does make sense to add a way to process silicon with create cobbleworks if the material stoneworks factory can do it too.
The automation chain is pretty long anyways, and it only has a chance to actually produce, so the smelting quartz way is still the preferrable route, but there is at least a create alternative that doesn't involve quartz.
Still up for discussion though