### PR TITLE
Better End Compat - add Ingot > Nugget recipe. Remove excess Jaopca blocks for Better End Metals

### DIFF
--- a/config/jaopca/modules/storage_blocks.toml
+++ b/config/jaopca/modules/storage_blocks.toml
@@ -1,5 +1,5 @@
 
 [general]
 	#The material blacklist of this module.
-	materialBlacklist = ["brick", "nether_brick", "obsidian", "prismarine", "salt", "dragonstone", "mana_diamond", "mana", "netherite_scrap", "ender_pearl", "ender", "end_stone"]
+	materialBlacklist = ["brick", "nether_brick", "obsidian", "prismarine", "salt", "dragonstone", "mana_diamond", "mana", "netherite_scrap", "ender_pearl", "ender", "end_stone", "thallasium", "terminite", "aeternium"]
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -7,6 +7,8 @@ events.listen('recipes', (event) => {
         { output: 'minecraft:chest', inputs: ['#forge:chests/wooden'] },
         { output: 'minecraft:pumpkin', inputs: ['autumnity:large_pumpkin_slice'] },
         { output: Item.of('powah:uraninite', 9), inputs: ['#forge:storage_blocks/uraninite'] },
+        { output: Item.of('betterendforge:thallasium_nugget', 9), inputs: ['#forge:ingots/thallasium'] },
+        { output: Item.of('betterendforge:terminite_nugget', 9), inputs: ['#forge:ingots/terminite'] },
         {
             output: 'minecraft:crafting_table',
             inputs: ['craftingstation:crafting_station_slab', 'craftingstation:crafting_station_slab']


### PR DESCRIPTION
Better end already has a block form of the ingots. No idea why Jaopca adds one. Removed.

Add missing recipes for ingot > nugget