### PR TITLE
Minor mold/die unification fixes

### DIFF
--- a/config/ftbquests/quests/chapters/thermal_series.snbt
+++ b/config/ftbquests/quests/chapters/thermal_series.snbt
@@ -364,7 +364,7 @@
 				{
 					id: "00000000000004F6",
 					type: "item",
-					item: "thermal:press_gear_die"
+					item: "immersiveengineering:mold_gear"
 				},
 				{
 					id: "000000000000068B",

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/disabled_items.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/disabled_items.js
@@ -85,10 +85,6 @@ const disabledItems = [
     'thermal:potato_block',
     'thermal:sugar_cane_block',
     'thermal:apple_block',
-    'thermal:press_gear_die',
-    'thermal:press_packing_3x3_die',
-    'thermal:press_packing_2x2_die',
-    'thermal:press_unpacking_die',
 
     'simplefarming:raw_bacon',
     'simplefarming:cooked_bacon',


### PR DESCRIPTION
This PR re-enables thermal's die recipes which were erroneously removed in 382a88d (see #1729), and changes the reward of the multiservo press quest to Immersive Engineering's gear mold