### PR TITLE
Fix missing Wire Coil Recipes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/normal/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/unification/unify_materials.js
@@ -129,7 +129,6 @@ events.listen('recipes', (event) => {
         }
 
         event.remove({ output: wire });
-        event.remove({ id: /immersiveengineering:crafting\/wire/ });
 
         const wireCutters = 'immersiveengineering:wirecutter';
         let output = wire,


### PR DESCRIPTION
Removes superfluous recipe removal responsible for missing wire coil and wire cutter recipes.

#1892