### PR TITLE
Blacklist Artifacts campsites from Undergarden biomes

### DIFF
--- a/config/artifacts-common.toml
+++ b/config/artifacts-common.toml
@@ -18,7 +18,7 @@
 	campsite_mimic_chance = 30
 	#List of biome IDs in which campsites are not allowed to generate. End and nether biomes are excluded by default.
 	# To blacklist all biomes from a single mod, use 'modid:*'
-	biome_blacklist = ["minecraft:void"]
+	biome_blacklist = ["minecraft:void", "undergarden:*"]
 	#Per-chunk probability (as a percentage) a campsite is attempted to be generated. Not every attempt succeeds, this also depends on the density and shape of caves
 	#Range: 0 ~ 100
 	campsite_chance = 8


### PR DESCRIPTION
Pretty self-explanatory 🙂
I updated the default config value for Artifacts not too long ago, but it seems like it got overlooked