### PR TITLE
Quartz Chunks from Laser Drill

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
@@ -542,7 +542,7 @@ events.listen('recipes', (event) => {
     event.recipes.industrialforegoing.laser_drill_ore({
         type: 'industrialforegoing.laser_drill_ore',
         output: {
-            item: 'minecraft:nether_quartz_ore'
+            tag: 'forge:chunks/quartz'
         },
         rarity: [
             {


### PR DESCRIPTION
Replaces Minecraft Quartz Ore with EE Quartz Chunks in the Laser Drill Outputs.