### PR TITLE
Apiary Beelancing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -433,6 +433,53 @@ events.listen('recipes', (event) => {
             'minecraft:honeycomb_block'
         ),
 
+        shapedRecipe(
+            Item.of('resourcefulbees:t1_apiary'),
+            ['ABA', 'BCB', 'ABA'],
+            {
+                A: 'minecraft:honeycomb_block',
+                B: 'minecraft:honey_block',
+                C: 'resourcefulbees:t4_beehive'
+            },
+            'resourcefulbees:t1_apiary'
+        ),
+
+        shapedRecipe(
+            Item.of('resourcefulbees:t2_apiary'),
+            ['ACA', 'BDB', 'ACA'],
+            {
+                A: 'minecraft:honeycomb_block',
+                B: 'resourcefulbees:t4_beehive',
+                C: 'resourcefulbees:t1_apiary',
+                D: 'minecraft:nether_star'
+            },
+            'resourcefulbees:t2_apiary'
+        ),
+
+        shapedRecipe(
+            Item.of('resourcefulbees:t3_apiary'),
+            ['DCD', 'BAB', 'DCD'],
+            {
+                A: 'minecraft:honeycomb_block',
+                B: 'resourcefulbees:t4_beehive',
+                C: 'resourcefulbees:t2_apiary',
+                D: 'minecraft:nether_star'
+            },
+            'resourcefulbees:t3_apiary'
+        ),
+
+        shapedRecipe(
+            Item.of('resourcefulbees:t4_apiary'),
+            ['DCD', 'BAB', 'DCD'],
+            {
+                A: 'minecraft:honeycomb_block',
+                B: 'resourcefulbees:t4_beehive',
+                C: 'resourcefulbees:t3_apiary',
+                D: 'minecraft:nether_star'
+            },
+            'resourcefulbees:t4_apiary'
+        ),
+
         // Torch from Stick+Standing Fire
         shapedRecipe(Item.of('minecraft:torch', 4), ['A', 'B'], {
             A: 'additional_lights:fire_for_standing_torch_s',


### PR DESCRIPTION
Per discussion #1695 item #1.

Remove Nether Star requirement for T1 Apiary to encourage moving to it and reducing number of entities required for volume production.
Move from ~4:1 scaling to 2:1 scaling for T2-T4 Apiaries.

T1 Apiaries costs no longer encourage the player to go wide rather than upgrading. T4 cost is still expensive, but requires about 10% as much grinding, with nether star progression at 0:2:6:16 vs 1:5:25:100.

Old T1 Cost:
<img width="712" alt="T1_old" src="https://user-images.githubusercontent.com/13169307/111209750-cddde680-85a2-11eb-9b72-767ca8bcf19a.png">
New T1 Cost:
<img width="712" alt="T1_new" src="https://user-images.githubusercontent.com/13169307/111209807-df26f300-85a2-11eb-8e52-0c5955372f9f.png">
Old T4 Cost:
<img width="712" alt="T4_old" src="https://user-images.githubusercontent.com/13169307/111209835-e64e0100-85a2-11eb-974d-7250fdb5ca26.png">
New T1 Cost:
<img width="460" alt="T4_new" src="https://user-images.githubusercontent.com/13169307/111209846-ebab4b80-85a2-11eb-9608-6cfb6535baa4.png">

