### PR TITLE
Tweaked the output of bonemeal mortar recipe to make it worth something

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
@@ -22,6 +22,9 @@ function botania_dye_pestle_mortar(event, recipe) {
     if (recipe.type == 'large') {
         multiplier = 2;
     }
+    if(recipe.primary == 'minecraft:bone_meal') {
+        multiplier = 2;
+    }
 
     var count = baseCount * multiplier,
         output = Item.of(recipe.primary, count),


### PR DESCRIPTION
Small fix suggested on discord. Default bone -> bone meal output is 3, but because of how our script works it was making the pestle recipe output two, making it worthless. you now get a small bonus by using it, but not big enough to make it better than crusher recipes