### PR TITLE
Move Mimiccream to Mimic drop table

### DIFF
--- a/kubejs/data/artifacts/loot_tables/entities/mimic.json
+++ b/kubejs/data/artifacts/loot_tables/entities/mimic.json
@@ -1,0 +1,34 @@
+{
+    "pools": [
+        {
+            "name": "main",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "name": "artifacts:artifact"
+                }
+            ]
+        },
+        {
+            "name": "mimicube",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "alexsmobs:mimicream",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": -1,
+                                "max": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Move Mimiccream to Mimic drop table

This lets us side-step the unintended dupe issues with the mimic cubes themselves, while retaining the interesting features of mimiccream. Given the rarity of mimics themselves, the fact they can't be spawned or farmed, and the lowish drop rate, this should make them quite uncommon to obtain.