### PR TITLE
Undergarden Crop update - fix broken Ditchbulb reference

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/crops.js
@@ -1366,7 +1366,7 @@ const cropRegistry = [
                 substrate: 'soul_sand'
             },
             {
-                seed: 'undergarden:ditchbulb_plant',
+                seed: 'undergarden:ditchbulb',
                 render: 'undergarden:ditchbulb_plant',
                 plant: 'undergarden:ditchbulb',
                 substrate: 'deepturf'


### PR DESCRIPTION
ditchbulb plant no longer exists as an item. The ditchbulbs themselves can be planted to grow more.