### PR TITLE
Occultism and Blood Magic Progression

### DIFF
--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -22,5 +22,10 @@
     "block.naturesaura.infused_iron_block": "Infused Sunmetal Block",
     "item.naturesaura.infused_iron": "Infused Sunmetal Ingot",
 
+    "block.eidolon.candle": "Consecrated Candle",
+    "block.eidolon.candlestick": "Consecrated Candlestick",
+
+    "block.occultism.candle_white": "Profaned Candle",
+
     "": ""
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -216,6 +216,24 @@ events.listen('recipes', (event) => {
             key: {
                 A: 'minecraft:snow_block'
             }
+        },
+        {
+            output: 'buildersaddition:candle',
+            pattern: ['A', 'B'],
+            key: {
+                A: 'buildersaddition:large_candle',
+                B: '#forge:nuggets/gold'
+            },
+            id: 'buildersaddition:candle'
+        },
+        {
+            output: 'buildersaddition:soul_candle',
+            pattern: ['A', 'B'],
+            key: {
+                A: 'buildersaddition:large_soul_candle',
+                B: '#forge:nuggets/gold'
+            },
+            id: 'buildersaddition:soul_candle'
         }
     ];
 
@@ -553,18 +571,7 @@ events.listen('recipes', (event) => {
                 F: 'morphtool:tool'
             }
         ),
