### PR TITLE
Remove a few unintended conflicting Bone > Bone meal recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -79,6 +79,7 @@ events.listen('recipes', (event) => {
         'immersiveengineering:crafting/stick_steel',
         'immersiveengineering:crafting/stick_aluminum',
         'immersiveengineering:crafting/stick_iron',
+        'immersiveengineering:cruser/bone_meal',
 
         'immersiveengineering:crafting/jerrycan',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
@@ -17,6 +17,10 @@ function botania_dye_pestle_mortar(event, recipe) {
         return;
     }
 
+    if (recipe.input == 'minecraft:bone') {
+        return;
+    }
+
     var baseCount = 2,
         multiplier = 1;
     if (recipe.type == 'large') {
@@ -149,6 +153,10 @@ function mekanism_dye_enriching(event, recipe) {
     event.recipes.mekanism.enriching(output, input);
 }
 function pedestals_dye_crushing(event, recipe) {
+    if (recipe.input == 'minecraft:bone') {
+        return;
+    }
+
     var baseCount = 2,
         multiplier = 1;
     if (recipe.type == 'large') {
@@ -171,6 +179,10 @@ function pedestals_dye_crushing(event, recipe) {
     });
 }
 function thermal_dye_centrifuge(event, recipe) {
+    if (recipe.input == 'minecraft:bone') {
+        return;
+    }
+
     var baseCount = 2,
         multiplier = 1;
     if (recipe.type == 'large') {


### PR DESCRIPTION
The mortar and pestle can still crush bone meal to extra dye, it's just not strong enough to do the bone itself (which already has a 3x3 recipe for more)

Also removed from pedestals since pedestals already has a recipe that gives more.
Similarly, removed bone > dye in the thermal centrifuge. Pulverize bone, then centrifuge the bone meal instead.

Finally, removed the basic IE Crusher recipe in favor of ours which is more generous.