### PR TITLE
Remove duplicate aquaculture recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -12,6 +12,8 @@ events.listen('recipes', (event) => {
     event.remove({ type: 'minecraft:smelting', input: '#farmersdelight:tools/knives' });
     event.remove({ type: 'minecraft:blasting', input: '#farmersdelight:tools/knives' });
 
+    event.remove({ mod: 'aquaculture', type: 'farmersdelight:cutting' })
+
     event.remove({ mod: 'prettypipes' });
 
     var outputRemovals = [


### PR DESCRIPTION
This PR removes the duplicate cutting board recipes added by Farmer's Delight Compats. 
I decided to keep the cutting recipes we already had, because they have bone meal as a secondary output. (Otherwise there wouldn't really be an incentive to cut fish on the cutting board instead of using the regular crafting recipe)

To be honest, I'm not entirely sure whether we really need Farmer's Delight Compats in the first place. From looking at the curseforge page, it seems this mod exclusively adds data files, most of which are already covered by the kubeJS scripts in the pack

(Also: no it's not a typo, for some reason FD Compats adds new recipes under the aquaculture namespace)