### PR TITLE
Add missing break statement for 'avocado' wood variant case.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/constants/wood_variants.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/wood_variants.js
@@ -213,6 +213,7 @@ woodVariantsToConstruct.forEach((variant) => {
             logBlockStripped = 'minecraft:stripped_oak_log';
             woodBlockStripped = 'minecraft:stripped_oak_wood';
             plankBlock = 'minecraft:oak_planks';
+            break;
         default:
     }
 


### PR DESCRIPTION
Add missing break statement for 'avocado' wood variant case to prevent case fall-through. While the default case is not currently used, this will prevent it being triggered for 'avocado' should that ever change.