### PR TITLE
Fix an issue with the last PR

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/apotheosis/fletching.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/apotheosis/fletching.js
@@ -62,7 +62,7 @@ events.listen('recipes', (event) => {
             // alex's mobs
             {
                 ingredients: [{item: 'alexsmobs:shark_tooth'}, { tag: 'forge:rods/wooden' }, { item: 'minecraft:kelp' }],
-                result: Item.of('alexsmobs:shark_tooth_arrow', 5)
+                result: Item.of('alexsmobs:shark_tooth_arrow', 8)
             },
         ]
     };


### PR DESCRIPTION
...where the shark tooth arrow's fletching recipe gave less than the crafting table one.
Changes fletching shark tooth arrow recipe output from 5 to 8. The pitfalls of copy-pasting your previous work...