### PR TITLE
Minor refactoring of create mechanical crafting recipes.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/mechanical_crafting.js
@@ -1,21 +1,13 @@
 events.listen('recipes', (event) => {
-    data = {
+    const data = {
         recipes: [
             {
                 pattern: ['  L  ', 'RRQRR', ' CCC '],
                 key: {
-                    L: {
-                        tag: 'forge:plates/lapis'
-                    },
-                    R: {
-                        tag: 'forge:dusts/redstone'
-                    },
-                    Q: {
-                        item: 'create:polished_rose_quartz'
-                    },
-                    C: {
-                        tag: 'forge:nuggets/gold'
-                    }
+                    L: '#forge:plates/lapis',
+                    R: '#forge:dusts/redstone',
+                    Q: 'create:polished_rose_quartz',
+                    C: '#forge:nuggets/gold'
                 },
                 result: 'create:integrated_circuit'
             }
@@ -23,13 +15,6 @@ events.listen('recipes', (event) => {
     };
 
     data.recipes.forEach((recipe) => {
-        event.recipes.create.mechanical_crafting({
-            type: 'create.mechanical_crafting',
-            pattern: recipe.pattern,
-            key: recipe.key,
-            result: {
-                item: recipe.result
-            }
-        });
+        event.recipes.create.mechanical_crafting(recipe.result, recipe.pattern, recipe.key);
     });
 });


### PR DESCRIPTION
A minor refactoring of Create's mechanical crafting recipes. As the create.mechanical_crafting method is being used here the entire method call structure can be simplified.

This new format yields the same results, as per the documentation here: https://www.curseforge.com/minecraft/mc-mods/kubejs-create