### PR TITLE
Integrated Dynamics/Tunnels Nerf

### DIFF
--- a/config/integrateddynamics-common.toml
+++ b/config/integrateddynamics-common.toml
@@ -21,7 +21,7 @@
 		#When enabled, networks will stop ticking and values will not be shown and evaluated again. This can be used to fix crashing networks by temporarily enabling this option.
 		safeMode = false
 		#The maximum network energy transfer rate.
-		energyRateLimit = 2147483647
+		energyRateLimit = 16384
 		#How deep the recursion stack on an operator can become. This is to avoid game crashes when building things like the omega operator.
 		operatorRecursionLimit = 256
 		#The number of threads that the ingredient network observer can use.
@@ -97,7 +97,7 @@
 		#Priority list of mod id's when determining tag-based recipe outputs.
 		recipeTagOutputModPriorities = ["emendatusenigmatica", "minecraft", "immersiveengineering", "thermal", "create", "mekanism", "jaopca", "kubejs", "pneumaticcraft", "occultism", "industrialforegoing", "botania", "quark", "pedestals"]
 		#The default update frequency in ticks to use for new parts.
-		defaultPartUpdateFreq = 1
+		defaultPartUpdateFreq = 10
 		#The NBT tags that are not allowed to be read by displaying NBT tags or performing operations on them.
 		nbtTagBlacklist = []
 

--- a/config/integrateddynamics-common.toml
+++ b/config/integrateddynamics-common.toml
@@ -21,7 +21,7 @@
 		#When enabled, networks will stop ticking and values will not be shown and evaluated again. This can be used to fix crashing networks by temporarily enabling this option.
 		safeMode = false
 		#The maximum network energy transfer rate.
-		energyRateLimit = 16384
+		energyRateLimit = 65536
 		#How deep the recursion stack on an operator can become. This is to avoid game crashes when building things like the omega operator.
 		operatorRecursionLimit = 256
 		#The number of threads that the ingredient network observer can use.
@@ -162,4 +162,3 @@
 	[biome.meneglin]
 		#The weight of spawning in the overworld, 0 disables spawning.
 		spawnWeight = 5
-

--- a/config/integratedtunnels-common.toml
+++ b/config/integratedtunnels-common.toml
@@ -61,7 +61,7 @@
 
 	[core.general]
 		#The maximum network fluid transfer rate.
-		fluidRateLimit = 16384
+		fluidRateLimit = 65536
 		#If particles should be shown and sounds should be played when tunnels are interacting with the world.
 		worldInteractionEvents = true
 		#If an anonymous mod startup analytics request may be sent to our analytics service.
@@ -74,4 +74,3 @@
 		ejectItemsOnInconsistentSimulationMovement = true
 		#If the version checker should be enabled.
 		versionChecker = false
-

--- a/config/integratedtunnels-common.toml
+++ b/config/integratedtunnels-common.toml
@@ -61,7 +61,7 @@
 
 	[core.general]
 		#The maximum network fluid transfer rate.
