### PR TITLE
Occultism Wither Summon: Change Loot Table to Armor and Weapon drops instead of Apoth targeted books

### DIFF
--- a/kubejs/data/occultism/loot_tables/entities/wild_hunt_wither_skeleton.json
+++ b/kubejs/data/occultism/loot_tables/entities/wild_hunt_wither_skeleton.json
@@ -97,11 +97,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:weapon_book",
+                    "name": "immersiveengineering:sword_steel",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]
@@ -109,11 +109,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:armor_head_book",
+                    "name": "immersiveengineering:armor_steel_head",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]
@@ -121,11 +121,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:armor_chest_book",
+                    "name": "immersiveengineering:armor_steel_chest",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]
@@ -133,11 +133,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:armor_legs_book",
+                    "name": "immersiveengineering:armor_steel_legs",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]
@@ -145,11 +145,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:armor_feet_book",
+                    "name": "immersiveengineering:armor_steel_feet",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]
@@ -157,11 +157,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:digger_book",
+                    "name": "immersiveengineering:pickaxe_steel",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]
@@ -169,11 +169,11 @@
                 {
                     "type": "item",
                     "weight": 1,
-                    "name": "apotheosis:bow_book",
+                    "name": "minecraft:bow",
                     "functions": [
                         {
                             "function": "enchant_with_levels",
-                            "levels": 50,
+                            "levels": 60,
                             "treasure": true
                         }
                     ]


### PR DESCRIPTION

Wasn't working properly with the apoth targeted books. Swapped to steel armor and tools instead.