### PR TITLE
Preliminary Blood Magic and Occultism Progression

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -3,22 +3,11 @@ events.listen('recipes', (event) => {
         return;
     }
 
-    const idRemovals = [
-        'architects_palette:sunmetal_blend',
-        'pneumaticcraft:explosion_crafting/compressed_iron_ingot',
-        'pneumaticcraft:explosion_crafting/compressed_iron_block',
-        'minecraft:conduit'
-    ];
+    const idRemovals = ['ars_nouveau:stone_2', 'minecraft:leather_to_stripes'];
 
     const outputRemovals = ['create:andesite_alloy', 'tiab:timeinabottle'];
 
-    const patchouli_safe_removals = [
-        { output: 'ars_nouveau:magic_clay', id: 'ars_nouveau:magic_clay' },
-        { output: 'ars_nouveau:arcane_stone', id: 'ars_nouveau:arcane_stone' },
-        { output: 'ars_nouveau:arcane_stone', id: 'ars_nouveau:stone_2' },
-        { output: 'naturesaura:wood_stand', id: 'naturesaura:wood_stand' },
-        { output: 'naturesaura:gold_fiber', id: 'naturesaura:gold_fiber' }
-    ];
+    const patchouli_safe_removals = [];
 
     idRemovals.forEach((id) => {
         event.remove({ id: id });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -234,6 +234,41 @@ events.listen('recipes', (event) => {
                 A: 'architects_palette:sunmetal_brick'
             },
             id: 'architects_palette:sunmetal_block'
+        },
+        {
+            output: 'bloodmagic:altar',
+            pattern: ['ABA', 'CDC', 'EEE'],
+            key: {
+                A: 'eidolon:gold_inlay',
+                B: 'eidolon:crucible',
+                C: 'occultism:otherstone',
+                D: 'minecraft:heart_of_the_sea',
+                E: '#forge:ingots/arcane_gold'
+            },
+            id: 'bloodmagic:blood_altar'
+        },
+        {
+            output: 'bloodmagic:alchemytable',
+            pattern: ['ABC', 'DDD', 'EEE'],
+            key: {
+                A: 'minecraft:brewing_stand',
+                B: 'bloodmagic:blankslate',
+                C: 'supplementaries:jar_tinted',
+                D: 'eidolon:wicked_weave',
+                E: 'eidolon:stone_altar'
+            },
+            id: 'bloodmagic:alchemy_table'
+        },
+        {
+            output: 'occultism:divination_rod',
+            pattern: [' CD', ' AC', 'AB '],
+            key: {
+                A: 'betterendforge:leather_wrapped_stick',
+                B: 'eidolon:tattered_cloth',
+                C: '#forge:rods/copper',
+                D: 'occultism:spirit_attuned_gem'
+            },
+            id: 'occultism:crafting/divination_rod'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -9,7 +9,8 @@ events.listen('recipes', (event) => {
                 inputs: ['#forge:dusts/silver', '#forge:dusts/silver', '#forge:dusts/silver', '#forge:dusts/silver'],
                 reagent: '#forge:dusts/sulfur',
                 output: 'architects_palette:sunmetal_blend',
-                count: 4
+                count: 4,
+                id: 'architects_palette:sunmetal_blend'
             },
             {
                 inputs: [
@@ -35,7 +36,49 @@ events.listen('recipes', (event) => {
                 ],
                 reagent: 'betterendforge:silk_fiber',
                 output: 'naturesaura:gold_fiber',
-                count: 4
+                count: 4,
+                id: 'naturesaura:gold_fiber'
+            },
+            {
+                inputs: [
+                    'eidolon:pewter_inlay',
+                    'betterendforge:andesite_pedestal',
+                    'eidolon:pewter_inlay',
+                    'thermal:phytogro'
+                ],
+                reagent: 'eidolon:crucible',
+                output: 'botania:apothecary_default',
+                count: 1,
+                id: 'botania:apothecary_default'
+            },
+            {
+                inputs: [
+                    'occultism:otherstone',
+                    '#forge:dusts/mana',
+                    'occultism:otherstone',
+                    'eidolon:pewter_inlay',
+                    'eidolon:pewter_inlay',
+                    'occultism:otherstone',
+                    'occultism:otherstone',
+                    'occultism:otherstone'
+                ],
+                reagent: 'minecraft:bowl',
+                output: 'occultism:sacrificial_bowl',
+                count: 1,
+                id: 'occultism:crafting/sacrificial_bowl'
+            },
+            {
+                inputs: [
+                    'eidolon:gold_inlay',
+                    '#forge:dusts/mana',
+                    'eidolon:gold_inlay',
+                    'eidolon:gold_inlay',
+                    'eidolon:gold_inlay'
+                ],
+                reagent: 'occultism:sacrificial_bowl',
+                output: 'occultism:golden_sacrificial_bowl',
+                count: 1,
+                id: 'occultism:crafting/golden_sacrificial_bowl'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -8,7 +8,65 @@ events.listen('recipes', (event) => {
                 syphon: 500,
                 ticks: 200,
                 orbLevel: 1,
-                id: 'arcane_ash'
+                id: 'bloodmagic:alchemytable/arcane_ash'
+            },
+            {
+                inputs: [
+                    'bloodmagic:plantoil',
+                    'alexsmobs:rattlesnake_rattle',
+                    '#forge:dusts/apatite',
+                    '#forge:dusts/charcoal'
+                ],
+                output: 'bloodmagic:basiccuttingfluid',
+                count: 1,
+                syphon: 1000,
+                ticks: 200,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/basic_cutting_fluid'
+            },
+            {
+                inputs: [
+                    'upgrade_aquatic:glowing_ink_sac',
+                    '#forge:dusts/aluminum',
+                    '#forge:dusts/aluminum',
+                    '#forge:dusts/aluminum',
+                    '#forge:dusts/aluminum'
+                ],
+                output: 'astralsorcery:illumination_powder',
+                count: 16,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: [
+                    'occultism:purified_ink',
+                    '#forge:dusts/obsidian',
+                    '#forge:dusts/obsidian',
+                    '#forge:dusts/obsidian',
+                    '#forge:dusts/obsidian'
+                ],
+                output: 'astralsorcery:nocturnal_powder',
+                count: 16,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: [
+                    'bloodmagic:plantoil',
+                    'occultism:burnt_otherstone',
+                    'occultism:burnt_otherstone',
+                    'occultism:otherworld_ashes',
+                    'occultism:otherworld_ashes',
+                    'occultism:otherworld_ashes'
+                ],
+                output: 'occultism:chalk_white_impure',
+                count: 1,
+                syphon: 500,
+                ticks: 200,
+                orbLevel: 1,
+                id: 'occultism:crafting/chalk_white_impure'
             }
         ]
     };
@@ -20,7 +78,7 @@ events.listen('recipes', (event) => {
             .ticks(recipe.ticks)
             .upgradeLevel(recipe.orbLevel);
         if (recipe.id) {
-            re.id(`bloodmagic:alchemytable/${recipe.id}`);
+            re.id(recipe.id);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -1,4 +1,7 @@
 events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
     data = {
         recipes: [
             {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -1,0 +1,38 @@
+events.listen('recipes', (event) => {
+    data = {
+        recipes: [
+            {
+                input: 'eidolon:unholy_symbol',
+                output: 'bloodmagic:weakbloodorb',
+                syphon: 7000,
+                ticks: 200,
+                altarLevel: 0,
+                consumptionRate: 5,
+                drainRate: 1,
+                id: 'bloodmagic:altar/weakbloodorb'
+            },
+            {
+                input: 'occultism:chalk_white_impure',
+                output: 'occultism:chalk_white',
+                syphon: 1000,
+                ticks: 200,
+                altarLevel: 0,
+                consumptionRate: 5,
+                drainRate: 1,
+                id: 'occultism:spirit_fire/chalk_white'
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.bloodmagic
+            .altar(recipe.output, recipe.input)
+            .upgradeLevel(recipe.altarLevel)
+            .altarSyphon(recipe.syphon)
+            .consumptionRate(recipe.consumptionRate)
+            .drainRate(recipe.drainRate);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -1,0 +1,34 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            inputs: [
+                { tag: 'botania:petals/white' },
+                { tag: 'botania:petals/white' },
+                { tag: 'botania:petals/white' },
+                { tag: 'botania:petals/white' },
+                { item: 'thermal:phytogro' }
+            ],
+            output: { item: 'botania:pure_daisy' },
+            id: 'pure_daisy'
+        },
+        {
+            inputs: [{ tag: 'forge:mushrooms' }, { item: 'thermal:phytogro' }],
+            output: { item: 'eidolon:fungus_sprouts', count: 2 }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'botania:petal_apothecary',
+            output: recipe.output,
+            ingredients: recipe.inputs
+        });
+        if (recipe.id) {
+            re.id(`botania:petal_apothecary/${recipe.id}`);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
@@ -1,3 +1,7 @@
+if (global.isExpertMode == false) {
+    return;
+}
+
 function cuttingRecipe(ingredient, tool, result) {
     return {
         type: 'farmersdelight:cutting',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
@@ -1,0 +1,29 @@
+function cuttingRecipe(ingredient, tool, result) {
+    return {
+        type: 'farmersdelight:cutting',
+        ingredients: [ingredient],
+        tool: tool,
+        result: result
+    };
+}
+
+function filletRecipe(fish, filletCount) {
+    return cuttingRecipe(Ingredient.of(fish), Ingredient.of('#forge:tools/knives'), [
+        Item.of('aquaculture:fish_fillet_raw', filletCount),
+        Item.of('minecraft:bone_meal', Math.ceil(filletCount / 3))
+    ]);
+}
+
+events.listen('recipes', (event) => {
+    var data = {
+        recipes: [
+            cuttingRecipe(Ingredient.of('minecraft:leather'), Ingredient.of('#forge:tools/knives'), [
+                Item.of('betterendforge:leather_stripe', 3)
+            ])
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        event.custom(recipe);
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
@@ -36,7 +36,8 @@ events.listen('recipes', (event) => {
                 entries: [{ result: { item: 'pneumaticcraft:ingot_iron_compressed', count: 4 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
-            }
+            },
+            id: 'pneumaticcraft:explosion_crafting/compressed_iron_ingot'
         },
         {
             inputs: [
@@ -48,7 +49,8 @@ events.listen('recipes', (event) => {
                 entries: [{ result: { item: 'pneumaticcraft:compressed_iron_block', count: 4 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
-            }
+            },
+            id: 'pneumaticcraft:explosion_crafting/compressed_iron_block'
         },
         {
             inputs: [{ tag: 'forge:gems/fluorite', count: 1 }],
@@ -85,10 +87,13 @@ events.listen('recipes', (event) => {
     ];
 
     recipes.forEach((recipe) => {
-        event.custom({
+        const re = event.custom({
             type: 'interactio:item_explode',
             inputs: recipe.inputs,
             output: recipe.output
         });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
@@ -17,7 +17,8 @@ events.listen('recipes', (event) => {
                 empty_weight: 0,
                 rolls: 1
             },
-            consume_fluid: 1.0
+            consume_fluid: 1.0,
+            id: 'ars_nouveau:magic_clay'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -26,7 +26,8 @@ events.listen('recipes', (event) => {
                 entries: [{ result: { item: 'ars_nouveau:arcane_stone', count: 1 }, weight: 9 }],
                 empty_weight: 1,
                 rolls: 4
-            }
+            },
+            id: 'ars_nouveau:arcane_stone'
         },
         {
             inputs: [
@@ -40,7 +41,8 @@ events.listen('recipes', (event) => {
                 entries: [{ result: { item: 'minecraft:conduit', count: 1 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
-            }
+            },
+            id: 'minecraft:conduit'
         },
         {
             inputs: [
@@ -53,7 +55,8 @@ events.listen('recipes', (event) => {
                 entries: [{ result: { item: 'naturesaura:wood_stand', count: 1 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
-            }
+            },
+            id: 'naturesaura:wood_stand'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/spirit_fire.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/spirit_fire.js
@@ -7,19 +7,27 @@ events.listen('recipes', (event) => {
         {
             input: 'ars_nouveau:magic_clay',
             output: 'bloodmagic:arcaneashes'
+        },
+        {
+            input: 'ars_nouveau:arcane_stone',
+            output: 'occultism:otherstone',
+            id: 'otherstone'
+        },
+        {
+            input: 'eidolon:shadow_gem',
+            output: 'occultism:spirit_attuned_gem',
+            id: 'spirit_attuned_gem'
         }
     ];
 
     recipes.forEach((recipe) => {
-        let input = recipe.input.charAt(0) == '#' ? { tag: recipe.input.slice(1) } : { item: recipe.input };
-
         let re = event.custom({
             type: 'occultism:spirit_fire',
-            ingredient: input,
-            result: { item: recipe.output }
+            ingredient: Ingredient.of(recipe.input).toJson(),
+            result: Ingredient.of(recipe.output).toJson()
         });
         if (recipe.id) {
-            re.id(recipe.id);
+            re.id(`occultism:spirit_fire/${recipe.id}`);
         }
     });
 });


### PR DESCRIPTION
Reworked ID removals to use ID replacements where valid. This requires an update to KubeJS.

Eidolon will open up the Blood Altar, Alchemy Table, and Low Grade rituals in Occultism, opening up some extra crafting mechanics. Blood Altar Tier 2 and up will require parallel progress in Occultism.

Petal Apothecary can make Sprouted Fungus, making a simpler way to create potions. I'm thinking enchanting should be pretty late game, considering the power level. We have a lot of really fancy potions and a cool new system with Ars Nouveau for making some very powerful brews, but enchants almost entirely invalidate potions. By making them easier and enchanting later, I'd hope to get people to use them a bit more.

Alchemy Table recipe for Nocturnal Powder and Illumination powder added. Nice reagents for other crafting, and very handy when searching for mobs early on.

Cutting Fluid made a bit easier, but more varied. Now requires snake rattles (farmable), apatite dust (goes a long way), charcoal dust, and plant oil. This should hopefully give magic players a decently automatable ore doubling system.

Considering boosting output for ores, considering Create's Milling is also fairly early game and considerably less effort.

Otherstone now crafted from Arcane Stone

Leather Stripe now a cutting board recipe

Spirit Attuned gem now made from Shadow Gem

New Recipe for Divination Rod

Impure White chalk moved to Alchemy Table

White Chalk moved to Blood Altar

Occultism Bowl recipes moved to Enchanting Apparatus