### PR TITLE
Update Growables to handle missing Better End compat

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_growables.js
@@ -569,6 +569,27 @@ function trees_immersiveengineering_cloche(event, tree) {
         case 'warped_nylium':
             substrate = 'minecraft:warped_nylium';
             break;
+        case 'jungle_moss':
+            substrate = 'betterendforge:jungle_moss';
+            break;
+        case 'end_moss':
+            substrate = 'betterendforge:end_moss';
+            break;
+        case 'amber_moss':
+            substrate = 'betterendforge:amber_moss';
+            break;
+        case 'pink_moss':
+            substrate = 'betterendforge:pink_moss';
+            break;
+        case 'chorus_nylium':
+            substrate = 'betterendforge:chorus_nylium';
+            break;
+        case 'end_moss':
+            substrate = 'betterendforge:end_moss';
+            break;
+        case 'shadow_grass':
+            substrate = 'betterendforge:shadow_grass';
+            break;
         default:
             substrate = 'minecraft:dirt';
     }

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -2027,6 +2027,22 @@ const cropRegistry = [
                 render: 'autumnity:foul_berry_bush',
                 plant: 'autumnity:foul_berries',
                 substrate: 'dirt'
+            },
+            {
+                seed: 'betterendforge:blue_vine_seed',
+                render: 'betterendforge:blue_vine_lantern',
+                plant: 'betterendforge:blue_vine_lantern',
+                plantSecondary: 'betterendforge:blue_vine_seed',
+                plantSecondaryRate: 'high',
+                substrate: 'end_mycelium'
+            },
+            {
+                seed: 'betterendforge:glowing_pillar_seed',
+                render: 'betterendforge:glowing_pillar_luminophor',
+                plant: 'betterendforge:glowing_pillar_luminophor',
+                plantSecondary: 'betterendforge:glowing_pillar_seed',
+                plantSecondaryRate: 'high',
+                substrate: 'amber_moss'
             }
         ]
     },
@@ -2159,18 +2175,7 @@ const cropRegistry = [
                 plant: 'betterendforge:glowing_bulb',
                 substrate: 'end_stone'
             },
-            {
-                seed: 'betterendforge:blue_vine_seed',
-                render: 'betterendforge:blue_vine',
-                plant: 'betterendforge:blue_vine_lantern',
-                substrate: 'end_mycelium'
-            },
-            {
-                seed: 'betterendforge:glowing_pillar_seed',
-                render: 'betterendforge:glowing_pillar_roots',
-                plant: 'betterendforge:glowing_pillar_luminophor',
-                substrate: 'amber_moss'
-            },
+
             {
                 seed: 'betterendforge:hydralux_sapling',
                 render: 'betterendforge:hydralux_sapling',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/soils.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/soils.js
@@ -91,6 +91,7 @@ const soilRegistry = [
     { block: 'betterendforge:jungle_moss', categories: ['end_stone', 'jungle_moss'], growthModifier: 0.5 },
     { block: 'betterendforge:end_moss', categories: ['end_stone', 'end_moss'], growthModifier: 0.5 },
     { block: 'betterendforge:shadow_grass', categories: ['end_stone', 'shadow_grass'], growthModifier: 0.5 },
+    { block: 'betterendforge:pink_moss', categories: ['end_stone', 'pink_moss'], growthModifier: 0.5 },
     {
         block: 'betterendforge:end_mycelium',
         categories: ['end_stone', 'end_mycelium', 'mushroom'],

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
@@ -744,7 +744,7 @@ const treeRegistry = [
                 sapling: 'betterendforge:small_jellyshroom',
                 trunk: 'betterendforge:jellyshroom_log',
                 leaf: 'betterendforge:jellyshroom_cap_purple',
-                substrate: 'end_stone'
+                substrate: 'jungle_moss'
             }
         ]
     }


### PR DESCRIPTION
Add missing Pink Moss to soil types.

Expanded substrate handling for Cloche to cover missing better end soils

Jellyshroom 'saplings' and umbrella tree 'saplings' are internally classified as mushrooms due to the actual parts that make them up, and are therefore treated like any other mushroom. Botany pots only grow the small shroom, while insolators and cloches grow the full shroom blocks/caps/etc similar to trees.

Anything classified as a vine has been left out of the Botany pot and Cloche. Reclassified Better End Blue Vines and Glowing Pillars to be 'shrubs'. They look a little cursed growing as just the glowy bit, but it could be worse.

Fixes #1754