### PR TITLE
Compact Machine Fixes

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
@@ -31,7 +31,8 @@ events.listen('recipes', (event) => {
                 B: '#forge:gems/dimensional',
                 C: 'occultism:wormhole_frame',
                 D: '#forge:chests'
-            }
+            },
+            id: 'compactmachines:tunnel/item'
         },
         {
             output: Item.of('compactmachines:tunnel', { definition: { id: 'compactmachines:redstone_in' } }),
@@ -41,7 +42,8 @@ events.listen('recipes', (event) => {
                 B: '#forge:gems/dimensional',
                 C: 'occultism:wormhole_frame',
                 D: 'minecraft:redstone_torch'
-            }
+            },
+            id: 'compactmachines:tunnel/redstone'
         },
         {
             output: 'minecraft:furnace',

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/miniaturization.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/miniaturization.js
@@ -38,7 +38,8 @@ events.listen('recipes', (event) => {
             },
             components: {
                 W: {
-                    Name: 'compactmachines:wall'
+                    type: 'compactcrafting:block',
+                    block: 'compactmachines:wall'
                 }
             },
             outputs: [
@@ -85,10 +86,12 @@ events.listen('recipes', (event) => {
             },
             components: {
                 W: {
-                    Name: 'compactmachines:wall'
+                    type: 'compactcrafting:block',
+                    block: 'compactmachines:wall'
                 },
                 R: {
-                    Name: 'minecraft:redstone_block'
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:redstone_block'
                 }
             },
             outputs: [
@@ -135,10 +138,12 @@ events.listen('recipes', (event) => {
             },
             components: {
                 W: {
-                    Name: 'compactmachines:wall'
+                    type: 'compactcrafting:block',
+                    block: 'compactmachines:wall'
                 },
                 D: {
-                    Name: 'minecraft:diamond_block'
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:diamond_block'
                 }
             },
             outputs: [
@@ -195,10 +200,12 @@ events.listen('recipes', (event) => {
             },
             components: {
                 W: {
-                    Name: 'compactmachines:wall'
+                    type: 'compactcrafting:block',
+                    block: 'compactmachines:wall'
                 },
                 R: {
-                    Name: 'minecraft:redstone_block'
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:redstone_block'
                 }
             },
             outputs: [
@@ -255,10 +262,12 @@ events.listen('recipes', (event) => {
             },
             components: {
                 W: {
-                    Name: 'compactmachines:wall'
+                    type: 'compactcrafting:block',
+                    block: 'compactmachines:wall'
                 },
                 D: {
-                    Name: 'minecraft:diamond_block'
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:diamond_block'
                 }
             },
             outputs: [
@@ -315,10 +324,12 @@ events.listen('recipes', (event) => {
             },
             components: {
                 W: {
-                    Name: 'compactmachines:wall'
+                    type: 'compactcrafting:block',
+                    block: 'compactmachines:wall'
                 },
                 E: {
-                    Name: 'emendatusenigmatica:enderium_block'
+                    type: 'compactcrafting:block',
+                    block: 'emendatusenigmatica:enderium_block'
                 }
             },
             outputs: [


### PR DESCRIPTION
#2056

Fix broken Tunnel recipe by adding IDs to them.

Changed compact machine recipes to match new specification.

Having trouble with the mixed layers still. They don't seem to like having empty spaces... If I fill them in with some component, they're fine. Tried specifying minecraft:air to try to get around it and they broke. May have to reconsider these a bit.

Possibly make them all 3x3x3 so there won't be any empty spaces inside. Or find an alternate 'filler' material that makes sense.