### PR TITLE
Add Recipes for Artifact Level Infinity Tools

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/nucleosynthesizing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/nucleosynthesizing.js
@@ -1,0 +1,104 @@
+events.listen('recipes', (event) => {
+    /* 
+        Recipes use about 40k rf per point of duration. 
+        Duration is not a fixed speed, as the machine runs at 10000% speed when the energy buffer is full.  
+           
+    */
+    var data = {
+        recipes: [
+            {
+                itemInput: { ingredient: { item: 'industrialforegoing:infinity_trident' } },
+                gasInput: { amount: 10000, gas: 'mekanism:antimatter' },
+                output: {
+                    item: 'industrialforegoing:infinity_trident',
+                    nbt: {
+                        CanCharge: 1,
+                        Riptide: 0,
+                        Channeling: 0,
+                        Energy: 9223372036854775807,
+                        Fluid: { FluidName: 'biofuel', Amount: 0 },
+                        Special: 1,
+                        Selected: 'ARTIFACT',
+                        Loyalty: 0
+                    }
+                },
+                duration: 2500000
+                //Approximately 100 billion RF to complete the craft.
+            },
+            {
+                itemInput: { ingredient: { item: 'industrialforegoing:infinity_hammer' } },
+                gasInput: { amount: 10000, gas: 'mekanism:antimatter' },
+                output: {
+                    item: 'industrialforegoing:infinity_hammer',
+                    nbt: {
+                        CanCharge: 1,
+                        Energy: 9223372036854775807,
+                        Fluid: { FluidName: 'biofuel', Amount: 0 },
+                        Special: 1,
+                        Selected: 'ARTIFACT',
+                        Beheading: 0
+                    }
+                },
+                duration: 2500000
+                //Approximately 100 billion RF to complete the craft.
+            },
+            {
+                itemInput: { ingredient: { item: 'industrialforegoing:infinity_drill' } },
+                gasInput: { amount: 10000, gas: 'mekanism:antimatter' },
+                output: {
+                    item: 'industrialforegoing:infinity_drill',
+                    nbt: {
+                        CanCharge: 1,
+                        Special: 1,
+                        Selected: 'ARTIFACT',
+                        Energy: 9223372036854775807,
+                        Fluid: { FluidName: 'biofuel', Amount: 0 }
+                    }
+                },
+                duration: 2500000
+                //Approximately 100 billion RF to complete the craft.
+            },
+            {
+                itemInput: { ingredient: { item: 'industrialforegoing:infinity_saw' } },
+                gasInput: { amount: 10000, gas: 'mekanism:antimatter' },
+                output: {
+                    item: 'industrialforegoing:infinity_saw',
+                    nbt: {
+                        CanCharge: 1,
+                        Special: 1,
+                        Selected: 'ARTIFACT',
+                        Energy: 9223372036854775807,
+                        Fluid: { FluidName: 'biofuel', Amount: 0 }
+                    }
+                },
+                duration: 2500000
+                //Approximately 100 billion RF to complete the craft.
+            },
+            {
+                itemInput: { ingredient: { item: 'industrialforegoing:infinity_backpack' } },
+                gasInput: { amount: 10000, gas: 'mekanism:antimatter' },
+                output: {
+                    item: 'industrialforegoing:infinity_backpack',
+                    nbt: {
+                        CanCharge: 1,
+                        Special: 1,
+                        Selected: 'ARTIFACT',
+                        Energy: 9223372036854775807
+                    }
+                },
+                duration: 2500000
+                //Approximately 100 billion RF to complete the craft.
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.custom({
+            type: 'mekanism:nucleosynthesizing',
+            itemInput: recipe.itemInput,
+            gasInput: recipe.gasInput,
+            output: recipe.output,
+            duration: recipe.duration
+        });
+    });
+});


### PR DESCRIPTION
I think there's a couple ways to go here, but I'm starting with this.

Running these recipes pretty much requires a high heat fusion reactor to do in a timely manner. Not to mention actually producing the Antimatter required (100k Uranium Ingots worth).

All in all, the craft should take about 20 minutes if the power costs can be kept up.

I also opted to actually use any tier of Infinity tool in the craft. I was originally leaning towards converting more conventional items, like a vanilla Trident for the Infinity Trident. A Saw blade for the saw, drill head for the drill, Netherite hammer for the hammer, and an Ender Chest for the backpack... Something similar may still be desirable since this -will- result in lost items if someone were to put their old Infinity backpack into the recipe.

#1694