### PR TITLE
Remove the need for the Ars Nouveau glyph recipe, use a not filter in…

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -36,7 +36,11 @@ events.listen('recipes', (event) => {
     event.replaceInput({}, 'simplefarming:cooked_bacon', '#forge:cooked_bacon');
     event.replaceInput({ mod: 'simplefarming' }, 'minecraft:cooked_chicken', '#forge:cooked_chicken');
     event.replaceInput({ id: '/simplefarming:\\w+burger/' }, 'minecraft:cooked_beef', 'farmersdelight:beef_patty');
-    event.replaceInput({}, 'minecraft:nether_brick', '#forge:ingots/nether_brick');
+    event.replaceInput({
+        not: [
+            { type: 'ars_nouveau:glyph_recipe' }
+        ]
+    }, 'minecraft:nether_brick', '#forge:ingots/nether_brick');
     event.replaceInput({}, 'minecraft:nether_bricks', '#forge:netherbricks');
     event.replaceInput({ type: 'minecraft:crafting_shaped' }, 'minecraft:stone', '#forge:stone', true);
     event.replaceInput({ type: 'minecraft:crafting_shapeless' }, 'minecraft:stone', '#forge:stone', true);

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/ars_nouveau/glyph_recipe.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/ars_nouveau/glyph_recipe.js
@@ -1,28 +1,17 @@
 events.listen('recipes', (event) => {
     const recipes = [
-        {
-            tier: 'TWO',
-            input: 'minecraft:nether_brick',
-            output: 'ars_nouveau:glyph_dampen',
-            id: 'ars_nouveau:glyph_dampen'
-        }
     ];
 
     recipes.forEach((recipe) => {
-        recipe.id
-            ? event
-                  .custom({
-                      type: 'ars_nouveau:glyph_recipe',
-                      tier: recipe.tier,
-                      input: recipe.input,
-                      output: recipe.output
-                  })
-                  .id(recipe.id)
-            : event.custom({
-                  type: 'ars_nouveau:glyph_recipe',
-                  tier: recipe.tier,
-                  input: recipe.input,
-                  output: recipe.output
-              });
+        const re = 
+            event.custom({
+                type: 'ars_nouveau:glyph_recipe',
+                tier: recipe.tier,
+                input: recipe.input,
+                output: recipe.output
+            });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
     });
 });


### PR DESCRIPTION
…stead.

The Ars Nouveau glyph recipe was added because the nether brick consolidation replaced nether bricks with a tag, which the glyph recipes do not support. This is now superfluous as KubeJS now supports a "not" filter on recipe types, meaning that the recipe type can simply be excluded from consolidation instead.

I also slightly reworked the glyph recipes script, just in case it is ever used in the future.