### PR TITLE
Zoology challenges

### DIFF
--- a/config/ftbquests/quests/chapters/challenges.snbt
+++ b/config/ftbquests/quests/chapters/challenges.snbt
@@ -559,6 +559,48 @@
 					}
 				}
 			}]
+		},
+		{
+			title: "Zoology",
+			x: 3.0d,
+			y: 0.5d,
+			subtitle: "Pets and kisses",
+			description: [
+				"Tame every animal there is to tame!",
+				"",
+				"(You can track the progress you've made by looking at the 'Zoology' advancement in the Husbandry tab)"
+			],
+			dependencies: ["1C6E46EA96373E74"],
+			id: "2AEE1AFA3BC416CE",
+			tasks: [{
+				id: "6550FEDCE5175F8C",
+				type: "advancement",
+				title: "Tame all tameable animals",
+				icon: "farmersdelight:horse_feed",
+				advancement: "enigmatica:husbandry/tame_all_animals",
+				criterion: ""
+			}]
+		},
+		{
+			title: "Two by Two",
+			x: 3.0d,
+			y: -0.5d,
+			subtitle: "The bees and the birds...",
+			description: [
+				"Breed every animal there is to breed!",
+				"",
+				"(You can track the progress you've made by looking at the 'Two by Two' advancement in the Husbandry tab)"
+			],
+			dependencies: ["1C6E46EA96373E74"],
+			id: "24ED473C9C545C09",
+			tasks: [{
+				id: "76A9D7B6C6D4C04F",
+				type: "advancement",
+				title: "Breed all breedable animals",
+				icon: "minecraft:golden_carrot",
+				advancement: "minecraft:husbandry/bred_all_animals",
+				criterion: ""
+			}]
 		}
 	]
 }

--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -16,5 +16,8 @@
     "entity.minecraft.villager.immersiveengineering:engineer": "Engineer",
     "entity.minecraft.villager.pneumaticcraft:mechanic": "Mechanic",
 
