### PR TITLE
Minor flour fixes

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -121,7 +121,6 @@ var itemsToHide = [
     'mapperbase:iron_rod',
     'mapperbase:raw_bitumen',
     'morevanillalib:obsidian_shard',
-    'pedestals:dustflour',
     'powah:uraninite_ore',
     'powah:uraninite_ore_dense',
     'powah:uraninite_ore_poor',
@@ -283,6 +282,8 @@ const disabledItems = [
     'mythicbotany:raindeletia_floating',
     'mythicbotany:wither_aconite',
     'mythicbotany:wither_aconite_floating',
+
+    'pedestals:dustflour',
 
     'pitg:green_dye',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_crushing.js
@@ -46,13 +46,8 @@ events.listen('recipes', (event) => {
     data.recipes.forEach((recipe) => {
         const re = event.custom({
             type: 'pedestals:pedestal_crushing',
-            ingredient: {
-                item: recipe.input
-            },
-            result: {
-                item: recipe.output,
-                count: recipe.count
-            }
+            ingredient: Ingredient.of(recipe.input),
+            result: Item.of(recipe.output, recipe.count)
         });
         if (recipe.id) {
             re.id(recipe.id);

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/dusts.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/dusts.js
@@ -12,7 +12,8 @@ events.listen('item.tags', (event) => {
         .add('immersiveengineering:dust_hop_graphite')
         .add('immersiveengineering:dust_saltpeter')
         .add('thermal:ender_pearl_dust')
-        .add('astralsorcery:stardust');
+        .add('astralsorcery:stardust')
+        .add('#forge:dusts/flour');
 
     event.add('forge:dusts/starmetal', 'astralsorcery:stardust');
     event.get('forge:dusts/lapis').add('mekanism:dust_lapis_lazuli');
@@ -29,6 +30,7 @@ events.listen('item.tags', (event) => {
     event.get('forge:dusts/netherite_scrap').remove('bloodmagic:sand_netherite');
 
     event.add('forge:dusts/flour', 'create:wheat_flour');
+    event.add('forge:dusts/flour', 'pedestals:dustflour');
 
     // Temporary until EE adapts this change
     event.get('forge:chunks/arcane').remove('emendatusenigmatica:arcane_chunk');

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/disabled_items.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/disabled_items.js
@@ -71,6 +71,8 @@ const disabledItems = [
     'mythicbotany:wither_aconite',
     'mythicbotany:wither_aconite_floating',
 
+    'pedestals:dustflour',
+
     'pitg:green_dye',
 
     'quark:pipe',


### PR DESCRIPTION
2 minor fixes related to the flour unification:
- I fixed a minor issue in the pedestals crushing script that was preventing the flour recipe from loading
- Pedestals' flour was previously hidden but not disabled, that's probably why it got missed. I've tagged it and removed the recipes