### PR TITLE
Update Insolator and Cloche to reduce rare drops like poison potatoes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
@@ -158,6 +158,10 @@ function crops_thermal_insolator(event, type, crop) {
         plantSecondary = crop.plantSecondary;
     }
 
+    if (crop.plantSecondaryRate == 'low') {
+        secondaryChance = 0.01;
+    }
+
     /*
     types:  cactus, cane_like, coral, crop_fiber, crop_fruit, 
             crop_gourd, crop_grain, crop_leafy, crop_legume,  
@@ -392,7 +396,7 @@ function crops_immersiveengineering_cloche(event, type, crop) {
         renderType = 'crop';
     }
 
-    if (plantSecondary) {
+    if (plantSecondary && crop.plantSecondaryRate != 'low') {
         //add any secondary
         outputs.push(Item.of(plantSecondary, secondaryCount));
     }

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -40,6 +40,7 @@ const cropRegistry = [
                 render: 'atmospheric:aloe_vera',
                 plant: 'atmospheric:aloe_leaves',
                 plantSecondary: 'atmospheric:yellow_blossoms',
+                plantSecondaryRate: 'high',
                 substrate: 'arid_sand'
             },
             {
@@ -733,6 +734,7 @@ const cropRegistry = [
                 render: 'minecraft:potatoes',
                 plant: 'minecraft:potato',
                 plantSecondary: 'minecraft:poisonous_potato',
+                plantSecondaryRate: 'low',
                 substrate: 'dirt'
             },
             {
@@ -2011,6 +2013,7 @@ const cropRegistry = [
                 render: 'undergarden:blisterberry_bush',
                 plant: 'undergarden:blisterberry',
                 plantSecondary: 'undergarden:rotten_blisterberry',
+                plantSecondaryRate: 'low',
                 substrate: 'deepturf'
             },
             {
@@ -2023,7 +2026,6 @@ const cropRegistry = [
                 seed: 'autumnity:foul_berries',
                 render: 'autumnity:foul_berry_bush',
                 plant: 'autumnity:foul_berries',
-                plantSecondary: '',
                 substrate: 'dirt'
             }
         ]
@@ -2155,21 +2157,18 @@ const cropRegistry = [
                 seed: 'betterendforge:bulb_vine_seed',
                 render: 'betterendforge:bulb_vine',
                 plant: 'betterendforge:glowing_bulb',
-                plantSecondary: 'betterendforge:bulb_vine_seed',
                 substrate: 'end_stone'
             },
             {
                 seed: 'betterendforge:blue_vine_seed',
                 render: 'betterendforge:blue_vine',
                 plant: 'betterendforge:blue_vine_lantern',
-                plantSecondary: 'betterendforge:blue_vine_seed',
                 substrate: 'end_mycelium'
             },
             {
                 seed: 'betterendforge:glowing_pillar_seed',
                 render: 'betterendforge:glowing_pillar_roots',
                 plant: 'betterendforge:glowing_pillar_luminophor',
-                plantSecondary: 'betterendforge:glowing_pillar_seed',
                 substrate: 'amber_moss'
             },
             {
@@ -2177,6 +2176,7 @@ const cropRegistry = [
                 render: 'betterendforge:hydralux_sapling',
                 plant: 'betterendforge:hydralux_petal',
                 plantSecondary: 'betterendforge:hydralux_sapling',
+                plantSecondaryRate: 'high',
                 substrate: 'water'
             },
             {


### PR DESCRIPTION
Introduced a new plantSecondaryRate tag to allow for finer control over this. Poison Potatoes and Rotten Blister Berries drop at a 1% rate now.

Removed 'low' rate items from the cloche entirely as it doesn't support chance outputs.

#1734