+    "advancements.enigmatica.husbandry.tame_all_animals.title": "Zoology",
+    "advancements.enigmatica.husbandry.tame_all_animals.description": "Tame every animal there is to tame!",
+
     "": ""
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/advancements/husbandry.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/advancements/husbandry.js
@@ -1,0 +1,104 @@
+events.listen('server.datapack.high_priority', function (event) {
+
+    var tamingCriteria = {};
+    tameableAnimals.forEach(entityType => {
+        tamingCriteria[entityType] = {
+            trigger: 'minecraft:tame_animal',
+            conditions: {
+                entity: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        predicate: {
+                            type: entityType
+                        },
+                        entity: 'this'
+                    }
+                ]
+            }
+        };
+    });
+    event.addJson('enigmatica:advancements/husbandry/tame_all_animals.json', {
+        parent: 'minecraft:husbandry/tame_an_animal',
+        display: {
+            icon: {
+                item: 'farmersdelight:horse_feed'
+            },
+            title: {
+                translate: 'advancements.enigmatica.husbandry.tame_all_animals.title'
+            },
+            description: {
+                translate: 'advancements.enigmatica.husbandry.tame_all_animals.description'
+            },
+            frame: 'challenge',
+            show_toast: true,
+            announce_to_chat: true,
+            hidden: false
+        },
+        criteria: tamingCriteria
+    });
+
+    var breedingCriteria = {};
+    breedableAnimals.forEach(entityType => {
+        breedingCriteria[entityType] = {
+            trigger: 'minecraft:bred_animals',
+            conditions: {
+                child: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        predicate: {
+                            type: entityType
+                        },
+                        entity: 'this'
+                    }
+                ]
+            }
+        };
+    });
+    eggLayingAnimals.forEach(entityType => {
+        breedingCriteria[entityType] = {
+            trigger: 'minecraft:bred_animals',
+            conditions: {
+                parent: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        predicate: {
+                            type: entityType
+                        },
+                        entity: 'this'
+                    }
+                ],
+                partner: [
+                    {
+                        condition: 'minecraft:entity_properties',
+                        predicate: {
+                            type: entityType
+                        },
+                        entity: 'this'
+                    }
+                ]
+            }
+        };
+    });
+    event.addJson('minecraft:advancements/husbandry/bred_all_animals.json', {
+        parent: 'minecraft:husbandry/breed_an_animal',
+        display: {
+            icon: {
+                item: 'minecraft:golden_carrot'
+            },
+            title: {
+                translate: 'advancements.husbandry.breed_all_animals.title'
+            },
+            description: {
+                translate: 'advancements.husbandry.breed_all_animals.description'
+            },
+            frame: 'challenge',
+            show_toast: true,
+            announce_to_chat: true,
+            hidden: false
+        },
+        rewards: {
+            experience: 100
+        },
+        criteria: breedingCriteria
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/animals.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/animals.js
@@ -1,0 +1,76 @@
+//priority: 1000
+
+// all animals that can be tamed, used for zoology challenge
+// raccoons and crows aren't in this list as they don't trigger the relevant advancement trigger when tamed
+const tameableAnimals = [
+    'minecraft:wolf',
+    'minecraft:cat',
+    'minecraft:parrot',
+    'minecraft:horse',
+    'minecraft:donkey',
+    'minecraft:mule',
+    'minecraft:llama',
+    'alexsmobs:capuchin_monkey',
+    'alexsmobs:elephant',
+    'alexsmobs:gorilla',
+    'alexsmobs:grizzly_bear',
+    'alexsmobs:kangaroo',
+    'alexsmobs:komodo_dragon',
+    'alexsmobs:mantis_shrimp',
+    'alexsmobs:warped_toad',
+    'quark:foxhound'
+];
+
+// all animals that can be bred (except egg laying animals)
+// all animals in this list are added to the 'Two by Two' advancement, which is used for conservationism challenge
+// autumnity already adds snails and turkeys to the advancement, these aren't needed here
+const breedableAnimals = [
+    'minecraft:horse',
+    'minecraft:donkey',
+    'minecraft:mule',
+    'minecraft:sheep',
+    'minecraft:cow',
+    'minecraft:mooshroom',
+    'minecraft:pig',
+    'minecraft:chicken',
+    'minecraft:wolf',
+    'minecraft:ocelot',
+    'minecraft:rabbit',
+    'minecraft:llama',
+    'minecraft:cat',
+    'minecraft:panda',
+    'minecraft:fox',
+    'minecraft:bee',
+    'minecraft:hoglin',
+    'minecraft:strider',
+    'alexsmobs:fly',
+    'alexsmobs:hummingbird',
+    'alexsmobs:endergrade',
+    'alexsmobs:capuchin_monkey',
+    'alexsmobs:warped_toad',
+    'alexsmobs:moose',
+    'alexsmobs:raccoon',
+    'alexsmobs:seal',
+    'alexsmobs:cockroach',
+    'alexsmobs:elephant',
+    'alexsmobs:snow_leopard',
+    'alexsmobs:alligator_snapping_turtle',
+    'alexsmobs:mungus',
+    'alexsmobs:mantis_shrimp',
+    'alexsmobs:emu',
+    'alexsmobs:platypus',
+    'alexsmobs:tasmanian_devil',
+    'alexsmobs:kangaroo',
+    'quark:crab',
+    'quark:foxhound',
+    'quark:frog',
+    'undergarden:gloomper',
+    'undergarden:dweller',
+    'upgrade_aquatic:goose'
+];
+
+// animals that can be bred, but don't immediately spawn a child after breeding
+const eggLayingAnimals = [
+    'minecraft:turtle',
+    'alexsmobs:crocodile'
+];


### PR DESCRIPTION
This PR adds two challenge quests, one for breeding and one for taming (#1797). Both are implemented via an advancement generated with kubejs, since that seemed like the simplest way to do it. Vanilla minecraft already has a breed-all-mobs-advancement so I overrode that one, I'm fairly certain progress already made towards vanilla mobs won't be affected.
I'm *think* I found all the relevant mobs, but there's always a chance I missed a few...

I wasn't entirely sure what to do with the folder structure for the advancements, feel free to move things around.