### PR TITLE
Lowered artifact rates in end city loot (and accidentally fixed #1391)

### DIFF
--- a/kubejs/data/minecraft/loot_tables/chests/end_city_treasure.json
+++ b/kubejs/data/minecraft/loot_tables/chests/end_city_treasure.json
@@ -335,13 +335,13 @@
             "conditions": [
                 {
                     "condition": "random_chance",
-                    "chance": 0.3
+                    "chance": 0.2
                 }
             ],
             "entries": [
                 {
                     "type": "loot_table",
-                    "weight": 3,
+                    "weight": 8,
                     "name": "artifacts:artifact"
                 },
                 {

--- a/kubejs/data/minecraft/loot_tables/chests/end_city_treasure.json
+++ b/kubejs/data/minecraft/loot_tables/chests/end_city_treasure.json
@@ -305,16 +305,6 @@
                             "treasure": true
                         }
                     ]
-                },
-                {
-                    "type": "loot_table",
-                    "weight": 40,
-                    "name": "artifacts:artifact"
-                },
-                {
-                    "type": "item",
-                    "weight": 5,
-                    "name": "artifacts:crystal_heart"
                 }
             ]
         },
@@ -337,6 +327,27 @@
                     "type": "item",
                     "weight": 1,
                     "name": "minecraft:elytra"
+                }
+            ]
+        },
+        {
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "random_chance",
+                    "chance": 0.3
+                }
+            ],
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "weight": 3,
+                    "name": "artifacts:artifact"
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "artifacts:crystal_heart"
                 }
             ]
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -5,6 +5,7 @@ events.listen('recipes', (event) => {
         { output: 'minecraft:flint', inputs: ['#forge:gravel', '#forge:gravel', '#forge:gravel'] },
         { output: 'simplefarming:cornbread', inputs: ['#forge:grain', '#forge:crops/corn', '#forge:grain'] },
         { output: 'minecraft:chest', inputs: ['#forge:chests/wooden'] },
+        { output: 'minecraft:pumpkin', inputs: ['autumnity:large_pumpkin_slice'] },
         {
             output: 'minecraft:crafting_table',
             inputs: ['craftingstation:crafting_station_slab', 'craftingstation:crafting_station_slab']


### PR DESCRIPTION
I think the artifact's weights for these chests is based on the 1-3 loot chests you would normally find in an end city... These new end cities can have 10-20+ chests in them, and with lootr basically a whole server will have every single artifact from 1-2 end cities found. I moved the artifacts in to their own pool and gave them a 30% chance of generating putting it much closer to what a vanilla end city might have.

Edit: accidentally put the fix for #1391 here too, whoops