-		fluidRateLimit = 2147483647
+		fluidRateLimit = 16384
 		#If particles should be shown and sounds should be played when tunnels are interacting with the world.
 		worldInteractionEvents = true
 		#If an anonymous mod startup analytics request may be sent to our analytics service.

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -107,6 +107,18 @@ events.listen('jei.information', (event) => {
             items: ['farmersdelight:red_mushroom_colony', 'minecraft:red_mushroom'],
             description: [
                 'Plant a Red Mushroom on Rich Soil in darkness to grow mushroom colonies, which may be broken for a nice yield.'
+            ],
+        },
+        {
+            items: ['integratedtunnels:part_interface_energy', 'integratedtunnels:part_importer_energy', 'integratedtunnels:part_exporter_energy'],
+            description: [
+                'Max Energy Transfer Rate has been limited to 16,384 FE per tick.'
+            ]
+        },
+        {
+            items: ['integratedtunnels:part_interface_fluid', 'integratedtunnels:part_importer_fluid', 'integratedtunnels:part_exporter_fluid'],
+            description: [
+                'Max Fluid Transfer Rate has been limited to 16,384mb per tick.'
             ]
         }
     ];

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -112,13 +112,13 @@ events.listen('jei.information', (event) => {
         {
             items: ['integratedtunnels:part_interface_energy', 'integratedtunnels:part_importer_energy', 'integratedtunnels:part_exporter_energy'],
             description: [
-                'Max Energy Transfer Rate has been limited to 16,384 FE per tick.'
+                'Max Energy Transfer Rate has been limited to 65,536 FE per tick.'
             ]
         },
         {
             items: ['integratedtunnels:part_interface_fluid', 'integratedtunnels:part_importer_fluid', 'integratedtunnels:part_exporter_fluid'],
             description: [
-                'Max Fluid Transfer Rate has been limited to 16,384mb per tick.'
+                'Max Fluid Transfer Rate has been limited to 65,536 mb per tick.'
             ]
         }
     ];

--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -12,7 +12,7 @@ onEvent('item.tooltip', (event) => {
             items: ['integratedtunnels:part_interface_fluid', 'integratedtunnels:part_importer_fluid', 'integratedtunnels:part_exporter_fluid'],
             text: [
                 Text.of(
-                    'Max Fluid Transfer Rate has been limited to 16,384mb per tick.'
+                    'Max Fluid Transfer Rate has been limited to 65,536 mb per tick.'
                 ).red()
             ],
         },
@@ -20,7 +20,7 @@ onEvent('item.tooltip', (event) => {
             items: ['integratedtunnels:part_interface_energy', 'integratedtunnels:part_importer_energy', 'integratedtunnels:part_exporter_energy'],
             text: [
                 Text.of(
-                    'Max Energy Transfer Rate has been limited to 16,384 FE per tick.'
+                    'Max Energy Transfer Rate has been limited to 65,536 FE per tick.'
                 ).red()
             ]
         }

--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -6,6 +6,22 @@ onEvent('item.tooltip', (event) => {
                 Text.of(
                     'Do not use, you will crash immediately if in multiplayer. We have notified the mod author about the issue.'
                 ).red()
+            ],
+        },
+        {
+            items: ['integratedtunnels:part_interface_fluid', 'integratedtunnels:part_importer_fluid', 'integratedtunnels:part_exporter_fluid'],
+            text: [
+                Text.of(
+                    'Max Fluid Transfer Rate has been limited to 16,384mb per tick.'
+                ).red()
+            ],
+        },
+        {
+            items: ['integratedtunnels:part_interface_energy', 'integratedtunnels:part_importer_energy', 'integratedtunnels:part_exporter_energy'],
+            text: [
+                Text.of(
+                    'Max Energy Transfer Rate has been limited to 16,384 FE per tick.'
+                ).red()
             ]
         }
     ];


### PR DESCRIPTION
This PR stems from a discussion with @MuteTiefling regarding Integrated Dynamics/Tunnels. These mods are super useful for their logistical capabilities, but they make it super easy to set up a transfer system for fluids and energy that blows away most other options - and can be interdimensionally wireless! - for the cost of trees. This aims to bring the max transfer rates down significantly, while still making Tunnels useful for their logistical integration with Dynamics. These changes are as follows:

1. Default new part update frequency of 10 ticks (up from 1)
2. Lower max network FE transfer rate to 16,384 rf/tick
3. Lower max network fluid transfer rate to 16,384 mb/tick
4. Add JEI info tabs and tool tips indicating new limits.

This change may/will be controversial, so no worries if you either want to reject it or table it for now. It's also worth noting that we will want to give users fair warning before this goes into effect - if they are using ID/IT with sinks for their Fission setups, this will at least take their system down, and at worst blow it up if they don't have an automatic safety shutdown.