### PR TITLE
Mekanism Power Pass - Remove Passive Fusion

### DIFF
--- a/config/Mekanism/generators.toml
+++ b/config/Mekanism/generators.toml
@@ -82,7 +82,7 @@
 	[generators.fusion_reactor]
 		#The fraction of the heat dissipated from the case that is converted to Joules.
 		#Range: 0.0 ~ 1.0
-		thermocoupleEfficiency = 0.05
+		thermocoupleEfficiency = 0
 		#The fraction fraction of heat from the casing that can be transfered to all sources that are not water. Will impact max heat, heat transfer to thermodynamic conductors, and power generation.
 		#Range: 0.001 ~ 1.0
 		casingThermalConductivity = 0.1


### PR DESCRIPTION
Messed around with the numbers again, but ultimately decided to leave things where they were with the previous pass. Only change is to remove the passive power from Fusion.

Will update the wiki  in a bit