### PR TITLE
Added Diet food groups to unsupported mod foods

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/fruits.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/fruits.js
@@ -1,0 +1,24 @@
+var fruitFoods = [
+    'integrateddynamics:menril_berries',
+    'betterendforge:shadow_berry_raw',
+    'betterendforge:shadow_berry_cooked',
+    'betterendforge:sweet_berry_jelly',
+    'betterendforge:shadow_berry_jelly',
+    'betterendforge:blossom_berry',
+    'undergarden:blisterberry',
+    'byg:baobab_fruit',
+    'byg:holly_berries',
+    'byg:green_apple',
+    'byg:cooked_joshua_fruit',
+    'byg:joshua_fruit',
+    'byg:crimson_berries',
+    'byg:nightshade_berries',
+    'byg:blueberries',
+    'ars_nouveau:mana_berry'
+];
+
+events.listen('item.tags', (event) => {
+    fruitFoods.forEach((food) => {
+        event.get('diet:fruits').add(food);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/grains.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/grains.js
@@ -1,0 +1,13 @@
+var grainFoods = [
+  'pneumaticcraft:sourdough_bread',
+  'pneumaticcraft:salmon_tempura',
+  'resourcefulbees:oreo_cookie',
+  'meetyourfight:aether_glazed_cupcake',
+  'meetyourfight:velvet_fortune'
+];
+
+events.listen('item.tags', (event) => {
+    grainFoods.forEach((food) => {
+        event.get('diet:grains').add(food);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/proteins.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/proteins.js
@@ -1,0 +1,19 @@
+var proteinFoods = [
+    'pneumaticcraft:cod_n_chips',
+    'pneumaticcraft:salmon_tempura',
+    'betterendforge:end_fish_raw',
+    'betterendforge:end_fish_cooked',
+    'undergarden:raw_dweller_meat',
+    'undergarden:dweller_steak',
+    'undergarden:raw_gwibling',
+    'undergarden:cooked_gwibling',
+    'undergarden:raw_gloomper_leg',
+    'undergarden:gloomper_leg',
+    'meetyourfight:marshy_delight'
+];
+
+events.listen('item.tags', (event) => {
+    proteinFoods.forEach((food) => {
+        event.get('diet:proteins').add(food);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/sugars.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/sugars.js
@@ -1,0 +1,20 @@
+var sugarFoods = [
+    'resourcefulbees:oreo_cookie',
+    'betterendforge:sweet_berry_jelly',
+    'betterendforge:shadow_berry_jelly',
+    'meetyourfight:aether_glazed_cupcake'
+];
+
+events.listen('item.tags', (event) => {
+    sugarFoods.forEach((food) => {
+        event.get('diet:sugars').add(food);
+    });
+
+    combVariants.forEach((comb) => {
+        event.get('diet:sugars').add('resourcefulbees:' + comb + '_honeycomb');
+    });
+
+    honeyVarieties.forEach((honey) => {
+        event.get('diet:sugars').add(honey + '_bottle');
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/vegetables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/diet/vegetables.js
@@ -1,0 +1,24 @@
+var vegetableFoods = [
+    'pneumaticcraft:chips',
+    'pneumaticcraft:cod_n_chips',
+    'undergarden:droopvine_item',
+    'undergarden:underbeans',
+    'undergarden:gloomgourd_pie',
+    'undergarden:bloody_stew',
+    'undergarden:inky_stew',
+    'undergarden:indigo_stew',
+    'undergarden:veiled_stew',
+    'byg:soul_shroom',
+    'byg:death_cap',
+    'byg:green_mushroom',
+    'byg:weeping_milkcap',
+    'byg:wood_blewit',
+    'byg:black_puff',
+    'meetyourfight:marshy_delight'
+];
+
+events.listen('item.tags', (event) => {
+    vegetableFoods.forEach((food) => {
+        event.get('diet:vegetables').add(food);
+    });
+});


### PR DESCRIPTION
The five scripts could easily be merged into a single one but I liked having them separate, felt a bit more tidy to me. If you think it should be merged I can do that quickly.

Also diet is really neat, just have to add the tag for the food group and it figures out the values by itself. I really like it :P

https://github.com/NillerMedDild/Enigmatica6/issues/1377