### PR TITLE
Fix Interactio script: move tag recipe to correct recipe type array.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/betterend/anvil_smithing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/betterend/anvil_smithing.js
@@ -1,8 +1,8 @@
 events.listen('recipes', (event) => {
-    var materials = ['aeternium', 'terminite', 'thallasium'],
+    const materials = ['aeternium', 'terminite', 'thallasium'],
         types = ['shovel_head', 'hammer_head', 'hoe_head', 'pickaxe_head', 'axe_head', 'sword_blade'];
 
-    var data = {
+    const data = {
         recipes: [
             {
                 id: 'betterendforge:ender_shard_to_dust',
@@ -27,7 +27,12 @@ events.listen('recipes', (event) => {
 
     materials.forEach((material) => {
         types.forEach((type) => {
-            var count, damage;
+            // Neither terminite nor thallasium have a hammer head.
+            if (type == 'hammer_head' && material != 'aeternium') {
+                return;
+            }
+
+            let count, damage;
             switch (type) {
                 case 'hoe_head':
                     count = 2;

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/interactio/item_fluid_transform.js
@@ -40,14 +40,14 @@ events.listen('recipes', (event) => {
         {
             input: 'forge:storage_blocks/iron',
             output: 'dustrial_decor:rusty_iron_block'
+        },
+        {
+            input: 'minecraft:logs',
+            output: 'upgrade_aquatic:driftwood_log'
         }
     ];
 
     const simpleItemRecipes = [
-        {
-            output: 'upgrade_aquatic:driftwood_log',
-            input: '#minecraft:logs'
-        },
         {
             output: 'embellishcraft:rusty_wall_ladder',
             input: 'embellishcraft:steel_wall_ladder'


### PR DESCRIPTION
This will fix an error I spotted in the KubeJS logs.

This relates to a recipe that allows for any item with the tag '#minecraft:logs' to be converted into the item 'upgrade_aquatic:driftwood_log' when the item interacts with water. It was incorrectly added to the `simpleItemRecipes` list (which species that the input is an item) rather than `simpleTagRecipes` list.

This patch merely moves the recipe to the correct type.