### PR TITLE
Add PNC essence compat to Pedestals and increase conversion rates

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_fluid_to_xp.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pedestals/pedestal_fluid_to_xp.js
@@ -1,0 +1,33 @@
+events.listen('recipes', (event) => {
+    var data = {
+        recipes: [
+            {
+                input: 'pneumaticcraft:memory_essence_bucket',
+                output: 'minecraft:experience_bottle',
+                count: 50,
+                id: 'pedestals:pedestal_fluid_to_xp/pnc_essence_to_xp'
+            },
+            {
+                input: 'industrialforegoing:essence_bucket',
+                output: 'minecraft:experience_bottle',
+                count: 50,
+                id: 'pedestals:pedestal_fluid_to_xp/if_essence_to_xp'
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'pedestals:pedestal_fluid_to_xp',
+            ingredient: {
+                item: recipe.input
+            },
+            result: {
+                item: recipe.output,
+                count: recipe.count
+            }
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});


### PR DESCRIPTION
The Aerial Interface converts 1 bucket of Essence to 50 xp points, so I've brought this up to parity with that.