### PR TITLE
Infinity tools update

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -72,6 +72,30 @@ events.listen('jei.information', (event) => {
                 'The Fusion Reactor has been nerfed quite heavily.',
                 'It produces 60k-250k rf/t passively, but has potential for far higher output when paired with one or multiple Steam Turbines.'
             ]
+        },
+        {
+            items: [
+                'industrialforegoing:infinity_backpack',
+                'industrialforegoing:infinity_saw',
+                'industrialforegoing:infinity_drill',
+                'industrialforegoing:infinity_hammer',
+                'industrialforegoing:infinity_trident'
+            ],
+            description: [
+                "Nine Quintillion is big. Really big. You just won't believe how vastly hugely mind-bogglingly big it is."
+            ]
+        },
+        {
+            items: [
+                'industrialforegoing:infinity_backpack',
+                'industrialforegoing:infinity_saw',
+                'industrialforegoing:infinity_drill',
+                'industrialforegoing:infinity_hammer',
+                'industrialforegoing:infinity_trident'
+            ],
+            description: [
+                "Unless you plan on sitting here for a few centuries, filling this tool isn't possible through conventional means. Some say the answer lies in Nucleosynthesis instead."
+            ]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/nucleosynthesizing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/nucleosynthesizing.js
@@ -17,7 +17,7 @@ events.listen('recipes', (event) => {
                         Channeling: 0,
                         Energy: 9223372036854775807,
                         Fluid: { FluidName: 'biofuel', Amount: 0 },
-                        Special: 1,
+                        Special: 0,
                         Selected: 'ARTIFACT',
                         Loyalty: 0
                     }
@@ -34,7 +34,7 @@ events.listen('recipes', (event) => {
                         CanCharge: 1,
                         Energy: 9223372036854775807,
                         Fluid: { FluidName: 'biofuel', Amount: 0 },
-                        Special: 1,
+                        Special: 0,
                         Selected: 'ARTIFACT',
                         Beheading: 0
                     }
@@ -49,7 +49,7 @@ events.listen('recipes', (event) => {
                     item: 'industrialforegoing:infinity_drill',
                     nbt: {
                         CanCharge: 1,
-                        Special: 1,
+                        Special: 0,
                         Selected: 'ARTIFACT',
                         Energy: 9223372036854775807,
                         Fluid: { FluidName: 'biofuel', Amount: 0 }
@@ -65,7 +65,7 @@ events.listen('recipes', (event) => {
                     item: 'industrialforegoing:infinity_saw',
                     nbt: {
                         CanCharge: 1,
-                        Special: 1,
+                        Special: 0,
                         Selected: 'ARTIFACT',
                         Energy: 9223372036854775807,
                         Fluid: { FluidName: 'biofuel', Amount: 0 }
@@ -81,7 +81,7 @@ events.listen('recipes', (event) => {
                     item: 'industrialforegoing:infinity_backpack',
                     nbt: {
                         CanCharge: 1,
-                        Special: 1,
+                        Special: 0,
                         Selected: 'ARTIFACT',
                         Energy: 9223372036854775807
                     }


### PR DESCRIPTION
#1694

Removes the special tag, which enables patreon only options.

Adds a JEI description to help guide people.