### PR TITLE
PVJ, Farmers Delight, and BYG Integration Update

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -96,6 +96,18 @@ events.listen('jei.information', (event) => {
             description: [
                 "Unless you plan on sitting here for a few centuries, filling this tool isn't possible through conventional means. Some say the answer lies in Nucleosynthesis instead."
             ]
+        },
+        {
+            items: ['farmersdelight:brown_mushroom_colony', 'minecraft:brown_mushroom'],
+            description: [
+                'Plant a Brown Mushroom on Rich Soil in darkness to grow mushroom colonies, which may be broken for a nice yield.'
+            ]
+        },
+        {
+            items: ['farmersdelight:red_mushroom_colony', 'minecraft:red_mushroom'],
+            description: [
+                'Plant a Red Mushroom on Rich Soil in darkness to grow mushroom colonies, which may be broken for a nice yield.'
+            ]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -484,6 +484,20 @@ events.listen('recipes', (event) => {
         shapedRecipe(Item.of('minecraft:torch', 4), ['A', 'B'], {
             A: 'additional_lights:fire_for_standing_torch_s',
             B: '#forge:rods/wooden'
+        }),
+
+        shapedRecipe(Item.of('projectvibrantjourneys:bones', 8), ['AAA', 'A A', 'AAA'], {
+            A: 'minecraft:bone'
+        }),
+
+        shapedRecipe(Item.of('projectvibrantjourneys:charred_bones', 8), ['AAA', 'ABA', 'AAA'], {
+            A: 'minecraft:bone',
+            B: 'minecraft:charcoal'
+        }),
+
+        shapedRecipe(Item.of('projectvibrantjourneys:seashells', 8), ['AAA', 'ABA', 'AAA'], {
+            A: 'minecraft:prismarine_shard',
+            B: 'minecraft:nautilus_shell'
         })
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -246,6 +246,50 @@ events.listen('recipes', (event) => {
         {
             output: 'minecraft:quartz',
             inputs: ['byg:quartzite_sand', 'byg:quartzite_sand', 'byg:quartzite_sand']
+        },
+        {
+            output: Item.of('projectvibrantjourneys:twigs', 4),
+            inputs: ['#minecraft:leaves', '#forge:shears']
+        },
+        {
+            output: Item.of('projectvibrantjourneys:pinecones', 6),
+            inputs: [
+                '#minecraft:leaves/coniferous',
+                '#minecraft:leaves/coniferous',
+                '#minecraft:leaves/coniferous',
+                '#forge:shears'
+            ]
+        },
+        {
+            output: Item.of('projectvibrantjourneys:fallen_leaves', 1),
+            inputs: ['quark:oak_leaf_carpet']
+        },
+        {
+            output: Item.of('projectvibrantjourneys:rocks', 4),
+            inputs: ['minecraft:cobblestone', ['emendatusenigmatica:enigmatic_hammer', 'immersiveengineering:hammer']]
+        },
+        {
+            output: Item.of('projectvibrantjourneys:mossy_rocks', 4),
+            inputs: [
+                'minecraft:mossy_cobblestone',
+                ['emendatusenigmatica:enigmatic_hammer', 'immersiveengineering:hammer']
+            ]
+        },
+        {
+            output: Item.of('projectvibrantjourneys:sandstone_rocks', 4),
+            inputs: ['minecraft:sandstone', ['emendatusenigmatica:enigmatic_hammer', 'immersiveengineering:hammer']]
+        },
+        {
+            output: Item.of('projectvibrantjourneys:red_sandstone_rocks', 4),
+            inputs: ['minecraft:red_sandstone', ['emendatusenigmatica:enigmatic_hammer', 'immersiveengineering:hammer']]
+        },
+        {
+            output: Item.of('projectvibrantjourneys:ice_chunks', 4),
+            inputs: ['minecraft:ice', ['emendatusenigmatica:enigmatic_hammer', 'immersiveengineering:hammer']]
+        },
+        {
+            output: Item.of('projectvibrantjourneys:glowcap'),
+            inputs: ['minecraft:glowstone_dust', ['minecraft:brown_mushroom', 'minecraft:red_mushroom']]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_caps.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_caps.js
@@ -8,6 +8,8 @@ events.listen('item.tags', (event) => {
         'byg:black_puff_mushroom_block',
         'byg:green_mushroom_block',
         'byg:sythian_wart_block',
+        'byg:imparius_mushroom_block',
+        'byg:fungal_imparius_block',
         'quark:glowshroom_block',
         'byg:purple_shroomlight',
         'undergarden:blood_mushroom_cap',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_stems.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushroom_stems.js
@@ -5,6 +5,8 @@ events.listen('item.tags', (event) => {
         'byg:red_glowshroom_stem',
         'byg:brown_mushroom_stem',
         'byg:white_mushroom_stem',
+        'byg:imparius_stem',
+        'byg:fungal_imparius_stem',
         'quark:glowshroom_stem',
         'undergarden:veil_mushroom_stalk',
         'undergarden:blood_mushroom_stalk',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushrooms.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/mushrooms.js
@@ -6,8 +6,12 @@ events.listen('item.tags', (event) => {
         'byg:soul_shroom',
         'byg:purple_glowshroom',
         'byg:blue_glowshroom',
+        'byg:imparius_mushroom',
+        'byg:fungal_imparius',
         'betterendforge:umbrella_tree_sapling',
         'betterendforge:mossy_glowshroom_sapling',
-        'betterendforge:small_jellyshroom'
+        'betterendforge:small_jellyshroom',
+        'projectvibrantjourneys:bark_mushroom',
+        'projectvibrantjourneys:glowcap'
     ]);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/minecraft/leaves.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/minecraft/leaves.js
@@ -1,0 +1,19 @@
+events.listen('item.tags', (event) => {
+    event
+        .get('minecraft:leaves/coniferous')
+        .add([
+            'atmospheric:aspen_leaves',
+            'byg:brown_zelkova_leaves',
+            'byg:aspen_leaves',
+            'byg:fir_leaves',
+            'byg:redwood_leaves',
+            'byg:zelkova_leaves',
+            'byg:araucaria_leaves',
+            'minecraft:spruce_leaves',
+            'byg:blue_spruce_leaves',
+            'byg:orange_spruce_leaves',
+            'byg:red_spruce_leaves',
+            'byg:yellow_spruce_leaves',
+            'byg:pine_leaves'
+        ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -1807,6 +1807,18 @@ const cropRegistry = [
                 render: 'byg:reeds',
                 plant: 'byg:reeds',
                 substrate: 'water'
+            },
+            {
+                seed: 'projectvibrantjourneys:cattail',
+                render: 'projectvibrantjourneys:cattail',
+                plant: 'projectvibrantjourneys:cattail',
+                substrate: 'water'
+            },
+            {
+                seed: 'projectvibrantjourneys:sea_oats',
+                render: 'projectvibrantjourneys:sea_oats',
+                plant: 'projectvibrantjourneys:sea_oats',
+                substrate: 'dirt'
             }
         ]
     },
@@ -1984,6 +1996,12 @@ const cropRegistry = [
                 render: 'minecraft:sea_pickle',
                 plant: 'minecraft:sea_pickle',
                 substrate: 'water'
+            },
+            {
+                seed: 'projectvibrantjourneys:bark_mushroom',
+                render: 'projectvibrantjourneys:bark_mushroom',
+                plant: 'projectvibrantjourneys:bark_mushroom',
+                substrate: 'mushroom'
             }
         ]
     },
@@ -2049,6 +2067,18 @@ const cropRegistry = [
                 render: 'byg:oddity_bush',
                 plant: 'byg:oddity_bush',
                 substrate: 'end_stone'
+            },
+            {
+                seed: 'projectvibrantjourneys:warped_nettle',
+                render: 'projectvibrantjourneys:warped_nettle',
+                plant: 'projectvibrantjourneys:warped_nettle',
+                substrate: 'warped_nylium'
+            },
+            {
+                seed: 'projectvibrantjourneys:crimson_nettle',
+                render: 'projectvibrantjourneys:crimson_nettle',
+                plant: 'projectvibrantjourneys:crimson_nettle',
+                substrate: 'crimson_nylium'
             }
         ]
     },
@@ -2194,6 +2224,12 @@ const cropRegistry = [
                 seed: 'atmospheric:passion_vine',
                 render: 'atmospheric:passion_vine',
                 plant: 'atmospheric:passion_vine',
+                substrate: 'dirt'
+            },
+            {
+                seed: 'byg:imparius_vine',
+                render: 'byg:imparius_vine',
+                plant: 'byg:imparius_vine',
                 substrate: 'dirt'
             }
         ]

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/soils.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/soils.js
@@ -98,5 +98,6 @@ const soilRegistry = [
         growthModifier: 0.5
     },
     { block: 'atmospheric:arid_sand', categories: ['sand', 'arid_sand'], growthModifier: 0.0 },
-    { block: 'atmospheric:red_arid_sand', categories: ['sand', 'arid_sand', 'red_arid_sand'], growthModifier: 0.0 }
+    { block: 'atmospheric:red_arid_sand', categories: ['sand', 'arid_sand', 'red_arid_sand'], growthModifier: 0.0 },
+    { block: 'byg:imparius_phylium', categories: ['end_stone', 'mushroom', 'imparius_phylium'], growthModifier: 0.5 }
 ];

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
@@ -745,6 +745,20 @@ const treeRegistry = [
                 trunk: 'betterendforge:jellyshroom_log',
                 leaf: 'betterendforge:jellyshroom_cap_purple',
                 substrate: 'jungle_moss'
+            },
+            {
+                sapling: 'byg:imparius_mushroom',
+                trunk: 'byg:imparius_stem',
+                leaf: 'byg:imparius_mushroom_block',
+                extraDecoration: 'byg:imparius_mushroom_branch',
+                substrate: 'mushroom'
+            },
+            {
+                sapling: 'byg:fungal_imparius',
+                trunk: 'byg:fungal_imparius_stem',
+                leaf: 'byg:fungal_imparius_block',
+                extraDecoration: 'byg:fungal_imparius_filament_block',
+                substrate: 'mushroom'
             }
         ]
     }


### PR DESCRIPTION
#1840
Creates recipes for PVJ ground clutter items and adds crop recipes for the plants.

Adds a note to red and brown mushrooms and colonies that explains how to obtain the colonies.

Added new crop recipes for the Imparius mushroom trees.
Added Imparius Phylium as valid soil for botany pots.

Tag all the things.