### PR TITLE
Mekanism Power Pass

### DIFF
--- a/config/Mekanism/general.toml
+++ b/config/Mekanism/general.toml
@@ -70,7 +70,7 @@
 		#Disables Forge Energy (FE,RF,IF,uF,CF) power integration. Requires world restart (server-side option in SMP).
 		blacklistForge = false
 		#Maximum Joules per mB of Steam. Also affects Thermoelectric Boiler.
-		maxEnergyPerSteam = "2"
+		maxEnergyPerSteam = "4"
 		#Conversion multiplier from Forge Energy to Joules (FE * JoulePerForgeEnergy = Joules)
 		JoulePerForgeEnergy = "2.5000"
 		#Conversion multiplier from EU to Joules (EU * JoulePerEU = Joules)

--- a/config/Mekanism/generators.toml
+++ b/config/Mekanism/generators.toml
@@ -82,7 +82,7 @@
 	[generators.fusion_reactor]
 		#The fraction of the heat dissipated from the case that is converted to Joules.
 		#Range: 0.0 ~ 1.0
-		thermocoupleEfficiency = 0.007
+		thermocoupleEfficiency = 0.014
 		#The fraction fraction of heat from the casing that can be transfered to all sources that are not water. Will impact max heat, heat transfer to thermodynamic conductors, and power generation.
 		#Range: 0.001 ~ 1.0
 		casingThermalConductivity = 0.1

--- a/config/Mekanism/generators.toml
+++ b/config/Mekanism/generators.toml
@@ -82,7 +82,7 @@
 	[generators.fusion_reactor]
 		#The fraction of the heat dissipated from the case that is converted to Joules.
 		#Range: 0.0 ~ 1.0
-		thermocoupleEfficiency = 0
+		thermocoupleEfficiency = 0.007
 		#The fraction fraction of heat from the casing that can be transfered to all sources that are not water. Will impact max heat, heat transfer to thermodynamic conductors, and power generation.
 		#Range: 0.001 ~ 1.0
 		casingThermalConductivity = 0.1


### PR DESCRIPTION
Re-introduces Passive energy from the Fusion reactor, though at a still greatly reduced rate over default. An Injection Rate of 99 settles in at about 116k FE/t without water cooling. With water cooling, it drops to around 35k FE/t.

Also backed out the steam changes a tiny bit as it has no impact on total energy production, just on the number of turbines needed to get that energy and your ability to cool fission reactors. Should be slightly easier now. 

#1662