### PR TITLE
Unified dies & molds

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -177,7 +177,7 @@ var regexHide = [
     /emendatusenigmatica:\w+_basalt_ore/,
     /titanium:\w+_gear/,
     /thermal:\w+_dust/,
-    /thermal:\w+_gear/,
+    /thermal:\w+_gear$/,
     /thermal:\w+_ingot/,
     /thermal:\w+_nugget/,
     /thermal:\w+_ore/,

--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -299,6 +299,10 @@ const disabledItems = [
     'thermal:potato_block',
     'thermal:sugar_cane_block',
     'thermal:apple_block',
+    'thermal:press_gear_die',
+    'thermal:press_packing_3x3_die',
+    'thermal:press_packing_2x2_die',
+    'thermal:press_unpacking_die',
 
     'simplefarming:raw_bacon',
     'simplefarming:cooked_bacon',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -121,6 +121,18 @@ events.listen('recipes', (event) => {
         'minecraft:nether_brick'
     );
 
+    sharedDies.forEach((die) => {
+        var dieTag = `#thermal:crafting/dies/${die.thermalName}`;
+        event.replaceInput({}, `immersiveengineering:mold_${die.immersiveEngineeringName}`, dieTag);
+        event.replaceInput({}, `thermal:press_${die.thermalName}_die`, dieTag);
+    });
+    thermalDies.forEach((dieName) => {
+        event.replaceInput({}, `thermal:press_${dieName}_die`, `#thermal:crafting/dies/${dieName}`);
+    });
+    immersiveEngineeringDies.forEach((dieName) => {
+        event.replaceInput({}, `immersiveengineering:mold_${dieName}`, `#thermal:crafting/dies/${dieName}`);
+    });
+
     colors.forEach((color) => {
         var dyeTag = `#forge:dyes/${color}`;
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_output.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_output.js
@@ -12,4 +12,8 @@ events.listen('recipes', (event) => {
 
     event.replaceOutput({ mod: 'dustrial_decor' }, 'minecraft:iron_ingot', 'dustrial_decor:rusty_iron_ingot');
     event.replaceOutput({ mod: 'dustrial_decor' }, 'minecraft:iron_nugget', 'dustrial_decor:rusty_iron_nugget');
+
+    sharedDies.forEach((die) => {
+        event.replaceOutput({}, `thermal:press_${die.thermalName}_die`, `immersiveengineering:mold_${die.immersiveEngineeringName}`);
+    });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
@@ -18,35 +18,35 @@ events.listen('recipes', (event) => {
                 output: Item.of('immersiveengineering:mold_rod', 1)
             },
             {
-                inputs: [Ingredient.of('#forge:ingots/copper'), Ingredient.of('immersiveengineering:mold_bullet_casing')],
+                inputs: [Ingredient.of('#forge:ingots/copper'), Ingredient.of('#thermal:crafting/dies/bullet_casing')],
                 output: Item.of('immersiveengineering:empty_casing', 2)
             },
             {
-                inputs: [Item.of('byg:pink_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('byg:pink_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('byg:pink_sand', 4)
             },
             {
-                inputs: [Item.of('byg:purple_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('byg:purple_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('byg:purple_sand', 4)
             },
             {
-                inputs: [Item.of('byg:blue_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('byg:blue_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('byg:blue_sand', 4)
             },
             {
-                inputs: [Item.of('byg:white_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('byg:white_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('byg:white_sand', 4)
             },
             {
-                inputs: [Item.of('byg:black_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('byg:black_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('byg:black_sand', 4)
             },
             {
-                inputs: [Item.of('atmospheric:arid_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('atmospheric:arid_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('atmospheric:arid_sand', 4)
             },
             {
-                inputs: [Item.of('atmospheric:red_arid_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('atmospheric:red_arid_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('atmospheric:red_arid_sand', 4)
             },
             {
@@ -81,12 +81,12 @@ events.listen('recipes', (event) => {
             //ID Overrides
             {
                 id: 'thermal:machine/press/packing2x2/press_honeycomb_packing',
-                inputs: [Item.of('minecraft:honeycomb', 9), Item.of('immersiveengineering:mold_packing_9')],
+                inputs: [Item.of('minecraft:honeycomb', 9), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('minecraft:honeycomb_block', 1)
             },
             {
                 id: 'thermal:machine/press/unpacking/press_honeycomb_unpacking',
-                inputs: [Item.of('minecraft:honeycomb_block', 1), Item.of('immersiveengineering:mold_unpacking')],
+                inputs: [Item.of('minecraft:honeycomb_block', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
                 output: Item.of('minecraft:honeycomb', 9)
             }
         ]
@@ -97,14 +97,14 @@ events.listen('recipes', (event) => {
             {
                 inputs: [
                     Item.of('resourcefulbees:' + variant + '_honeycomb', 9),
-                    Item.of('immersiveengineering:mold_packing_9')
+                    Ingredient.of('#thermal:crafting/dies/packing_3x3')
                 ],
                 output: Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1)
             },
             {
                 inputs: [
                     Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1),
-                    Item.of('immersiveengineering:mold_unpacking')
+                    Ingredient.of('#thermal:crafting/dies/unpacking')
                 ],
                 output: Item.of('resourcefulbees:' + variant + '_honeycomb', 9)
             }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
@@ -18,31 +18,35 @@ events.listen('recipes', (event) => {
                 output: Item.of('immersiveengineering:mold_rod', 1)
             },
             {
-                inputs: [Item.of('byg:pink_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Ingredient.of('#forge:ingots/copper'), Ingredient.of('immersiveengineering:mold_bullet_casing')],
+                output: Item.of('immersiveengineering:empty_casing', 2)
+            },
+            {
+                inputs: [Item.of('byg:pink_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('byg:pink_sand', 4)
             },
             {
-                inputs: [Item.of('byg:purple_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('byg:purple_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('byg:purple_sand', 4)
             },
             {
-                inputs: [Item.of('byg:blue_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('byg:blue_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('byg:blue_sand', 4)
             },
             {
-                inputs: [Item.of('byg:white_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('byg:white_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('byg:white_sand', 4)
             },
             {
-                inputs: [Item.of('byg:black_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('byg:black_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('byg:black_sand', 4)
             },
             {
-                inputs: [Item.of('atmospheric:arid_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('atmospheric:arid_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('atmospheric:arid_sand', 4)
             },
             {
-                inputs: [Item.of('atmospheric:red_arid_sandstone', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('atmospheric:red_arid_sandstone', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('atmospheric:red_arid_sand', 4)
             },
             {
@@ -77,12 +81,12 @@ events.listen('recipes', (event) => {
             //ID Overrides
             {
                 id: 'thermal:machine/press/packing2x2/press_honeycomb_packing',
-                inputs: [Item.of('minecraft:honeycomb', 9), Item.of('thermal:press_packing_3x3_die')],
+                inputs: [Item.of('minecraft:honeycomb', 9), Item.of('immersiveengineering:mold_packing_9')],
                 output: Item.of('minecraft:honeycomb_block', 1)
             },
             {
                 id: 'thermal:machine/press/unpacking/press_honeycomb_unpacking',
-                inputs: [Item.of('minecraft:honeycomb_block', 1), Item.of('thermal:press_unpacking_die')],
+                inputs: [Item.of('minecraft:honeycomb_block', 1), Item.of('immersiveengineering:mold_unpacking')],
                 output: Item.of('minecraft:honeycomb', 9)
             }
         ]
@@ -93,14 +97,14 @@ events.listen('recipes', (event) => {
             {
                 inputs: [
                     Item.of('resourcefulbees:' + variant + '_honeycomb', 9),
-                    Item.of('thermal:press_packing_3x3_die')
+                    Item.of('immersiveengineering:mold_packing_9')
                 ],
                 output: Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1)
             },
             {
                 inputs: [
                     Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1),
-                    Item.of('thermal:press_unpacking_die')
+                    Item.of('immersiveengineering:mold_unpacking')
                 ],
                 output: Item.of('resourcefulbees:' + variant + '_honeycomb', 9)
             }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/thermal/dies.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/thermal/dies.js
@@ -1,14 +1,17 @@
 events.listen('item.tags', (event) => {
-    var dies = [
-        'immersiveengineering:mold_unpacking',
-        'immersiveengineering:mold_packing_9',
-        'immersiveengineering:mold_packing_4',
-        'immersiveengineering:mold_wire',
-        'immersiveengineering:mold_bullet_casing',
-        'immersiveengineering:mold_rod',
-        'immersiveengineering:mold_gear',
-        'immersiveengineering:mold_plate'
-    ];
-
-    event.get('thermal:crafting/dies').add(dies);
+    sharedDies.forEach((die) => {
+        event.add('thermal:crafting/dies', [`#thermal:crafting/dies/${die.thermalName}`])
+        event.add(`thermal:crafting/dies/${die.thermalName}`, [
+            `thermal:press_${die.thermalName}_die`,
+            `immersiveengineering:mold_${die.immersiveEngineeringName}`
+        ])
+    });
+    thermalDies.forEach((dieName) => {
+        event.add('thermal:crafting/dies', [`#thermal:crafting/dies/${dieName}`])
+        event.add(`thermal:crafting/dies/${dieName}`, [`thermal:press_${dieName}_die`])
+    });
+    immersiveEngineeringDies.forEach((dieName) => {
+        event.add('thermal:crafting/dies', [`#thermal:crafting/dies/${dieName}`])
+        event.add(`thermal:crafting/dies/${dieName}`, [`immersiveengineering:mold_${dieName}`])
+    });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -69,7 +69,7 @@ function gear_unification(event, material, ingot, gem, gear) {
 
     var output = gear,
         input,
-        mold = 'immersiveengineering:mold_gear';
+        mold = '#thermal:crafting/dies/gear';
 
     if (ingot != air) {
         input = '#forge:ingots/' + material;
@@ -98,7 +98,7 @@ function rod_unification(event, material, ingot, gem, rod) {
 
     var output = Item.of(rod, 2),
         input,
-        mold = 'immersiveengineering:mold_rod';
+        mold = '#thermal:crafting/dies/rod';
 
     if (ingot != air) {
         input = '#forge:ingots/' + material;
@@ -655,7 +655,7 @@ function immersiveengineering_press_plates(event, material, ingot, gem, plate) {
     }
 
     var output = plate,
-        mold = 'immersiveengineering:mold_plate';
+        mold = '#thermal:crafting/dies/plate';
     if (ingot != air) {
         input = '#forge:ingots/' + material;
     } else if (gem != air) {
@@ -1326,6 +1326,6 @@ function thermal_press_wires(event, material, wire) {
 
     var output = Item.of(wire, 2),
         input = '#forge:ingots/' + material,
-        mold = 'immersiveengineering:mold_wire';
+        mold = '#thermal:crafting/dies/wire';
     event.recipes.thermal.press(output, [input, mold]).energy(2400);
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/dies.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/dies.js
@@ -1,0 +1,31 @@
+//priority: 1000
+
+const sharedDies = [
+    {
+        thermalName: 'gear',
+        immersiveEngineeringName: 'gear'
+    },
+    {
+        thermalName: 'unpacking',
+        immersiveEngineeringName: 'unpacking'
+    },
+    {
+        thermalName: 'packing_3x3',
+        immersiveEngineeringName: 'packing_9'
+    },
+    {
+        thermalName: 'packing_2x2',
+        immersiveEngineeringName: 'packing_4'
+    }
+];
+
+const thermalDies = [
+    'coin'
+];
+
+const immersiveEngineeringDies = [
+    'plate',
+    'rod',
+    'wire',
+    'bullet_casing'
+];


### PR DESCRIPTION
This PR adds tags to thermal's dies and immersive engineering's molds to allow them to be used interchangeably, fixing #1722.
*However*, there's currently an issue with immersive engineering's press recipes, preventing the usage of tags as the mold. Because of this I just went ahead and unified the dies/molds, removing the packing, unpacking and gear dies from thermal.