### PR TITLE
Compact Machines recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -53,6 +53,8 @@ events.listen('recipes', (event) => {
 
         'buildersaddition:iron_rod',
 
+        'compactmachines:wall',
+
         'create:mechanical_crafting/integrated_circuit',
         'create:pressing/lapis_block',
         'create:fill_minecraft_bucket_with_create_honey',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/injecting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/injecting.js
@@ -4,12 +4,7 @@ events.listen('recipes', (event) => {
             {
                 output: 'buildinggadgets:construction_block_dense',
                 input: 'buildinggadgets:construction_block_powder',
-                gas: { gas: 'mekanism:steam', amount: 200 }
-            },
-            {
-                output: 'buildinggadgets:construction_block_dense',
-                input: 'buildinggadgets:construction_block_powder',
-                gas: { gas: 'mekanism:water_vapor', amount: 200 }
+                gas: { tag: 'mekanism:water_vapor', amount: 200 }
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/remove.js
@@ -1,5 +1,5 @@
 events.listen('recipes', (event) => {
-    if (global.packmode !== 'normal') {
+    if (global.packmode != 'normal') {
         return;
     }
 

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/replace_input.js
@@ -1,0 +1,7 @@
+events.listen('recipes', (event) => {
+    if (global.packmode != 'normal') {
+        return;
+    }
+
+    event.replaceInput({id: 'compactmachines:personal_shrinking_device'}, 'minecraft:book', 'shrink:shrinking_device');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
@@ -1,5 +1,5 @@
 events.listen('recipes', (event) => {
-    if (global.packmode !== 'normal') {
+    if (global.packmode != 'normal') {
         return;
     }
 
@@ -14,6 +14,18 @@ events.listen('recipes', (event) => {
             A: '#forge:ingots/gold',
             B: '#forge:glass',
             C: '#forge:storage_blocks/glowstone'
+        }),
+        shapedRecipe(Item.of('compactmachines:tunnel', {definition: {id: "compactmachines:item"}}), ['ABA', 'BCB', 'DBD'], {
+            A: 'minecraft:hopper',
+            B: '#forge:gems/dimensional',
+            C: 'occultism:wormhole_frame',
+            D: '#forge:chests'
+        }),
+        shapedRecipe(Item.of('compactmachines:tunnel', {definition:{id:"compactmachines:redstone_in"}}), ['ABA', 'BCB', 'DBD'], {
+            A: 'glassential:glass_redstone',
+            B: '#forge:gems/dimensional',
+            C: 'occultism:wormhole_frame',
+            D: 'minecraft:redstone_torch'
         })
     ];
     recipes.forEach(function (recipe) {

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
@@ -1,5 +1,5 @@
 events.listen('recipes', (event) => {
-    if (global.packmode !== 'normal') {
+    if (global.packmode != 'normal') {
         return;
     }
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/miniaturization.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/miniaturization.js
@@ -1,0 +1,1032 @@
+events.listen('recipes', (event) => {
+    if (global.packmode != 'normal') {
+        return;
+    }
+
+    //https://github.com/CompactMods/CompactCrafting/wiki/Recipe-Specification
+
+    //Also note, can't use Item.of because Count is caps sensitive (Name too)
+
+    var data = {
+        recipes: [
+            {
+                //Tiny
+                recipeSize: 5,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'fluxnetworks:flux_dust',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_tiny',
+                        Count: 1
+                    }
+                ]
+            },
+            //Small
+            {
+                recipeSize: 5,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', 'W'],
+                            ['W', '-', 'R', '-', 'W'],
+                            ['W', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W']
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'industrialforegoing:common_black_hole_unit',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_small',
+                        Count: 1
+                    }
+                ]
+            },
+            {
+                recipeSize: 5,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', 'W'],
+                            ['W', '-', 'R', '-', 'W'],
+                            ['W', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W']
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'occultism:storage_stabilizer_tier1',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_small',
+                        Count: 1
+                    }
+                ]
+            },
+
+            //Normal
+            {
+                recipeSize: 7,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W']
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'industrialforegoing:pity_black_hole_unit',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_normal',
+                        Count: 1
+                    }
+                ]
+            },
+            {
+                recipeSize: 7,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W']
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'occultism:storage_stabilizer_tier1',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_normal',
+                        Count: 1
+                    }
+                ]
+            },
+
+            //Large
+            {
+                recipeSize: 9,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'E', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'industrialforegoing:simple_black_hole_unit',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    },
+                    E: {
+                        Name: 'emendatusenigmatica:enderium_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_large',
+                        Count: 1
+                    }
+                ]
+            },
+            {
+                recipeSize: 9,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'E', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'R', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'occultism:storage_stabilizer_tier2',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    },
+                    E: {
+                        Name: 'emendatusenigmatica:enderium_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_large',
+                        Count: 1
+                    }
+                ]
+            },
+
+            //Giant
+            {
+                recipeSize: 11,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'E', 'E', 'E', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'industrialforegoing:advanced_black_hole_unit',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    },
+                    E: {
+                        Name: 'emendatusenigmatica:enderium_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_giant',
+                        Count: 1
+                    }
+                ]
+            },
+            {
+                recipeSize: 11,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', 'R', 'E', 'E', 'E', 'R', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'R', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'occultism:storage_stabilizer_tier3',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    },
+                    E: {
+                        Name: 'emendatusenigmatica:enderium_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_giant',
+                        Count: 1
+                    }
+                ]
+            },
+
+            //Maximum
+            {
+                recipeSize: 13,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'E', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'E', 'E', 'E', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'R', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'E', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'R', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'E', 'E', 'E', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'E', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'industrialforegoing:supreme_black_hole_unit',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    },
+                    E: {
+                        Name: 'emendatusenigmatica:enderium_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_maximum',
+                        Count: 1
+                    }
+                ]
+            },
+            {
+                recipeSize: 13,
+                layers: [
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'E', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'E', 'E', 'E', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'R', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', 'R', 'E', 'E', 'E', 'R', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'R', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'E', 'E', 'E', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', 'R', 'E', 'R', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:mixed',
+                        pattern: [
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', 'E', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'W'],
+                            ['W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W', 'W'],
+                        ]
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:hollow',
+                        wall: 'W'
+                    },
+                    {
+                        type: 'compactcrafting:filled',
+                        component: 'W'
+                    }
+                ],
+                catalyst: {
+                    id: 'occultism:storage_stabilizer_tier4',
+                    Count: 1
+                },
+                components: {
+                    W: {
+                        Name: 'compactmachines:wall'
+                    },
+                    R: {
+                        Name: 'minecraft:redstone_block'
+                    },
+                    E: {
+                        Name: 'emendatusenigmatica:enderium_block'
+                    }
+                },
+                outputs: [
+                    {
+                        id: 'compactmachines:machine_maximum',
+                        Count: 1
+                    }
+                ]
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.custom({
+            type: 'compactcrafting:miniaturization',
+            version: 1,
+            recipeSize: recipe.recipeSize,
+            layers: recipe.layers,
+            catalyst: recipe.catalyst,
+            components: recipe.components,
+            outputs: recipe.outputs
+        });
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
@@ -1,0 +1,20 @@
+events.listen('recipes', (event) => {
+    if (global.packmode != 'normal') {
+        return;
+    }
+
+    var data = {
+        recipes: [
+            {
+                output: Item.of('compactmachines:wall', 32),
+                inputItem: '#forge:storage_blocks/ender',
+                infusionInput: 'mekanism:refined_obsidian',
+                infusionAmount: 160
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.recipes.mekanism.metallurgic_infusing(recipe.output, recipe.inputItem, recipe.infusionInput, recipe.infusionAmount)
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
@@ -6,10 +6,10 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             {
-                output: Item.of('compactmachines:wall', 64),
+                output: Item.of('compactmachines:wall', 32),
                 inputItem: '#forge:storage_blocks/ender',
                 infusionInput: 'mekanism:refined_obsidian',
-                infusionAmount: 160
+                infusionAmount: 80
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mekanism/metallurgic_infusing.js
@@ -6,7 +6,7 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             {
-                output: Item.of('compactmachines:wall', 32),
+                output: Item.of('compactmachines:wall', 64),
                 inputItem: '#forge:storage_blocks/ender',
                 infusionInput: 'mekanism:refined_obsidian',
                 infusionAmount: 160

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
@@ -1,0 +1,28 @@
+events.listen('recipes', (event) => {
+    if (global.packmode != 'normal') {
+        return;
+    }
+
+    var data = {
+        recipes: [
+            {
+                input: Ingredient.of('#forge:storage_blocks/enderium'),
+                output: Item.of('compactmachines:wall', 32),
+                aura_type: 'naturesaura:overworld',
+                aura: 15000,
+                time: 100
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.custom({
+            type: 'naturesaura:altar',
+            input: recipe.input,
+            output: recipe.output,
+            aura_type: recipe.aura_type,
+            aura: recipe.aura,
+            time: recipe.time
+        });
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
@@ -6,8 +6,8 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             {
-                input: Ingredient.of('#forge:storage_blocks/enderium'),
-                output: Item.of('compactmachines:wall', 64),
+                input: Ingredient.of('#forge:ingots/enderium'),
+                output: Item.of('compactmachines:wall', 32),
                 aura_type: 'naturesaura:overworld',
                 aura: 15000,
                 time: 100

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/altar.js
@@ -7,7 +7,7 @@ events.listen('recipes', (event) => {
         recipes: [
             {
                 input: Ingredient.of('#forge:storage_blocks/enderium'),
-                output: Item.of('compactmachines:wall', 32),
+                output: Item.of('compactmachines:wall', 64),
                 aura_type: 'naturesaura:overworld',
                 aura: 15000,
                 time: 100

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
@@ -7,11 +7,11 @@ events.listen('recipes', (event) => {
         recipes: [
             {
                 inputs: [
-                    '#forge:storage_blocks/enderium',
+                    '#forge:ingots/enderium',
                     Item.of('fluxnetworks:flux_dust', 8)
                 ],
                 outputs: [
-                    Item.of('compactmachines:wall', 64)
+                    Item.of('compactmachines:wall', 32)
                 ]
             }
         ]

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
@@ -1,0 +1,23 @@
+events.listen('recipes', (event) => {
+    if (global.packmode != 'normal') {
+        return;
+    }
+
+    var data = {
+        recipes: [
+            {
+                inputs: [
+                    '#forge:storage_blocks/enderium',
+                    Item.of('fluxnetworks:flux_dust', 8)
+                ],
+                outputs: [
+                    Item.of('compactmachines:wall', 32)
+                ]
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.recipes.thermal.smelter(recipe.outputs, recipe.inputs);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/thermal/machine/induction_smelter.js
@@ -11,7 +11,7 @@ events.listen('recipes', (event) => {
                     Item.of('fluxnetworks:flux_dust', 8)
                 ],
                 outputs: [
-                    Item.of('compactmachines:wall', 32)
+                    Item.of('compactmachines:wall', 64)
                 ]
             }
         ]


### PR DESCRIPTION
I'm still not convinced on these since they might feel a bit too much and I'm probably looking over them again, but I'll still open the PR to get feedback from you guys as well.

The main idea is give three different routes to make walls centered around enderium/enderperals, giving both magic and tech alternatives to make them.

The actual machines then start with a 5x5x5 and tier up to a 13x13x13 for the max tier (how it was in the original mod) and the catalysts gate them a bit more, with the different tiers of IF black hole units or Occultism stabilizers

The main cost here is enderium, so let me drop a quick table to show you the costs:

| Tier  | #Enderium Blocks|
| ------------- | ------------- |
| Tiny  | 2 |
| Small  | 2 |
| Normal | 4 |
| Large | 8 |
| Giant | 17 |
| Maximum  | 31 |

the rampup is quite steep there at the end since I'm using enderium in the structure too which might change. In the end I still think this is a bit too extreme for non expert, so if you have any other ideas let me know