### PR TITLE
Pressure Chamber Wheat Recipe Override

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/explosion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/explosion.js
@@ -10,16 +10,20 @@ events.listen('recipes', (event) => {
                         item: 'create:wheat_flour'
                     }
                 ],
-                loss_rate: 50
+                loss_rate: 50,
+                id: 'wheat_flour'
             }
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.custom({
+        let re = event.custom({
             type: 'pneumaticcraft:explosion_crafting',
             input: recipe.input,
             results: recipe.results,
             loss_rate: recipe.loss_rate
         });
+        if (recipe.id) {
+            re.id(`pneumaticcraft:explosion_crafting/${recipe.id}`);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/fuels.js
@@ -13,29 +13,14 @@ events.listen('recipes', (event) => {
                 rate: 1
             },
             {
-                fluid: 'thermal:tree_oil',
-                air: 100,
-                rate: 0.5
-            },
-            {
-                fluid: 'thermal:creosote',
-                air: 20,
-                rate: 0.25
-            },
-            {
                 fluid: 'immersiveengineering:creosote',
-                air: 20,
+                air: 50,
                 rate: 0.25
-            },
-            {
-                fluid: 'thermal:refined_fuel',
-                air: 1500,
-                rate: 1.5
             }
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.recipes.pneumaticcraft.fuel_quality({
+        event.custom({
             type: 'pneumaticcraft:fuel_quality',
             fluid: {
                 type: 'pneumaticcraft:fluid',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -1,8 +1,4 @@
 events.listen('recipes', (event) => {
-    event.remove({ id: 'pneumaticcraft:pressure_chamber/empty_pcb' });
-    event.remove({ id: 'pneumaticcraft:pressure_chamber/transistor' });
-    event.remove({ id: 'pneumaticcraft:pressure_chamber/capacitor' });
-
     var data = {
         recipes: [
             {
@@ -12,7 +8,8 @@ events.listen('recipes', (event) => {
                     { item: 'pneumaticcraft:plastic' }
                 ],
                 pressure: 1.5,
-                output: [{ item: 'pneumaticcraft:empty_pcb', count: 3 }]
+                output: [{ item: 'pneumaticcraft:empty_pcb', count: 3 }],
+                id: 'empty_pcb'
             },
             {
                 ingredients: [
@@ -21,7 +18,8 @@ events.listen('recipes', (event) => {
                     { item: 'pneumaticcraft:plastic' }
                 ],
                 pressure: 1.0,
-                output: [{ item: 'pneumaticcraft:capacitor' }]
+                output: [{ item: 'pneumaticcraft:capacitor' }],
+                id: 'capacitor'
             },
             {
                 ingredients: [
@@ -30,12 +28,14 @@ events.listen('recipes', (event) => {
                     { item: 'pneumaticcraft:plastic' }
                 ],
                 pressure: 1.0,
-                output: [{ item: 'pneumaticcraft:transistor' }]
+                output: [{ item: 'pneumaticcraft:transistor' }],
+                id: 'transistor'
             },
             {
                 ingredients: [{ type: 'pneumaticcraft:stacked_item', tag: 'forge:grain', count: 1 }],
                 pressure: 1.5,
-                output: [{ item: 'create:wheat_flour', count: 2 }]
+                output: [{ item: 'create:wheat_flour', count: 2 }],
+                id: 'wheat_flour'
             },
             {
                 ingredients: [{ type: 'pneumaticcraft:stacked_item', item: 'minecraft:snow_block', count: 4 }],
@@ -45,11 +45,14 @@ events.listen('recipes', (event) => {
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.recipes.pneumaticcraft.pressure_chamber({
+        let re = event.custom({
             type: 'pneumaticcraft:pressure_chamber',
             inputs: recipe.ingredients,
             pressure: recipe.pressure,
             results: recipe.output
         });
+        if (recipe.id) {
+            re.id(`pneumaticcraft:pressure_chamber/${recipe.id}`);
+        }
     });
 });


### PR DESCRIPTION
Fixes #2051

Changed the recipes for this to add optional ID override. All recipes that override base PNC recipes now use this instead of ID removals.

Minor change to fuel recipe to use 'custom' method instead of the old way.

Removed Thermal fuels from our scripts as they're now handled natively by PNC.

IE's Creosote buffed to match Thermal's Creosote values as a fuel source.