### PR TITLE
Better End : The Taggening - Add basic tags to many items/blocks from better end 

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/crushing.js
@@ -6,8 +6,19 @@ events.listen('recipes', (event) => {
                 input: 'minecraft:obsidian'
             },
             {
-                outputs: [Item.of('buildinggadgets:construction_paste', 3), Item.of('buildinggadgets:construction_paste').withChance(0.75), Item.of('buildinggadgets:construction_paste').withChance(0.50)],
+                outputs: [
+                    Item.of('buildinggadgets:construction_paste', 3),
+                    Item.of('buildinggadgets:construction_paste').withChance(0.75),
+                    Item.of('buildinggadgets:construction_paste').withChance(0.5)
+                ],
                 input: 'buildinggadgets:construction_block_dense'
+            },
+            {
+                outputs: [
+                    Item.of('betterendforge:crystal_shards', 3),
+                    Item.of('betterendforge:crystal_shards').withChance(0.5)
+                ],
+                input: '#forge:storage_blocks/aurora'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/crusher.js
@@ -80,6 +80,10 @@ events.listen('recipes', (event) => {
                 input: 'atmospheric:red_arid_sandstone',
                 output: Item.of('atmospheric:red_arid_sand', 2),
                 secondary: [Item.of('emendatusenigmatica:potassium_nitrate_dust').chance(0.5)]
+            },
+            {
+                input: '#forge:storage_blocks/aurora',
+                output: Item.of('betterendforge:crystal_shards', 4)
             }
         ]
     };
@@ -89,6 +93,11 @@ events.listen('recipes', (event) => {
             mod: 'immersiveengineering',
             type: 'immersiveengineering:crusher'
         });
-        event.recipes.immersiveengineering.crusher(recipe.output, recipe.input, recipe.secondary);
+
+        if (recipe.secondary) {
+            event.recipes.immersiveengineering.crusher(recipe.output, recipe.input, recipe.secondary);
+        } else {
+            event.recipes.immersiveengineering.crusher(recipe.output, recipe.input);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/integrateddynamics/mechanical_squeezer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/integrateddynamics/mechanical_squeezer.js
@@ -66,6 +66,12 @@ events.listen('recipes', function (event) {
                 output: 'emendatusenigmatica:obsidian_dust',
                 count: 4,
                 duration: 60
+            },
+            {
+                input: 'betterendforge:aurora_crystal',
+                output: 'betterendforge:crystal_shards',
+                count: 4,
+                duration: 300
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/integrateddynamics/squeezer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/integrateddynamics/squeezer.js
@@ -55,6 +55,11 @@ events.listen('recipes', function (event) {
                 input: 'minecraft:obsidian',
                 output: 'emendatusenigmatica:obsidian_dust',
                 count: 4
+            },
+            {
+                input: 'betterendforge:aurora_crystal',
+                output: 'betterendforge:crystal_shards',
+                count: 4
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/enriching.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/enriching.js
@@ -1,16 +1,17 @@
 events.listen('recipes', (event) => {
-    output = 'emendatusenigmatica:dimensional_gem';
-    count = 8;
-    event.recipes.mekanism.enriching({
-        type: 'mekanism.enriching',
-        input: {
-            ingredient: {
-                tag: 'forge:ores/dimensional'
+    var data = {
+        recipes: [
+            {
+                input: '#forge:storage_blocks/aurora',
+                output: Item.of('betterendforge:crystal_shards', 4)
+            },
+            {
+                input: '#forge:ores/dimensional',
+                output: Item.of('emendatusenigmatica:dimensional_gem', 8)
             }
-        },
-        output: {
-            item: output,
-            count: count
-        }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        event.recipes.mekanism.enriching(recipe.output, recipe.input);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
@@ -137,6 +137,11 @@ events.listen('recipes', (event) => {
                     Item.of('emendatusenigmatica:silicon_gem').chance(0.25)
                 ],
                 experience: 0.2
+            },
+            {
+                input: '#forge:storage_blocks/aurora',
+                outputs: [Item.of('betterendforge:crystal_shards', 4)],
+                experience: 0.2
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/bookshelves.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/bookshelves.js
@@ -1,0 +1,13 @@
+events.listen('block.tags', (event) => {
+    event.add('forge:bookshelves', [
+        'betterendforge:jellyshroom_bookshelf',
+        'betterendforge:umbrella_tree_bookshelf',
+        'betterendforge:helix_tree_bookshelf',
+        'betterendforge:tenanea_bookshelf',
+        'betterendforge:dragon_tree_bookshelf',
+        'betterendforge:pythadendron_bookshelf',
+        'betterendforge:end_lotus_bookshelf',
+        'betterendforge:lacugrove_bookshelf',
+        'betterendforge:mossy_glowshroom_bookshelf'
+    ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/storage_blocks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/storage_blocks.js
@@ -1,4 +1,6 @@
 events.listen('block.tags', (event) => {
-    event.get('forge:storage_blocks').add('minecraft:glowstone');
-    event.get('forge:storage_blocks/glowstone').add('minecraft:glowstone');
+    event.add('forge:storage_blocks', ['minecraft:glowstone', 'betterendforge:aurora_crystal']);
+
+    event.add('forge:storage_blocks/glowstone', ['minecraft:glowstone']);
+    event.add('forge:storage_blocks/aurora', ['betterendforge:aurora_crystal']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/workbench.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/forge/workbench.js
@@ -1,0 +1,14 @@
+events.listen('block.tags', (event) => {
+    event.add('forge:workbench', [
+        'minecraft:crafting_table',
+        'betterendforge:jellyshroom_crafting_table',
+        'betterendforge:umbrella_tree_crafting_table',
+        'betterendforge:helix_tree_crafting_table',
+        'betterendforge:tenanea_crafting_table',
+        'betterendforge:dragon_tree_crafting_table',
+        'betterendforge:pythadendron_crafting_table',
+        'betterendforge:end_lotus_crafting_table',
+        'betterendforge:lacugrove_crafting_table',
+        'betterendforge:mossy_glowshroom_crafting_table'
+    ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/betterend/betterend.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/betterend/betterend.js
@@ -1,4 +1,0 @@
-events.listen('item.tags', (event) => {
-    event.get('forge:dusts/ender').add('betterendforge:ender_dust');
-    event.get('forge:dusts/ender_pearl').add('betterendforge:ender_dust');
-});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/bookshelves.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/bookshelves.js
@@ -1,0 +1,13 @@
+events.listen('item.tags', (event) => {
+    event.add('forge:bookshelves', [
+        'betterendforge:jellyshroom_bookshelf',
+        'betterendforge:umbrella_tree_bookshelf',
+        'betterendforge:helix_tree_bookshelf',
+        'betterendforge:tenanea_bookshelf',
+        'betterendforge:dragon_tree_bookshelf',
+        'betterendforge:pythadendron_bookshelf',
+        'betterendforge:end_lotus_bookshelf',
+        'betterendforge:lacugrove_bookshelf',
+        'betterendforge:mossy_glowshroom_bookshelf'
+    ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/dusts.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/dusts.js
@@ -20,8 +20,8 @@ events.listen('item.tags', (event) => {
     event.get('forge:dusts').remove('minecraft:prismarine_shard');
     event.get('forge:dusts/prismarine').remove('minecraft:prismarine_shard');
 
-    event.get('forge:dusts/ender_pearl').add('emendatusenigmatica:ender_dust');
-    event.get('forge:dusts/ender').add('thermal:ender_pearl_dust');
+    event.get('forge:dusts/ender_pearl').add('emendatusenigmatica:ender_dust').add('betterendforge:ender_dust');
+    event.get('forge:dusts/ender').add('thermal:ender_pearl_dust').add('betterendforge:ender_dust');
 
     event.get('forge:dusts/gold_copper').add('#forge:dusts/gold').add('#forge:dusts/copper');
     event.get('forge:dusts/iron_aluminum').add('#forge:dusts/iron').add('#forge:dusts/aluminum');

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/fruits.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/fruits.js
@@ -1,0 +1,18 @@
+events.listen('item.tags', (event) => {
+    event.add('forge:fruits', [
+        'ars_nouveau:mana_berry',
+        'betterendforge:blossom_berry',
+        'betterendforge:shadow_berry_raw',
+        'autumnity:foul_berries',
+        'atmospheric:yucca_fruit',
+        'atmospheric:passionfruit'
+    ]);
+
+    event.add('forge:fruits/mana_berry', ['ars_nouveau:mana_berry']);
+    event.add('forge:fruits/blossom_berry', ['betterendforge:blossom_berry']);
+    event.add('forge:fruits/shadow_berry', ['betterendforge:shadow_berry_raw']);
+    event.add('forge:fruits/foul_berries', ['autumnity:foul_berries']);
+    event.add('forge:fruits/yucca_fruit', ['atmospheric:yucca_fruit']);
+    event.add('forge:fruits/passionfruit', ['atmospheric:passionfruit']);
+    event.add('forge:fruits/menril_berries', ['integrateddynamics:menril_berries']);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/gems.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/gems.js
@@ -2,15 +2,17 @@ events.listen('item.tags', (event) => {
     var gems = 'forge:gems';
     var gems_ender = gems + '/ender';
 
-    event
-        .get(gems)
-        .add('rftoolsbase:dimensionalshard')
-        .add('minecraft:ender_pearl')
-        .add('ars_nouveau:mana_gem')
-        .add('mapperbase:raw_bitumen')
-        .add('immersivepetroleum:bitumen')
-        .add('thermal:bitumen')
-        .add('betterendforge:crystalline_sulphur');
+    event.add(gems, [
+        'rftoolsbase:dimensionalshard',
+        'minecraft:ender_pearl',
+        'ars_nouveau:mana_gem',
+        'mapperbase:raw_bitumen',
+        'immersivepetroleum:bitumen',
+        'thermal:bitumen',
+        'betterendforge:crystalline_sulphur',
+        'betterendforge:amber_gem'
+    ]);
+
     event.add(gems + '/coal_coke', [
         'emendatusenigmatica:coke_gem',
         'immersiveengineering:coal_coke',
@@ -20,13 +22,8 @@ events.listen('item.tags', (event) => {
     event.get('forge:gems/dimensional').add('rftoolsbase:dimensionalshard');
     event.get('forge:gems/mana').add('ars_nouveau:mana_gem');
     event.get('forge:gems/charcoal').add('minecraft:charcoal');
-    event
-        .get('forge:gems/bitumen')
-        .add('mapperbase:raw_bitumen')
-        .add('immersivepetroleum:bitumen')
-        .add('thermal:bitumen');
-
+    event.add('forge:gems/bitumen', ['mapperbase:raw_bitumen', 'immersivepetroleum:bitumen', 'thermal:bitumen']);
     event.get('forge:gems/mana_gem').remove('ars_nouveau:mana_gem');
-
     event.get('forge:gems/sulfur').add('betterendforge:crystalline_sulphur');
+    event.get('forge:gems/amber').add('betterendforge:amber_gem');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ingots.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ingots.js
@@ -1,24 +1,30 @@
 events.listen('item.tags', (event) => {
-    event.get('forge:ingots').add('powah:uraninite');
     event.get('forge:ingots/uraninite').add('powah:uraninite');
     event.get('forge:ingots/energized_steel').add('powah:steel_energized');
     event.get('forge:ingots/radioactive').add('#forge:ingots/uraninite').add('#forge:ingots/uranium');
 
-    event
-        .get('forge:ingots')
-        .add('immersiveengineering:ingot_aluminum')
-        .add('immersiveengineering:ingot_lead')
-        .add('immersiveengineering:ingot_silver')
-        .add('immersiveengineering:ingot_nickel')
-        .add('immersiveengineering:ingot_uranium')
-        .add('immersiveengineering:ingot_constantan')
-        .add('immersiveengineering:ingot_electrum')
-        .add('immersiveengineering:ingot_hop_graphite')
-        .add('mythicbotany:alfsteel_ingot')
-        .add('industrialforegoing:pink_slime_ingot')
-        .add('occultism:iesnium_ingot')
-        .add('astralsorcery:starmetal_ingot')
-        .add('create:andesite_alloy');
+    event.add('forge:ingots', [
+        'astralsorcery:starmetal_ingot',
+        'betterendforge:aeternium_ingot',
+        'betterendforge:terminite_ingot',
+        'botania:gaia_ingot',
+        'create:andesite_alloy',
+        'immersiveengineering:ingot_aluminum',
+        'immersiveengineering:ingot_constantan',
+        'immersiveengineering:ingot_electrum',
+        'immersiveengineering:ingot_hop_graphite',
+        'immersiveengineering:ingot_lead',
+        'immersiveengineering:ingot_nickel',
+        'immersiveengineering:ingot_silver',
+        'immersiveengineering:ingot_uranium',
+        'industrialforegoing:pink_slime_ingot',
+        'mythicbotany:alfsteel_ingot',
+        'naturesaura:infused_iron',
+        'naturesaura:sky_ingot',
+        'naturesaura:tainted_gold',
+        'occultism:iesnium_ingot',
+        'powah:uraninite'
+    ]);
 
     event.get('forge:ingots/copper').add('immersiveengineering:ingot_copper');
     event.get('forge:ingots/alfsteel').add('mythicbotany:alfsteel_ingot');
@@ -26,13 +32,10 @@ events.listen('item.tags', (event) => {
     event.get('forge:ingots/gaia').add('botania:gaia_ingot');
     event.get('forge:ingots/gaia_spirit').add('botania:gaia_ingot');
     event.add('forge:ingots/starmetal', ['astralsorcery:starmetal_ingot']);
-    event
-        .get('forge:ingots')
-        .add('naturesaura:sky_ingot')
-        .add('naturesaura:tainted_gold')
-        .add('naturesaura:infused_iron');
-    event.get('forge:ingots').add('botania:gaia_ingot');
     event.add('forge:ingots/andesite_alloy', ['create:andesite_alloy']);
+
+    event.add('forge:ingots/aeternium', ['betterendforge:aeternium_ingot']);
+    event.add('forge:ingots/terminite', ['betterendforge:terminite_ingot']);
 
     event.get('forge:ingots/gold_brass').add('#forge:ingots/gold').add('#forge:ingots/brass');
     event.get('forge:ingots/gold_bronze').add('#forge:ingots/gold').add('#forge:ingots/bronze');

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_caps.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_caps.js
@@ -1,5 +1,5 @@
 events.listen('item.tags', (event) => {
-    var items = [
+    event.add('forge:mushroom_caps', [
         'byg:shulkren_wart_block',
         'byg:death_cap_mushroom_block',
         'byg:soul_shroom_block',
@@ -15,7 +15,9 @@ events.listen('item.tags', (event) => {
         'undergarden:veil_mushroom_cap',
         'undergarden:indigo_mushroom_cap',
         'byg:embur_gel_block',
-        'undergarden:grongle_cap'
-    ];
-    event.get('forge:mushroom_caps').add(items);
+        'undergarden:grongle_cap',
+        'betterendforge:umbrella_tree_membrane',
+        'betterendforge:mossy_glowshroom_cap',
+        'betterendforge:jellyshroom_cap_purple'
+    ]);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_stems.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_stems.js
@@ -1,5 +1,5 @@
 events.listen('item.tags', (event) => {
-    var items = [
+    event.add('forge:mushroom_stems', [
         'byg:soul_shroom_stem',
         'byg:yellow_glowshroom_stem',
         'byg:red_glowshroom_stem',
@@ -8,7 +8,9 @@ events.listen('item.tags', (event) => {
         'quark:glowshroom_stem',
         'undergarden:veil_mushroom_stalk',
         'undergarden:blood_mushroom_stalk',
-        'undergarden:indigo_mushroom_stalk'
-    ];
-    event.get('forge:mushroom_stems').add(items);
+        'undergarden:indigo_mushroom_stalk',
+        'betterendforge:umbrella_tree_log',
+        'betterendforge:mossy_glowshroom_log',
+        'betterendforge:jellyshroom_log'
+    ]);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushrooms.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushrooms.js
@@ -1,11 +1,13 @@
 events.listen('item.tags', (event) => {
-    var items = [
+    event.add('forge:mushrooms', [
         'byg:death_cap',
         'byg:shulkren_fungus',
         'byg:soul_shroom_spore_end',
         'byg:soul_shroom',
         'byg:purple_glowshroom',
-        'byg:blue_glowshroom'
-    ];
-    event.get('forge:mushrooms').add(items);
+        'byg:blue_glowshroom',
+        'betterendforge:umbrella_tree_sapling',
+        'betterendforge:mossy_glowshroom_sapling',
+        'betterendforge:small_jellyshroom'
+    ]);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
@@ -1,18 +1,24 @@
 events.listen('item.tags', (event) => {
-    event
-        .get('forge:ores')
-        .add(['powah:uraninite_ore_poor', 'powah:uraninite_ore', 'powah:uraninite_ore_dense'])
-        .add('minecraft:ancient_debris')
-        .add('occultism:iesnium_ore');
-    event
-        .get('forge:ores/dimensional')
-        .add([
-            'rftoolsbase:dimensionalshard_overworld',
-            'rftoolsbase:dimensionalshard_nether',
-            'rftoolsbase:dimensionalshard_end'
-        ]);
+    event.add('forge:ores', [
+        'powah:uraninite_ore_poor',
+        'powah:uraninite_ore',
+        'powah:uraninite_ore_dense',
+        'betterendforge:ender_ore',
+        'betterendforge:amber_ore',
+        'minecraft:ancient_debris',
+        'occultism:iesnium_ore'
+    ]);
+    event.add('forge:ores/dimensional', [
+        'rftoolsbase:dimensionalshard_overworld',
+        'rftoolsbase:dimensionalshard_nether',
+        'rftoolsbase:dimensionalshard_end'
+    ]);
 
     event.get('forge:ores/nether/gold').add('minecraft:nether_gold_ore');
     event.get('forge:ores/netherite_scrap').remove('minecraft:ancient_debris');
     event.get('forge:ores/netherite').add('minecraft:ancient_debris');
+
+    event.add('forge:ores/ender', ['betterendforge:ender_ore']);
+
+    event.add('forge:ores/amber', ['betterendforge:amber_ore']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/seeds.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/seeds.js
@@ -1,4 +1,23 @@
 events.listen('item.tags', (event) => {
-    event.get('forge:seeds').add('immersiveengineering:seed');
-    event.get('forge:seeds/hemp').add('immersiveengineering:seed');
+    event.add('forge:seeds', [
+        'immersiveengineering:seed',
+        'betterendforge:bulb_vine_seed',
+        'betterendforge:blossom_berry_seed',
+        'betterendforge:shadow_berry',
+        'betterendforge:glowing_pillar_seed',
+        'betterendforge:lanceleaf_seed',
+        'betterendforge:end_lotus_seed',
+        'betterendforge:end_lily_seed',
+        'betterendforge:blue_vine_seed'
+    ]);
+    event.add('forge:seeds/hemp', ['immersiveengineering:seed']);
+
+    event.add('forge:seeds/bulb_vine', ['betterendforge:bulb_vine_seed']);
+    event.add('forge:seeds/blossom_berry', ['betterendforge:blossom_berry_seed']);
+    event.add('forge:seeds/shadow_berry', ['betterendforge:shadow_berry']);
+    event.add('forge:seeds/glowing_pillar', ['betterendforge:glowing_pillar_seed']);
+    event.add('forge:seeds/lanceleaf', ['betterendforge:lanceleaf_seed']);
+    event.add('forge:seeds/end_lotus', ['betterendforge:end_lotus_seed']);
+    event.add('forge:seeds/end_lily', ['betterendforge:end_lily_seed']);
+    event.add('forge:seeds/blue_vine', ['betterendforge:blue_vine_seed']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/shards.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/shards.js
@@ -1,0 +1,10 @@
+events.listen('item.tags', (event) => {
+    event.add('forge:shards', [
+        'betterendforge:ender_shard',
+        'betterendforge:crystal_shards',
+        'betterendforge:raw_amber'
+    ]);
+    event.add('forge:shards/ender', ['betterendforge:ender_shard']);
+    event.add('forge:shards/aurora', ['betterendforge:crystal_shards']);
+    event.add('forge:shards/amber', ['betterendforge:raw_amber']);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
@@ -1,28 +1,40 @@
 events.listen('item.tags', (event) => {
     var storageBlocks = 'forge:storage_blocks';
-    event.get(storageBlocks + '/glowstone').add('minecraft:glowstone');
-    event
-        .get(storageBlocks)
-        .add('minecraft:glowstone')
-        .add('immersiveengineering:storage_aluminum')
-        .add('immersiveengineering:storage_lead')
-        .add('immersiveengineering:storage_silver')
-        .add('immersiveengineering:storage_nickel')
-        .add('immersiveengineering:storage_uranium')
-        .add('immersiveengineering:storage_constantan')
-        .add('immersiveengineering:storage_electrum')
-        .add('immersiveengineering:coke')
-        .add('powah:uraninite_block')
-        .add('occultism:iesnium_block')
-        .add('naturesaura:infused_iron_block')
-        .add('naturesaura:tainted_gold_block')
-        .add('astralsorcery:starmetal')
-        .add('ars_nouveau:mana_gem_block');
+    event.add(storageBlocks, [
+        'minecraft:glowstone',
+        'immersiveengineering:storage_aluminum',
+        'immersiveengineering:storage_lead',
+        'immersiveengineering:storage_silver',
+        'immersiveengineering:storage_nickel',
+        'immersiveengineering:storage_uranium',
+        'immersiveengineering:storage_constantan',
+        'immersiveengineering:storage_electrum',
+        'immersiveengineering:coke',
+        'powah:uraninite_block',
+        'occultism:iesnium_block',
+        'naturesaura:infused_iron_block',
+        'naturesaura:tainted_gold_block',
+        'astralsorcery:starmetal',
+        'ars_nouveau:mana_gem_block',
+        'betterendforge:aeternium_block',
+        'betterendforge:terminite_block',
+        'betterendforge:ender_block',
+        'betterendforge:aurora_crystal',
+        'betterendforge:amber_block'
+    ]);
 
+    event.get(storageBlocks + '/glowstone').add('minecraft:glowstone');
     event.get(storageBlocks + '/mana').add('ars_nouveau:mana_gem_block');
     event.get(storageBlocks + '/infused_iron').add('naturesaura:infused_iron_block');
     event.get(storageBlocks + '/tainted_gold').add('naturesaura:tainted_gold_block');
     event.get(storageBlocks + '/starmetal').add('astralsorcery:starmetal');
+
+    event.add(storageBlocks + '/aeternium', ['betterendforge:aeternium_block']);
+    event.add(storageBlocks + '/terminite', ['betterendforge:terminite_block']);
+    event.add(storageBlocks + '/ender', ['betterendforge:ender_block']);
+    event.add(storageBlocks + '/aurora', ['betterendforge:aurora_crystal']);
+    event.add(storageBlocks + '/amber', ['betterendforge:amber_block']);
+
     event
         .get(storageBlocks + '/gold_bronze')
         .add('#' + storageBlocks + '/gold')

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/weapons/melee.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/weapons/melee.js
@@ -64,7 +64,9 @@ events.listen('item.tags', (event) => {
         'betterendforge:golden_hammer',
         'betterendforge:iron_hammer',
         'betterendforge:aeternium_hammer',
-        'betterendforge:terminite_hammer'
+        'betterendforge:terminite_hammer',
+        'betterendforge:aeternium_sword',
+        'betterendforge:terminite_sword'
     ];
     event.get('forge:weapons').add(items);
     event.get('forge:weapons/melee').add(items);

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/workbench.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/workbench.js
@@ -1,3 +1,14 @@
 events.listen('item.tags', (event) => {
-    event.get('forge:workbench').add('minecraft:crafting_table');
+    event.add('forge:workbench', [
+        'minecraft:crafting_table',
+        'betterendforge:jellyshroom_crafting_table',
+        'betterendforge:umbrella_tree_crafting_table',
+        'betterendforge:helix_tree_crafting_table',
+        'betterendforge:tenanea_crafting_table',
+        'betterendforge:dragon_tree_crafting_table',
+        'betterendforge:pythadendron_crafting_table',
+        'betterendforge:end_lotus_crafting_table',
+        'betterendforge:lacugrove_crafting_table',
+        'betterendforge:mossy_glowshroom_crafting_table'
+    ]);
 });


### PR DESCRIPTION


Did a bit of cleanup in the tag scripts I touched too.

The ores are not yet handled by unification properly. Amber ore outputs nothing and end ore is giving pearls in some cases.

Both of these drop 'shards' that are used for different things. I've tagged them as such for now, but perhaps they should go into another tag?