### PR TITLE
Updated occultism loot boxes

### DIFF
--- a/kubejs/data/enigmatica/loot_tables/chests/quest_occultism_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_occultism_loot_epic.json
@@ -1,22 +1,10 @@
 {
-    "type": "minecraft:chest",
     "pools": [
         {
             "rolls": 1,
             "entries": [
                 {
-                    "type": "minecraft:item",
-                    "weight": 2,
-                    "name": "occultism:otherstone",
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": 8
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:spirit_attuned_gem",
                     "functions": [
@@ -27,7 +15,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:otherworld_sapling",
                     "functions": [
@@ -38,51 +26,18 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 2,
-                    "name": "occultism:chalk_white",
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": 1
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 2,
-                    "name": "occultism:chalk_purple",
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": 1
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 2,
-                    "name": "occultism:chalk_gold",
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": 1
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:soul_gem",
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 1
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:book_of_binding_foliot",
                     "functions": [
@@ -93,7 +48,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:book_of_binding_djinni",
                     "functions": [
@@ -104,7 +59,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "occultism:iesnium_block",
                     "functions": [
@@ -115,7 +70,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "occultism:iesnium_ore",
                     "functions": [
@@ -126,7 +81,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "occultism:stable_wormhole",
                     "functions": [

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_occultism_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_occultism_loot_epic.json
@@ -32,7 +32,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 2
+                            "count": 1
                         }
                     ]
                 },
@@ -88,6 +88,20 @@
                         {
                             "function": "set_count",
                             "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "occultism:storage_stabilizer_tier2",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
                         }
                     ]
                 }

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_occultism_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_occultism_loot_legendary.json
@@ -1,11 +1,10 @@
 {
-    "type": "minecraft:chest",
     "pools": [
         {
             "rolls": 1,
             "entries": [
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:iesnium_block",
                     "functions": [
@@ -16,7 +15,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
                     "name": "occultism:miner_djinni_ores",
                     "functions": [
@@ -27,9 +26,9 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 2,
-                    "name": "occultism:storage_stabilizer_tier2",
+                    "name": "occultism:storage_stabilizer_tier4",
                     "functions": [
                         {
                             "function": "set_count",
@@ -38,13 +37,13 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "occultism:storage_stabilizer_tier3",
+                    "type": "item",
+                    "weight": 2,
+                    "name": "occultism:stable_wormhole",
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 1
+                            "count": 4
                         }
                     ]
                 }


### PR DESCRIPTION
removed chalk types from epic loot boxes as chalk is no longer needed to craft books making having more than 1 piece of each type unnecessary. Also moved t2 stabilizers to this loot box.

Removed tier 2 and 3 stabilizers from the legendary loot boxes and added tier 4 as by the time the player gets to these, they have access to tier 4