### PR TITLE
Increase IE Crusher ore output back to 2x, plus 10% secondary

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -527,7 +527,7 @@ function immersiveengineering_ore_processing_with_secondary_outputs(event, mater
         return;
     }
 
-    var primaryOutput = dust,
+    var primaryOutput = Item.of(dust, 2),
         secondaryMaterial,
         secondaryChance = 0.1,
         input = '#forge:ores/' + material;


### PR DESCRIPTION
Bit of an oversight when I brought this script into Unify. Completely removed the multiplier on the output. Ooops.