-        shapedRecipe(Item.of('occultism:candle_white'), [' B ', 'AAA', 'AAA'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
-        shapedRecipe(Item.of('eidolon:candle', 4), ['B', 'A'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
-        shapedRecipe(Item.of('quark:white_candle', 2), ['B', 'A', 'A'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
+
         shapedRecipe(Item.of('byg:embur_hyphae', 3), ['AA', 'AA'], {
             A: 'byg:embur_pedu'
         }),

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -198,10 +198,6 @@ events.listen('recipes', (event) => {
             }),
             inputs: ['minecraft:book', '#forge:bookshelves']
         },
-        {
-            output: Item.of('buildersaddition:large_candle', 4),
-            inputs: ['#forge:wax', '#forge:wax', '#forge:wax', '#forge:string']
-        },
         { output: Item.of('occultism:tallow', 9), inputs: ['quark:tallow_block'] },
         {
             output: 'minecraft:writable_book',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -3,7 +3,11 @@ events.listen('recipes', (event) => {
         return;
     }
 
-    const idRemovals = ['ars_nouveau:stone_2', 'minecraft:leather_to_stripes'];
+    const idRemovals = [
+        'ars_nouveau:stone_2',
+        'minecraft:leather_to_stripes',
+        'quark:building/crafting/candles/candle_basic'
+    ];
 
     const outputRemovals = ['create:andesite_alloy', 'tiab:timeinabottle'];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -269,6 +269,16 @@ events.listen('recipes', (event) => {
                 D: 'occultism:spirit_attuned_gem'
             },
             id: 'occultism:crafting/divination_rod'
+        },
+        {
+            output: 'meetyourfight:caged_heart',
+            pattern: ['AAA', 'ABA', 'ACA'],
+            key: {
+                A: '#forge:bones',
+                B: 'eidolon:zombie_heart',
+                C: 'meetyourfight:mossy_tooth'
+            },
+            id: 'meetyourfight:caged_heart'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -79,6 +79,38 @@ events.listen('recipes', (event) => {
                 output: 'occultism:golden_sacrificial_bowl',
                 count: 1,
                 id: 'occultism:crafting/golden_sacrificial_bowl'
+            },
+            {
+                inputs: [
+                    'eidolon:pewter_inlay',
+                    'occultism:stable_wormhole',
+                    'eidolon:pewter_inlay',
+                    'occultism:otherstone',
+                    'occultism:otherstone',
+                    'eidolon:pewter_inlay',
+                    'occultism:otherstone_pedestal',
+                    'eidolon:pewter_inlay'
+                ],
+                reagent: 'eidolon:crucible',
+                output: 'bloodmagic:soulforge',
+                count: 1,
+                id: 'bloodmagic:soul_forge'
+            },
+            {
+                inputs: [
+                    'eidolon:gold_inlay',
+                    '#forge:ingots/silver',
+                    'eidolon:gold_inlay',
+                    '#forge:ingots/silver',
+                    '#forge:ingots/silver',
+                    'eidolon:gold_inlay',
+                    '#forge:ingots/silver',
+                    'eidolon:gold_inlay'
+                ],
+                reagent: 'astralsorcery:aquamarine',
+                output: 'undergarden:catalyst',
+                count: 1,
+                id: 'undergarden:catalyst'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -111,6 +111,22 @@ events.listen('recipes', (event) => {
                 output: 'undergarden:catalyst',
                 count: 1,
                 id: 'undergarden:catalyst'
+            },
+            {
+                inputs: [
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle',
+                    'buildersaddition:large_soul_candle'
+                ],
+                reagent: 'bloodmagic:holy_water_anointment',
+                output: 'eidolon:candle',
+                count: 8,
+                id: 'eidolon:candle'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -67,6 +67,48 @@ events.listen('recipes', (event) => {
                 ticks: 200,
                 orbLevel: 1,
                 id: 'occultism:crafting/chalk_white_impure'
+            },
+            {
+                inputs: [
+                    'bloodmagic:plantoil',
+                    'occultism:chalk_white_impure',
+                    'architects_palette:sunmetal_blend',
+                    'naturesaura:gold_powder'
+                ],
+                output: 'occultism:chalk_gold_impure',
+                count: 1,
+                syphon: 1000,
+                ticks: 200,
+                orbLevel: 2,
+                id: 'occultism:crafting/chalk_gold_impure'
+            },
+            {
+                inputs: [
+                    'bloodmagic:plantoil',
+                    'occultism:chalk_white_impure',
+                    'betterendforge:enchanted_petal',
+                    'eidolon:ender_calx'
+                ],
+                output: 'occultism:chalk_purple_impure',
+                count: 1,
+                syphon: 1500,
+                ticks: 200,
+                orbLevel: 3,
+                id: 'occultism:crafting/chalk_purple_impure'
+            },
+            {
+                inputs: [
+                    'bloodmagic:plantoil',
+                    'occultism:chalk_white_impure',
+                    'occultism:afrit_essence',
+                    'create:cinder_flour'
+                ],
+                output: 'occultism:chalk_red_impure',
+                count: 1,
+                syphon: 5000,
+                ticks: 200,
+                orbLevel: 4,
+                id: 'occultism:crafting/chalk_red_impure'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -8,21 +8,64 @@ events.listen('recipes', (event) => {
                 input: 'eidolon:unholy_symbol',
                 output: 'bloodmagic:weakbloodorb',
                 syphon: 7000,
-                ticks: 200,
                 altarLevel: 0,
                 consumptionRate: 5,
                 drainRate: 1,
                 id: 'bloodmagic:altar/weakbloodorb'
             },
             {
+                input: 'meetyourfight:caged_heart',
+                output: 'bloodmagic:apprenticebloodorb',
+                syphon: 7000,
+                altarLevel: 1,
+                consumptionRate: 5,
+                drainRate: 5,
+                id: 'bloodmagic:altar/apprenticebloodorb'
+            },
+            {
                 input: 'occultism:chalk_white_impure',
                 output: 'occultism:chalk_white',
-                syphon: 1000,
-                ticks: 200,
+                syphon: 7000,
                 altarLevel: 0,
                 consumptionRate: 5,
                 drainRate: 1,
                 id: 'occultism:spirit_fire/chalk_white'
+            },
+            {
+                input: 'occultism:chalk_gold_impure',
+                output: 'occultism:chalk_gold',
+                syphon: 7000,
+                altarLevel: 1,
+                consumptionRate: 5,
+                drainRate: 5,
+                id: 'occultism:spirit_fire/chalk_gold'
+            },
+            {
+                input: 'occultism:chalk_purple_impure',
+                output: 'occultism:chalk_purple',
+                syphon: 25000,
+                altarLevel: 2,
+                consumptionRate: 20,
+                drainRate: 20,
+                id: 'occultism:spirit_fire/chalk_purple'
+            },
+            {
+                input: 'occultism:chalk_red_impure',
+                output: 'occultism:chalk_red',
+                syphon: 40000,
+                altarLevel: 3,
+                consumptionRate: 30,
+                drainRate: 50,
+                id: 'occultism:spirit_fire/chalk_red'
+            },
+            {
+                input: 'ars_nouveau:mana_fiber',
+                output: 'bloodmagic:soulsnare',
+                syphon: 500,
+                altarLevel: 1,
+                consumptionRate: 5,
+                drainRate: 1,
+                id: 'bloodmagic:altar/soul_snare'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
@@ -1,0 +1,71 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    var data = {
+        recipes: [
+            {
+                inputs: ['#forge:wax', '#forge:string'],
+                output: 'buildersaddition:large_candle',
+                count: 1,
+                cookingTime: 100,
+                id: 'buildersaddition:large_candle'
+            },
+            {
+                inputs: ['#forge:tallow', '#forge:string'],
+                output: 'buildersaddition:large_candle',
+                count: 1,
+                cookingTime: 100
+            },
+            {
+                inputs: ['minecraft:honeycomb', '#forge:string'],
+                output: 'buildersaddition:large_candle',
+                count: 1,
+                cookingTime: 100
+            },
+            {
+                inputs: ['minecraft:soul_sand', 'buildersaddition:large_candle'],
+                output: 'buildersaddition:large_soul_candle',
+                count: 1,
+                cookingTime: 100,
+                id: 'buildersaddition:large_soul_candle_soul_sand'
+            },
+            {
+                inputs: ['minecraft:soul_soil', 'buildersaddition:large_candle'],
+                output: 'buildersaddition:large_soul_candle',
+                count: 1,
+                cookingTime: 100,
+                id: 'buildersaddition:large_soul_candle_soul_soil'
+            }
+        ]
+    };
+
+    colors.forEach((color) => {
+        data.recipes.push({
+            inputs: [`#forge:dyes/${color}`, 'buildersaddition:large_candle'],
+            output: `quark:${color}_candle`,
+            count: 1,
+            cookingTime: 100,
+            id: `quark:building/crafting/candles/${color}_candle`
+        });
+    });
+
+    data.recipes.forEach((recipe) => {
+        let ingredients = [];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input).toJson());
+        });
+
+        const re = event.custom({
+            type: 'farmersdelight:cooking',
+            ingredients: ingredients,
+            result: Ingredient.of(recipe.output).toJson(),
+            cookingtime: recipe.cookingTime
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cutting.js
@@ -1,7 +1,3 @@
-if (global.isExpertMode == false) {
-    return;
-}
-
 function cuttingRecipe(ingredient, tool, result) {
     return {
         type: 'farmersdelight:cutting',
@@ -11,14 +7,11 @@ function cuttingRecipe(ingredient, tool, result) {
     };
 }
 
-function filletRecipe(fish, filletCount) {
-    return cuttingRecipe(Ingredient.of(fish), Ingredient.of('#forge:tools/knives'), [
-        Item.of('aquaculture:fish_fillet_raw', filletCount),
-        Item.of('minecraft:bone_meal', Math.ceil(filletCount / 3))
-    ]);
-}
-
 events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
     var data = {
         recipes: [
             cuttingRecipe(Ingredient.of('minecraft:leather'), Ingredient.of('#forge:tools/knives'), [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -57,6 +57,21 @@ events.listen('recipes', (event) => {
                 rolls: 1
             },
             id: 'naturesaura:wood_stand'
+        },
+        {
+            inputs: [
+                { item: 'undergarden:music_disc_relict', count: 1, return_chance: 1.0 },
+                { item: 'aquaculture:fish_bones', count: 1 },
+                { tag: 'forge:dusts/lapis', count: 2 },
+                { item: 'minecraft:fermented_spider_eye', count: 2 },
+                { item: 'undergarden:raw_dweller_meat', count: 4 }
+            ],
+            output: {
+                entries: [{ result: { item: 'meetyourfight:fossil_bait', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            },
+            id: 'meetyourfight:fossil_bait'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -11,7 +11,7 @@ events.listen('recipes', (event) => {
                 aura_type: 'naturesaura:overworld',
                 aura: 15000,
                 time: 80,
-                id: 'infused_iron'
+                id: 'naturesaura:altar/infused_iron'
             },
             {
                 input: 'architects_palette:sunmetal_block',
@@ -19,22 +19,34 @@ events.listen('recipes', (event) => {
                 aura_type: 'naturesaura:overworld',
                 aura: 135000,
                 time: 700,
-                id: 'infused_iron_block'
+                id: 'naturesaura:altar/infused_iron_block'
+            },
+            {
+                input: 'eidolon:candle',
+                output: 'occultism:candle_white',
+                aura_type: 'naturesaura:nether',
+                aura: 5000,
+                time: 60,
+                id: 'occultism:crafting/candle'
             }
         ]
     };
 
     data.recipes.forEach((recipe) => {
-        const re = event.custom({
+        let constructed_recipe = {
             type: 'naturesaura:altar',
-            input: recipe.input.charAt(0) == '#' ? { tag: recipe.input.slice(1) } : { item: recipe.input },
-            output: { item: recipe.output },
+            input: Ingredient.of(recipe.input).toJson(),
+            output: Ingredient.of(recipe.output).toJson(),
             aura_type: recipe.aura_type,
             aura: recipe.aura,
             time: recipe.time
-        });
+        };
+        if (recipe.catalyst) {
+            constructed_recipe.catalyst = Ingredient.of(recipe.catalyst).toJson();
+        }
+        const re = event.custom(constructed_recipe);
         if (recipe.id) {
-            re.id(`naturesaura:altar/${recipe.id}`);
+            re.id(recipe.id);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
@@ -58,6 +58,30 @@ events.listen('recipes', (event) => {
             key: {
                 A: '#minecraft:logs'
             }
+        },
+        {
+            output: Item.of('occultism:candle_white'),
+            pattern: [' B ', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:wax',
+                B: '#forge:string'
+            }
+        },
+        {
+            output: Item.of('eidolon:candle', 4),
+            pattern: ['B', 'A'],
+            key: {
+                A: '#forge:wax',
+                B: '#forge:string'
+            }
+        },
+        {
+            output: Item.of('quark:white_candle', 2),
+            pattern: ['B', 'A', 'A'],
+            key: {
+                A: '#forge:wax',
+                B: '#forge:string'
+            }
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
@@ -8,6 +8,10 @@ events.listen('recipes', (event) => {
             output: 'mekanism:hdpe_sheet',
             inputs: [['immersiveengineering:hammer', 'emendatusenigmatica:enigmatic_hammer'], 'mekanism:hdpe_pellet'],
             id: 'mekanism:hdpe_sheet'
+        },
+        {
+            output: Item.of('buildersaddition:large_candle', 4),
+            inputs: ['#forge:wax', '#forge:wax', '#forge:wax', '#forge:string']
         }
     ];
 


### PR DESCRIPTION
Next step in Occultism and Blood Magic Progression will go hand in hand. Progressing to higher altars unlocks more and more rituals in occultism.

Phase 1

Go to Undergarden with Catalyst
Get Relict Disc via trade. Specific disc for now.. may make it use any if this proves too hard to find.
Make Fossil Bait with Disc (lightning recipe, disc returned 100%)
Craft Caged Heart using Mossy Tooth from the boss fight
Craft Apprentice Orb from Caged Heart
Craft Gold Chalk using new orb in Alchemy Table
Craft Stable Wormhole with newly available rituals
Craft Hellfire Forge with Stable Wormhole

At this point all rituals using Gold or White chalk would be available. Next steps will delve into demonic will to proceed. 