### PR TITLE
Add extra fuel to the Lapidary Dynamo

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/lapidary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/dynamo/lapidary.js
@@ -30,6 +30,30 @@ events.listen('recipes', (event) => {
             {
                 gem: 'forge:gems/dragonstone',
                 energy: 750000
+            },
+            {
+                gem: 'forge:gems/mana',
+                energy: 10000
+            },
+            {
+                gem: 'forge:gems/fluorite',
+                energy: 40000
+            },
+            {
+                gem: 'forge:gems/dimensional',
+                energy: 700000
+            },
+            {
+                gem: 'forge:gems/apatite',
+                energy: 40000
+            },
+            {
+                gem: 'forge:gems/aquarmarine',
+                energy: 10000
+            },
+            {
+                gem: 'forge:gems/amber',
+                energy: 160000
             }
         ]
     };


### PR DESCRIPTION
Adds new fuels to the Lapidary Dynamo.

A little hesitant about mana gems and aquamarine since they're so easy to automate, so I've set them relatively low.