### PR TITLE
Host of minor integrations additions

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -75,6 +75,8 @@ events.listen('recipes', (event) => {
 
         'buildersaddition:iron_rod',
 
+        'byg:vermilion_sculk',
+
         'compactmachines:wall',
 
         'create:mechanical_crafting/integrated_circuit',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -209,6 +209,13 @@ events.listen('recipes', (event) => {
                 C: 'powah:furnator_nitro',
                 D: 'powah:reactor_nitro'
             }
+        },
+        {
+            output: 'betterendforge:dense_snow',
+            pattern: ['AAA', 'AAA', 'AAA'],
+            key: {
+                A: 'minecraft:snow_block'
+            }
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
@@ -2,7 +2,7 @@ events.listen('recipes', (event) => {
     data = {
         recipes: [
             {
-                inputs: [{ tag: 'forge:rods/blaze' }],
+                inputs: ['#forge:rods/blaze'],
                 output: 'minecraft:blaze_powder',
                 count: 4,
                 syphon: 50,
@@ -10,7 +10,7 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: [{ item: 'thermal:basalz_rod' }],
+                inputs: ['#forge:rods/basalz'],
                 output: 'thermal:basalz_powder',
                 count: 4,
                 syphon: 50,
@@ -18,7 +18,7 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: [{ item: 'thermal:blizz_rod' }],
+                inputs: ['#forge:rods/blizz'],
                 output: 'thermal:blizz_powder',
                 count: 4,
                 syphon: 50,
@@ -26,7 +26,7 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: [{ item: 'thermal:blitz_rod' }],
+                inputs: ['#forge:rods/blitz'],
                 output: 'thermal:blitz_powder',
                 count: 4,
                 syphon: 50,
@@ -34,7 +34,7 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: [{ item: 'minecraft:dirt' }, { item: 'minecraft:bone_meal' }, { tag: 'forge:mushrooms' }],
+                inputs: ['minecraft:dirt', 'minecraft:bone_meal', '#forge:mushrooms'],
                 output: 'minecraft:mycelium',
                 count: 1,
                 syphon: 200,
@@ -42,7 +42,7 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: [{ item: 'minecraft:dirt' }, { item: 'minecraft:bone_meal' }, { tag: 'minecraft:leaves' }],
+                inputs: ['minecraft:dirt', 'minecraft:bone_meal', '#minecraft:leaves'],
                 output: 'minecraft:podzol',
                 count: 1,
                 syphon: 200,
@@ -50,16 +50,92 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: [
-                    { item: 'byg:quartzite_sand' },
-                    { item: 'byg:quartzite_sand' },
-                    { item: 'byg:quartzite_sand' }
-                ],
+                inputs: ['byg:quartzite_sand', 'byg:quartzite_sand', 'byg:quartzite_sand'],
                 output: 'minecraft:quartz',
                 count: 3,
                 syphon: 50,
                 ticks: 20,
                 orbLevel: 0
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:bulbis_sprouts'],
+                output: 'byg:bulbis_phycelium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:imparius_vine'],
+                output: 'byg:imparius_phylium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:shulkren_moss_blanket'],
+                output: 'byg:shulkren_phylium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:nightshade_sprouts'],
+                output: 'byg:nightshade_phylium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:ivis_sprout'],
+                output: 'byg:ivis_phylium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['byg:ether_soil', 'minecraft:bone_meal', 'byg:ether_foliage'],
+                output: 'byg:ether_phylium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:dirt', 'minecraft:bone_meal', 'byg:ether_foliage'],
+                output: 'byg:ether_soil',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['byg:ether_stone', 'minecraft:bone_meal', 'byg:vermilion_sculk_growth'],
+                output: 'byg:vermilion_sculk',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:netherrack', 'minecraft:bone_meal', '#forge:mushrooms'],
+                output: 'byg:mycelium_netherrack',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', '#forge:mushrooms'],
+                output: 'betterendforge:end_mycelium',
+                count: 1,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/pure_daisy.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/pure_daisy.js
@@ -1,0 +1,22 @@
+events.listen('recipes', (event) => {
+    var data = {
+        recipes: [
+            {
+                input: 'minecraft:snow_block',
+                output: 'betterendforge:dense_snow'
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        event.custom({
+            type: 'botania:pure_daisy',
+            input: {
+                type: 'block',
+                block: recipe.input
+            },
+            output: {
+                name: recipe.output
+            }
+        });
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/mixing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/mixing.js
@@ -2,20 +2,11 @@ events.listen('recipes', (event) => {
     var data = {
         recipes_unheated: [
             {
-                inputs: [
-                    '#minecraft:planks',
-                    '#minecraft:planks',
-                    Fluid.of('immersiveengineering:creosote', 250)
-                ],
+                inputs: ['#minecraft:planks', '#minecraft:planks', Fluid.of('immersiveengineering:creosote', 250)],
                 output: Item.of('immersiveengineering:treated_wood_horizontal', 2)
             },
             {
-                inputs: [
-                    '#minecraft:coals',
-                    '#minecraft:coals',
-                    '#forge:clay',
-                    Fluid.of('minecraft:lava', 500)
-                ],
+                inputs: ['#minecraft:coals', '#minecraft:coals', '#forge:clay', Fluid.of('minecraft:lava', 500)],
                 output: Item.of('powah:dielectric_paste', 16)
             },
             {
@@ -24,7 +15,7 @@ events.listen('recipes', (event) => {
                     '#forge:gravel',
                     '#forge:sand',
                     '#forge:sand',
-                    {fluidTag: 'minecraft:water', amount: 500}
+                    Fluid.of('minecraft:water', 500)
                 ],
                 output: Fluid.of('immersiveengineering:concrete', 500)
             },
@@ -34,7 +25,7 @@ events.listen('recipes', (event) => {
                     '#forge:gravel',
                     '#forge:slag',
                     '#forge:slag',
-                    {fluidTag: 'minecraft:water', amount: 750}
+                    Fluid.of('minecraft:water', 750)
                 ],
                 output: Fluid.of('immersiveengineering:concrete', 750)
             },
@@ -44,7 +35,7 @@ events.listen('recipes', (event) => {
                     '#forge:gravel',
                     '#forge:sand',
                     '#forge:sand',
-                    {fluidTag: 'minecraft:water', amount: 500}
+                    Fluid.of('minecraft:water', 500)
                 ],
                 output: Item.of('immersivepetroleum:asphalt', 12)
             },
@@ -54,9 +45,41 @@ events.listen('recipes', (event) => {
                     '#forge:gravel',
                     '#forge:slag',
                     '#forge:slag',
-                    {fluidTag: 'minecraft:water', amount: 500}
+                    Fluid.of('minecraft:water', 500)
                 ],
                 output: Item.of('immersivepetroleum:asphalt', 16)
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:bulbis_sprouts'],
+                output: Item.of('byg:bulbis_phycelium')
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:imparius_vine'],
+                output: Item.of('byg:imparius_phylium')
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:shulkren_moss_blanket'],
+                output: Item.of('byg:shulkren_phylium')
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:nightshade_sprouts'],
+                output: Item.of('byg:nightshade_phylium')
+            },
+            {
+                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:ivis_sprout'],
+                output: Item.of('byg:ivis_phylium')
+            },
+            {
+                inputs: ['byg:ether_soil', 'minecraft:bone_meal', 'byg:ether_foliage'],
+                output: Item.of('byg:ether_phylium')
+            },
+            {
+                inputs: ['minecraft:dirt', 'minecraft:bone_meal', 'byg:ether_foliage'],
+                output: Item.of('byg:ether_soil')
+            },
+            {
+                inputs: ['byg:ether_stone', 'minecraft:bone_meal', 'byg:vermilion_sculk_growth'],
+                output: Item.of('byg:vermilion_sculk')
             }
         ],
         recipes_heated: [
@@ -140,10 +163,7 @@ events.listen('recipes', (event) => {
                 output: Item.of('emendatusenigmatica:enderium_ingot', 2)
             },
             {
-                inputs: [
-                    '#forge:ingots/netherite',
-                    'betterendforge:terminite_ingot'
-                ],
+                inputs: ['#forge:ingots/netherite', 'betterendforge:terminite_ingot'],
                 output: Item.of('betterendforge:aeternium_ingot')
             }
         ]

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/splashing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/splashing.js
@@ -63,6 +63,10 @@ events.listen('recipes', (event) => {
             {
                 outputs: ['minecraft:terracotta'],
                 input: '#enigmatica:washables/terracotta'
+            },
+            {
+                outputs: ['betterendforge:dense_snow'],
+                input: 'minecraft:snow_block'
             }
         ],
         rusty_items: [

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/metallurgic_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/metallurgic_infusing.js
@@ -1,0 +1,25 @@
+events.listen('recipes', (event) => {
+    var data = {
+        recipes: [
+            {
+                output: 'betterendforge:end_mycelium',
+                input: 'minecraft:end_stone',
+                infusionInput: 'mekanism:fungi',
+                infusionAmount: 10
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        recipe.id
+            ? event.recipes.mekanism
+                  .metallurgic_infusing(recipe.output, recipe.input, recipe.infusionInput, recipe.infusionAmount)
+                  .id(recipe.id)
+            : event.recipes.mekanism.metallurgic_infusing(
+                  recipe.output,
+                  recipe.input,
+                  recipe.infusionInput,
+                  recipe.infusionAmount
+              );
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/block_heat_properties.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/block_heat_properties.js
@@ -44,6 +44,15 @@ events.listen('recipes', (event) => {
                     block: 'emendatusenigmatica:lead_block'
                 },
                 heatCapacity: 500000
+            },
+            {
+                block: 'betterendforge:dense_snow',
+                temperature: 263,
+                thermalResistance: 500,
+                transformCold: {
+                    block: 'minecraft:snow_block'
+                },
+                heatCapacity: 2000
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -33,11 +33,14 @@ events.listen('recipes', (event) => {
                 output: [{ item: 'pneumaticcraft:transistor' }]
             },
             {
-                ingredients: [
-                    { type: 'pneumaticcraft:stacked_item', tag: 'forge:grain', count: 1 }
-                ],
+                ingredients: [{ type: 'pneumaticcraft:stacked_item', tag: 'forge:grain', count: 1 }],
                 pressure: 1.5,
-                output: [{ item: 'create:wheat_flour', count: 2}]
+                output: [{ item: 'create:wheat_flour', count: 2 }]
+            },
+            {
+                ingredients: [{ type: 'pneumaticcraft:stacked_item', item: 'minecraft:snow_block', count: 4 }],
+                pressure: 2.0,
+                output: [{ item: 'betterendforge:dense_snow', count: 1 }]
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
@@ -49,6 +49,14 @@ events.listen('recipes', (event) => {
             output: Item.of('atmospheric:red_arid_sand', 4)
         },
         {
+            inputs: [Item.of('betterendforge:dense_snow', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
+            output: Item.of('minecraft:snow_block', 9)
+        },
+        {
+            inputs: [Item.of('minecraft:snow_block', 9), Ingredient.of('#thermal:crafting/dies/packing_3x3')],
+            output: Item.of('betterendforge:dense_snow', 1)
+        },
+        {
             inputs: [Ingredient.of('#integrateddynamics:menril_logs', 1)],
             output: [
                 Item.of('integrateddynamics:crystalized_menril_chunk', 4),

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/rods.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/rods.js
@@ -1,0 +1,6 @@
+events.listen('item.tags', (event) => {
+    event.get('forge:rods').add(['thermal:basalz_rod', 'thermal:blizz_rod', 'thermal:blitz_rod']);
+    event.get('forge:rods/basalz').add('thermal:basalz_rod');
+    event.get('forge:rods/blizz').add('thermal:blizz_rod');
+    event.get('forge:rods/blitz').add('thermal:blitz_rod');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -1509,6 +1509,30 @@ const cropRegistry = [
                 substrate: 'end_stone'
             },
             {
+                seed: 'byg:tall_ether_grass',
+                render: 'byg:tall_ether_grass',
+                plant: 'byg:tall_ether_grass',
+                substrate: 'end_stone'
+            },
+            {
+                seed: 'byg:ether_bush',
+                render: 'byg:ether_bush',
+                plant: 'byg:ether_bush',
+                substrate: 'end_stone'
+            },
+            {
+                seed: 'byg:imparius_bush',
+                render: 'byg:imparius_bush',
+                plant: 'byg:imparius_bush',
+                substrate: 'end_stone'
+            },
+            {
+                seed: 'byg:bulbis_sprouts',
+                render: 'byg:bulbis_sprouts',
+                plant: 'byg:bulbis_sprouts',
+                substrate: 'end_stone'
+            },
+            {
                 seed: 'byg:flower_patch',
                 render: 'byg:flower_patch',
                 plant: 'byg:flower_patch',


### PR DESCRIPTION
#1960
Adds Alchemy Table and Create Mixing recipes for the following:
Vermillion Sculk = Vermilion Sculk Growth+ Ether Stone
Ether Phylium = Ether Foliage + Ether Soil
Nightshade Phylium = Nightshade Sprouts + End Stone
Shulkren Phylium = Shulkren Moss Blanket + End Stone
Imparius Phylium = Imparius Vine + End Stone
Bulbis Phycelium = Bulbis Sprouts + End Stone

Adds a few missing plants to the crop registry
Removes the default lossy vermilion sculk recipe
Adds end mycelium to the metallurgic infuser

Add Thermal elemental rods to forge tag.
Some recipe cleanup in the Alchemy Table

Add Dense Snow recipes to PNC, Botania, Create, Thermal, and 3x3 crafting
Add Dense Snow as cooling source for PNC