### PR TITLE
Split up Masonry wall/slab stonecutting recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -155,7 +155,9 @@ events.listen('recipes', (event) => {
         /emendatusenigmatica:ore_from_chunk_crafting/,
         /emendatusenigmatica:ore_from_chunk_stonecutting/,
         /create:\w+\/bread/,
-        /byg:\w*red_rock_\w+_from_\w*stonecutting/
+        /byg:\w*red_rock_\w+_from_\w*stonecutting/,
+        /masonry:\w+wall_from_\w+_stonecutting/,
+        /masonry:\w+slab_from_\w+_stonecutting/
     ];
 
     outputRemovals.forEach((removal) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/stonecutter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/stonecutter.js
@@ -34,6 +34,73 @@ events.listen('recipes', (event) => {
         event.stonecutting(`minecraft:${color}_terracotta`, `quark:${color}_shingles`);
     });
 
+    var masonryStoneTypes = ['stone', 'granite', 'andesite', 'diorite', 'darkprismarine', 'prismarine'];
+    var masonryCuttingTypes = ['slab', 'wall'];
+    var masonryPatterns = [
+        'carvedcreeper',
+        'carvedderp',
+        'carvedvillager',
+        'carvedwither',
+        'carvedwriting',
+        'column',
+        'cut',
+        'engraved',
+        'panels',
+        'pavers',
+        'pillar',
+        'polished',
+        'roughcut',
+        'chiseled',
+        'cobbled',
+        'cobbledmossy',
+        'diamondpavers',
+        'largebricks',
+        'largebrickscracked',
+        'largebricksmossy',
+        'smallbrick'
+    ];
+    var masonryIgnoredInputs = [
+        'stonecobbled',
+        'stonecobbledmossy',
+        'stonelargebricks',
+        'stonelargebricksmossy',
+        'stonechiseled',
+        'stonelargebrickscracked',
+        'granitepolished',
+        'dioritepolished',
+        'andesitepolished',
+        'darkprismarinepanels',
+        'prismarinepavers',
+        'stonesmallbrick'
+    ];
+    masonryStoneTypes.forEach((stoneType) => {
+        masonryPatterns.forEach((pattern) => {
+            masonryCuttingTypes.forEach((cuttingType) => {
+                let input = stoneType + pattern
+                if (!masonryIgnoredInputs.includes(input)) {
+                    event.stonecutting('masonry:' + input + cuttingType, 'masonry:' + input);
+                }
+            });
+        });
+    });
+    event.stonecutting('masonry:stonechiseledslab', 'minecraft:chiseled_stone_bricks');
+    event.stonecutting('masonry:stonechiseledwall', 'minecraft:chiseled_stone_bricks');
+    event.stonecutting('masonry:stonelargebrickscrackedslab', 'minecraft:cracked_stone_bricks');
+    event.stonecutting('masonry:stonelargebrickscrackedwall', 'minecraft:cracked_stone_bricks');
+    event.stonecutting('masonry:granitepolishedwall', 'minecraft:polished_granite');
+    event.stonecutting('masonry:dioritepolishedwall', 'minecraft:polished_diorite');
+    event.stonecutting('masonry:andesitepolishedwall', 'minecraft:polished_andesite');
+    event.stonecutting('masonry:darkprismarinepanelswall', 'minecraft:dark_prismarine');
+    event.stonecutting('masonry:prismarinepaverswall', 'minecraft:prismarine_bricks');
+
+    var masonryTiledStoneTypes = masonryStoneTypes.concat(['endstone', 'netherrack', 'obsidian']);
+    masonryTiledStoneTypes.forEach((stoneType) => {
+        masonryCuttingTypes.forEach((cuttingType) => {
+            event.stonecutting(`masonry:${stoneType}tiledslab`, `masonry:${stoneType}tiled`);
+            event.stonecutting(`masonry:${stoneType}tiledwall`, `masonry:${stoneType}tiled`);
+        });
+    });
+
     ['#forge:dirt', '#forge:workbench', '#forge:grass'].forEach((tag) => {
         stonecutterTagConversion(event, tag);
     });


### PR DESCRIPTION
Masonry adds all their wall/slab variants to all variants of a stone in the stonecutter (for example,  when you put granite in a stonecutter you can craft Granite Brick Walls, Granite Column Walls etc). This PR changes that such that you need a specific stone variant to craft the corresponding wall/slab, to reduce the amount of clutter in some of the stonecutting lists. (see #1820)