### PR TITLE
Compact Machine Crafting Fix and Quests to Introduce Them

### DIFF
--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -64,6 +64,7 @@
 			title: "Refined Storage",
 			x: 1.0d,
 			y: -6.0d,
+			subtitle: "Energy Mass Conversion in a Square",
 			description: [
 				"Taking storage into the digital age, Refined Storage allows for the storage of items and fluids on disk drives with wireless access and transfer capabilities. It can also interface with most machines and inventories to expand its capabilities. ",
 				"",
@@ -120,8 +121,8 @@
 		},
 		{
 			icon: "mekanism:basic_bin",
-			x: -2.0d,
-			y: -9.0d,
+			x: 0.5d,
+			y: -9.5d,
 			subtitle: "I Like Big Bins and I Cannot Lie",
 			description: ["Often overlooked, Bins are an excellent choice for dense item storage. They can even be used in your inventory crafting grid to manipulate their contents. "],
 			dependencies: ["00000000000003FF"],
@@ -176,8 +177,8 @@
 		},
 		{
 			title: "Black Hole Storage",
-			x: 1.0d,
-			y: -9.0d,
+			x: 1.5d,
+			y: -8.5d,
 			subtitle: "Physics Breaking Hoarding",
 			description: [
 				"Industrial Foregoing has massive storage capabilities. ",
@@ -204,7 +205,7 @@
 			title: "Find Me",
 			icon: "naturesaura:range_visualizer",
 			x: -2.0d,
-			y: -6.0d,
+			y: -9.0d,
 			description: ["Forgot where you left your precious diorite? Mouse over some in your inventory or JEI and press Y to locate it in nearby inventories. "],
 			dependencies: ["00000000000003FF"],
 			id: "000000000000040B",
@@ -225,7 +226,7 @@
 			title: "Plonk",
 			icon: "botania:cosmetic_thinking_hand",
 			x: -3.0d,
-			y: -5.0d,
+			y: -10.0d,
 			description: [
 				"Looking for a handy place to store your hammer at the forge? Tired of rummaging through chest after chest for that gear press? Place them in world instead!",
 				"",
@@ -925,6 +926,217 @@
 				title: "Alchemist's Delight",
 				icon: "kubejs:alchemists_delight",
 				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_alchemists_delight",
+				player_command: false
+			}]
+		},
+		{
+			x: -3.0d,
+			y: -5.0d,
+			subtitle: "Do not screw with the regulator",
+			description: [
+				"A minor recalibration and the Personal Shrinking Device can shrink one right out of sight and into the nooks and crannies of special machines. ",
+				"",
+				"Build your own contraption within them to suit your needs, complete with custom input and output sides. ",
+				"",
+				"Simply Right-Click a Compact Machine with the PSD to warp inside of it. "
+			],
+			dependencies: ["2A74822BE970E9D4"],
+			id: "0AD2769DC173D26D",
+			tasks: [{
+				id: "6B198B6A029D9333",
+				type: "item",
+				item: "compactmachines:personal_shrinking_device"
+			}],
+			rewards: [{
+				id: "07BAD39E967F6B85",
+				type: "item",
+				item: "enderstorage:ender_pouch"
+			}]
+		},
+		{
+			title: "Field Projector",
+			x: -4.5d,
+			y: -5.0d,
+			subtitle: "Non-renormalizability",
+			description: [
+				"Crafting Compact Machines themselves is done with Field Projectors. Four of them need to be placed facing each other in a cross shape. ",
+				"",
+				"Begin by placing one a few blocks off the ground and then right click it. It will show you a series of marks floating in front of it that represent valid locations for the next Projector. ",
+				"",
+				"Once the second Projector is placed, Right-Clicking again will show the final two Projector locations. ",
+				"",
+				"If done correctly, an orange force field will appear in the center. This area is where the Compact Machines themselves must be constructed. "
+			],
+			dependencies: ["0AD2769DC173D26D"],
+			min_width: 250,
+			id: "5A1F6BA9BE06D643",
+			tasks: [{
+				id: "5D5A7187E1979D0D",
+				type: "item",
+				item: "compactcrafting:field_projector",
+				count: 4L
+			}],
+			rewards: [{
+				id: "36C4E2AF07DE5E40",
+				type: "item",
+				item: "enderstorage:ender_chest"
+			}]
+		},
+		{
+			x: -2.0d,
+			y: -6.0d,
+			subtitle: "Pym Powered",
+			description: [
+				"Smaller, but equally strong? Impossible!",
+				"",
+				"Until now. ",
+				"",
+				"With Shrink’s Personal Shrinking Device in hand, shrink to the tiniest of sizes and slip through cracks even a mouse would scoff at. ",
+				"",
+				"Sneak + Right Click to shrink yourself, or left click an entity to shrink it instead. Right click a shrunken entity to bottle it up and carry it with you. Keep a villager in your pocket for good luck!"
+			],
+			dependencies: ["00000000000003FF"],
+			id: "2A74822BE970E9D4",
+			tasks: [{
+				id: "417D1AA02B005770",
+				type: "item",
+				item: {
+					id: "shrink:shrinking_device",
+					Count: 1b,
+					tag: {}
+				}
+			}],
+			rewards: [
+				{
+					id: "39498CF292AB8B53",
+					type: "item",
+					item: "minecraft:glass_bottle",
+					count: 8
+				},
+				{
+					id: "00012916E3BF0CC7",
+					type: "command",
+					title: "Scavenger's Delight",
+					icon: "kubejs:scavengers_delight",
+					command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_scavengers_delight",
+					player_command: false
+				}
+			]
+		},
+		{
+			icon: "compactmachines:machine_tiny",
+			x: -4.5d,
+			y: -3.5d,
+			subtitle: "One, cut a hole in a box",
+			description: [
+				"Gather the materials for your first Compact Machine!",
+				"",
+				"To construct it, build the multi-block shown in JEI within the field and finally drop the catalyst item into the field. The structure will animate and begin to shrink down, finally dropping the fully crafted Compact Machine on the ground. ",
+				"",
+				"The Tiny Compact Machine has an internal volume of 3x3x3 and while that seems terribly small, it is perfect for certain smaller automations. And if you yourself are shrunk it can make placing the blocks inside quite simple. ",
+				"",
+				"Make a challenge for yourself and try to automate Industrial Foregoing Latex and Rubber in one. With clever use of other mods, this could be entirely self contained, including wood, power, and transformation from latex to plastic sheets all within this tiny box. "
+			],
+			dependencies: ["5A1F6BA9BE06D643"],
+			min_width: 250,
+			id: "3787A109AABC8921",
+			tasks: [
+				{
+					id: "16A0C1D718EA19AF",
+					type: "item",
+					item: "compactmachines:machine_tiny"
+				},
+				{
+					id: "32D8F9B8CDED9E06",
+					type: "item",
+					item: "minecraft:brown_concrete",
+					count: 48L
+				},
+				{
+					id: "1AC67E05941AD859",
+					type: "item",
+					item: "immersiveengineering:sheetmetal_colored_black",
+					count: 44L
+				},
+				{
+					id: "7825B867D82C7434",
+					type: "item",
+					item: "compactmachines:wall",
+					count: 26L
+				},
+				{
+					id: "10B5CC28DFBCC2DF",
+					type: "item",
+					item: "immersiveengineering:insulating_glass",
+					count: 6L
+				},
+				{
+					id: "1E69615DDBADE72F",
+					type: "item",
+					item: "emendatusenigmatica:copper_block"
+				}
+			],
+			rewards: [{
+				id: "3E2CA8D755178794",
+				type: "command",
+				title: "Scavenger's Delight",
+				icon: "kubejs:scavengers_delight",
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_scavengers_delight",
+				player_command: false
+			}]
+		},
+		{
+			x: -3.0d,
+			y: -3.5d,
+			description: ["Weighing in at 13x13x13 internal volume, the Maximum sized Compact Machine truly offers a world of automation possibilities. What will you build in yours? A mobile base of operations? Compact ore processing? Zombie-proof Villager trading hall? "],
+			dependencies: ["3787A109AABC8921"],
+			id: "0DAA452348B02827",
+			tasks: [{
+				id: "21ED2337B44743E5",
+				type: "item",
+				item: "compactmachines:machine_maximum"
+			}],
+			rewards: [{
+				id: "299A8E596E259DC4",
+				type: "command",
+				title: "Scavenger's Delight",
+				icon: "kubejs:scavengers_delight",
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_scavengers_delight",
+				player_command: false
+			}]
+		},
+		{
+			x: -5.5d,
+			y: -2.5d,
+			subtitle: "Quantum Tunneling",
+			description: [
+				"Placed on the walls inside Compact Machines, Tunnels permit a connection to the outside world. ",
+				"",
+				"For example, place a Tunnel on a wall and right click it until it reports it is configured to the up position, then place a chest against it. Warp back outside and place a Hopper on the top of the machine and feed in a few items. They’ll be whisked away into that chest inside. Use this concept to feed items into or out of the machine, as necessary. ",
+				"",
+				"Of course, many other options exist for getting stuff in and out. Ender Storage for items and fluids, Ender Gates for power, etc. "
+			],
+			dependencies: ["3787A109AABC8921"],
+			id: "5511E0236BA3BDCA",
+			tasks: [{
+				id: "2D8BF6B60DE16FC8",
+				type: "item",
+				item: {
+					id: "compactmachines:tunnel",
+					Count: 1b,
+					tag: {
+						definition: {
+							id: "compactmachines:item"
+						}
+					}
+				}
+			}],
+			rewards: [{
+				id: "526E10A2F22FF97C",
+				type: "command",
+				title: "Scavenger's Delight",
+				icon: "kubejs:scavengers_delight",
+				command: "/execute at @p run loot spawn ~ ~1 ~ loot enigmatica:chests/quest_scavengers_delight",
 				player_command: false
 			}]
 		}

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/miniaturization.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/miniaturization.js
@@ -6,40 +6,176 @@ events.listen('recipes', (event) => {
     //https://github.com/CompactMods/CompactCrafting/wiki/Recipe-Specification
     //Also note, can't use Item.of because Count is caps sensitive (Name too)
 
+    const machineShapes = {
+        five_by_five: [
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'A', 'A', 'A', 'A'],
+                    ['A', 'B', 'B', 'B', 'A'],
+                    ['A', 'B', 'C', 'B', 'A'],
+                    ['A', 'B', 'B', 'B', 'A'],
+                    ['A', 'A', 'A', 'A', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'B', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'B', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'C', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['C', 'D', 'E', 'D', 'C'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'C', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'B', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'B', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'A', 'A', 'A', 'A'],
+                    ['A', 'B', 'B', 'B', 'A'],
+                    ['A', 'B', 'C', 'B', 'A'],
+                    ['A', 'B', 'B', 'B', 'A'],
+                    ['A', 'A', 'A', 'A', 'A']
+                ]
+            }
+        ],
+        seven_by_seven: [
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'A', 'A', 'A', 'A', 'A', 'A'],
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A'],
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A'],
+                    ['A', 'B', 'C', 'B', 'C', 'B', 'A'],
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A'],
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A'],
+                    ['A', 'A', 'A', 'A', 'A', 'A', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'C', 'B', 'C', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['B', 'D', 'D', 'E', 'D', 'D', 'B'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'C', 'B', 'C', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['C', 'D', 'D', 'D', 'D', 'D', 'C'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['B', 'D', 'D', 'D', 'D', 'D', 'B'],
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A']
+                ]
+            },
+            {
+                type: 'compactcrafting:mixed',
+                pattern: [
+                    ['A', 'A', 'A', 'A', 'A', 'A', 'A'],
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A'],
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A'],
+                    ['A', 'B', 'C', 'B', 'C', 'B', 'A'],
+                    ['A', 'B', 'C', 'C', 'C', 'B', 'A'],
+                    ['A', 'B', 'B', 'B', 'B', 'B', 'A'],
+                    ['A', 'A', 'A', 'A', 'A', 'A', 'A']
+                ]
+            }
+        ]
+    };
+
     const recipes = [
         {
             //Tiny
             recipeSize: 5,
-            layers: [
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                }
-            ],
+            layers: machineShapes.five_by_five,
             catalyst: {
                 id: 'fluxnetworks:flux_dust',
                 Count: 1
             },
             components: {
-                W: {
+                A: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:sheetmetal_colored_black'
+                },
+                B: {
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:brown_concrete'
+                },
+                C: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:insulating_glass'
+                },
+                D: {
                     type: 'compactcrafting:block',
                     block: 'compactmachines:wall'
+                },
+                E: {
+                    type: 'compactcrafting:block',
+                    block: 'emendatusenigmatica:copper_block'
                 }
             },
             outputs: [
@@ -52,46 +188,31 @@ events.listen('recipes', (event) => {
         //Small
         {
             recipeSize: 5,
-            layers: [
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:mixed',
-                    pattern: [
-                        ['W', 'W', 'W', 'W', 'W'],
-                        ['W', '-', '-', '-', 'W'],
-                        ['W', '-', 'R', '-', 'W'],
-                        ['W', '-', '-', '-', 'W'],
-                        ['W', 'W', 'W', 'W', 'W']
-                    ]
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                }
-            ],
+            layers: machineShapes.five_by_five,
             catalyst: {
                 id: 'fluxnetworks:flux_dust',
                 Count: 1
             },
             components: {
-                W: {
+                A: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:sheetmetal_colored_black'
+                },
+                B: {
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:white_concrete'
+                },
+                C: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:insulating_glass'
+                },
+                D: {
                     type: 'compactcrafting:block',
                     block: 'compactmachines:wall'
                 },
-                R: {
+                E: {
                     type: 'compactcrafting:block',
-                    block: 'minecraft:redstone_block'
+                    block: 'emendatusenigmatica:invar_block'
                 }
             },
             outputs: [
@@ -104,46 +225,31 @@ events.listen('recipes', (event) => {
         //Normal
         {
             recipeSize: 5,
-            layers: [
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:mixed',
-                    pattern: [
-                        ['W', 'W', 'W', 'W', 'W'],
-                        ['W', '-', '-', '-', 'W'],
-                        ['W', '-', 'D', '-', 'W'],
-                        ['W', '-', '-', '-', 'W'],
-                        ['W', 'W', 'W', 'W', 'W']
-                    ]
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                }
-            ],
+            layers: machineShapes.five_by_five,
             catalyst: {
                 id: 'fluxnetworks:flux_dust',
                 Count: 1
             },
             components: {
-                W: {
+                A: {
                     type: 'compactcrafting:block',
-                    block: 'compactmachines:wall'
+                    block: 'immersiveengineering:sheetmetal_colored_black'
+                },
+                B: {
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:yellow_concrete'
+                },
+                C: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:insulating_glass'
                 },
                 D: {
                     type: 'compactcrafting:block',
-                    block: 'minecraft:diamond_block'
+                    block: 'compactmachines:wall'
+                },
+                E: {
+                    type: 'compactcrafting:block',
+                    block: 'emendatusenigmatica:electrum_block'
                 }
             },
             outputs: [
@@ -156,56 +262,31 @@ events.listen('recipes', (event) => {
         //Large
         {
             recipeSize: 7,
-            layers: [
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:mixed',
-                    pattern: [
-                        ['W', 'W', 'W', 'W', 'W', 'W', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', 'R', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', 'W', 'W', 'W', 'W', 'W', 'W']
-                    ]
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                }
-            ],
+            layers: machineShapes.seven_by_seven,
             catalyst: {
                 id: 'fluxnetworks:flux_dust',
                 Count: 1
             },
             components: {
-                W: {
+                A: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:sheetmetal_steel'
+                },
+                B: {
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:black_concrete'
+                },
+                C: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:insulating_glass'
+                },
+                D: {
                     type: 'compactcrafting:block',
                     block: 'compactmachines:wall'
                 },
-                R: {
+                E: {
                     type: 'compactcrafting:block',
-                    block: 'minecraft:redstone_block'
+                    block: 'emendatusenigmatica:signalum_block'
                 }
             },
             outputs: [
@@ -218,56 +299,31 @@ events.listen('recipes', (event) => {
         //Giant
         {
             recipeSize: 7,
-            layers: [
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:mixed',
-                    pattern: [
-                        ['W', 'W', 'W', 'W', 'W', 'W', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', 'D', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', 'W', 'W', 'W', 'W', 'W', 'W']
-                    ]
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                }
-            ],
+            layers: machineShapes.seven_by_seven,
             catalyst: {
                 id: 'fluxnetworks:flux_dust',
                 Count: 1
             },
             components: {
-                W: {
+                A: {
                     type: 'compactcrafting:block',
-                    block: 'compactmachines:wall'
+                    block: 'immersiveengineering:sheetmetal_steel'
+                },
+                B: {
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:cyan_concrete'
+                },
+                C: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:insulating_glass'
                 },
                 D: {
                     type: 'compactcrafting:block',
-                    block: 'minecraft:diamond_block'
+                    block: 'compactmachines:wall'
+                },
+                E: {
+                    type: 'compactcrafting:block',
+                    block: 'emendatusenigmatica:lumium_block'
                 }
             },
             outputs: [
@@ -280,50 +336,25 @@ events.listen('recipes', (event) => {
         //Max
         {
             recipeSize: 7,
-            layers: [
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:mixed',
-                    pattern: [
-                        ['W', 'W', 'W', 'W', 'W', 'W', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', 'E', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', '-', '-', '-', '-', '-', 'W'],
-                        ['W', 'W', 'W', 'W', 'W', 'W', 'W']
-                    ]
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:hollow',
-                    wall: 'W'
-                },
-                {
-                    type: 'compactcrafting:filled',
-                    component: 'W'
-                }
-            ],
+            layers: machineShapes.seven_by_seven,
             catalyst: {
                 id: 'fluxnetworks:flux_dust',
                 Count: 1
             },
             components: {
-                W: {
+                A: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:sheetmetal_steel'
+                },
+                B: {
+                    type: 'compactcrafting:block',
+                    block: 'minecraft:light_blue_terracotta'
+                },
+                C: {
+                    type: 'compactcrafting:block',
+                    block: 'immersiveengineering:insulating_glass'
+                },
+                D: {
                     type: 'compactcrafting:block',
                     block: 'compactmachines:wall'
                 },


### PR DESCRIPTION
Introduces new Compact Machine recipes to bypass an issue whereby mixed sections wouldn't work if they contained empty spaces.

As a result, this reduces the amount of Compact Machine Walls are required for each craft, while also increasing the total number of blocks required. This mostly requires simple materials such as Sheet Metal and Concrete.

In addition, a few quests have been added to introduce people to the concept of Compact Machine Crafting.

Resolves #2061 and partially resolves #2056.

As a visual aid, the new recipes look something like this: 

![image](https://user-images.githubusercontent.com/9543430/116338825-58248780-a7aa-11eb-84a2-a330d94ecfea.png)

Lower tier ones are 5x5x5 crafts and use varying materials, such as black sheet metal which uses any spare metal to craft and different colors of concrete. Upper tiers are 7x7x7 and use steel sheet metal and more colors of concrete. Each tier has a unique core of metal. 