### PR TITLE
Added missing titles to quest rewards

### DIFF
--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -28,6 +28,7 @@
 			rewards: [{
 				id: "00000000000003AF",
 				type: "item",
+				title: "Novice Spell Book",
 				item: "ars_nouveau:novice_spell_book"
 			}]
 		},
@@ -50,6 +51,7 @@
 			rewards: [{
 				id: "00000000000005F5",
 				type: "item",
+				title: "Glyph: AOE",
 				item: "ars_nouveau:glyph_aoe"
 			}]
 		},
@@ -91,6 +93,7 @@
 				{
 					id: "00000000000003C1",
 					type: "item",
+					title: "Worldshaper's Sextant",
 					item: "botania:sextant"
 				},
 				{
@@ -124,6 +127,7 @@
 			rewards: [{
 				id: "0000000000000647",
 				type: "item",
+				title: "Glyph: Craft",
 				item: "ars_nouveau:glyph_craft"
 			}]
 		},
@@ -152,6 +156,7 @@
 			rewards: [{
 				id: "0000000000000669",
 				type: "item",
+				title: "Glyph: Grow",
 				item: "ars_nouveau:glyph_grow"
 			}]
 		},
@@ -180,6 +185,7 @@
 			rewards: [{
 				id: "0000000000000668",
 				type: "item",
+				title: "Glyph: Split",
 				item: "ars_nouveau:glyph_split"
 			}]
 		},
@@ -245,6 +251,7 @@
 			rewards: [{
 				id: "00000000000009F6",
 				type: "item",
+				title: "Glyph: Launch",
 				item: "ars_nouveau:glyph_launch"
 			}]
 		},
@@ -303,6 +310,7 @@
 			rewards: [{
 				id: "00000000000003D4",
 				type: "item",
+				title: "Scribes Table",
 				item: "ars_nouveau:scribes_table"
 			}]
 		},
@@ -325,6 +333,7 @@
 			rewards: [{
 				id: "00000000000005F4",
 				type: "item",
+				title: "Glyph: Harvest",
 				item: "ars_nouveau:glyph_harvest"
 			}]
 		},
@@ -403,6 +412,7 @@
 			rewards: [{
 				id: "00000000000009FA",
 				type: "item",
+				title: "Jar of Voiding",
 				item: "ars_nouveau:void_jar"
 			}]
 		},
@@ -427,6 +437,7 @@
 			rewards: [{
 				id: "000000000000067F",
 				type: "item",
+				title: "Glyph: Light",
 				item: "ars_nouveau:glyph_light"
 			}]
 		},
@@ -451,6 +462,7 @@
 			rewards: [{
 				id: "00000000000003EF",
 				type: "item",
+				title: "Dominion Wand",
 				item: "ars_nouveau:dominion_wand"
 			}]
 		},
@@ -524,11 +536,13 @@
 				{
 					id: "00000000000009EA",
 					type: "item",
+					title: "Item Scroll: Allow",
 					item: "ars_nouveau:allow_scroll"
 				},
 				{
 					id: "00000000000009EB",
 					type: "item",
+					title: "Item Scroll: Deny",
 					item: "ars_nouveau:deny_scroll"
 				}
 			]
@@ -563,18 +577,21 @@
 				{
 					id: "0AC24D43ED187EBE",
 					type: "item",
+					title: "Bamboo",
 					item: "minecraft:bamboo",
 					count: 4
 				},
 				{
 					id: "4A7B725DE75256E3",
 					type: "item",
+					title: "Pumpkin Seeds",
 					item: "minecraft:pumpkin_seeds",
 					count: 4
 				},
 				{
 					id: "307E04AA8AC5B992",
 					type: "item",
+					title: "Dark Oak Sapling",
 					item: "minecraft:dark_oak_sapling",
 					count: 4
 				}
@@ -758,6 +775,7 @@
 			rewards: [{
 				id: "00000000000009FE",
 				type: "item",
+				title: "Glyph: Fortune",
 				item: "ars_nouveau:glyph_fortune"
 			}]
 		},
@@ -781,6 +799,7 @@
 			rewards: [{
 				id: "0000000000000A37",
 				type: "item",
+				title: "Glyph: Fangs",
 				item: "ars_nouveau:glyph_fangs"
 			}]
 		},
@@ -904,6 +923,7 @@
 				{
 					id: "3775F901374943C8",
 					type: "item",
+					title: "Potion of Absorption",
 					item: {
 						id: "minecraft:potion",
 						Count: 1b,
@@ -915,6 +935,7 @@
 				{
 					id: "77257BF40CBAC438",
 					type: "item",
+					title: "Potion of Fire Resistance",
 					item: {
 						id: "minecraft:potion",
 						Count: 1b,

--- a/config/ftbquests/quests/chapters/astral_sorcery_wip.snbt
+++ b/config/ftbquests/quests/chapters/astral_sorcery_wip.snbt
@@ -28,6 +28,7 @@
 			rewards: [{
 				id: "0000000000000AF6",
 				type: "item",
+				title: "Resonating Wand",
 				item: "astralsorcery:wand"
 			}]
 		},
@@ -61,6 +62,7 @@
 				{
 					id: "0000000000000BDB",
 					type: "item",
+					title: "Warp Scroll",
 					item: "ars_nouveau:warp_scroll",
 					count: 16
 				},
@@ -171,6 +173,7 @@
 				{
 					id: "0000000000000BE0",
 					type: "item",
+					title: "Aquamarine Shale",
 					item: "astralsorcery:aquamarine_sand_ore",
 					count: 8
 				},
@@ -486,6 +489,7 @@
 				{
 					id: "0000000000000C23",
 					type: "item",
+					title: "Raw Cod",
 					item: "minecraft:cod",
 					count: 16
 				}
@@ -609,6 +613,7 @@
 			rewards: [{
 				id: "0000000000000C2E",
 				type: "item",
+				title: "Cave Illuminator",
 				item: "astralsorcery:illuminator"
 			}]
 		},
@@ -797,6 +802,7 @@
 				{
 					id: "0000000000000BBC",
 					type: "item",
+					title: "Linking Tool",
 					item: "astralsorcery:linking_tool"
 				},
 				{
@@ -934,6 +940,7 @@
 			rewards: [{
 				id: "0000000000000BB0",
 				type: "item",
+				title: "Unbreaking III",
 				item: {
 					id: "minecraft:enchanted_book",
 					Count: 1b,
@@ -1358,6 +1365,7 @@
 				{
 					id: "0000000000000C21",
 					type: "item",
+					title: "Celestial Gateway",
 					item: {
 						id: "astralsorcery:celestial_gateway",
 						Count: 1b,
@@ -1400,6 +1408,7 @@
 				{
 					id: "0000000000000C2D",
 					type: "item",
+					title: "Infused Glass",
 					item: {
 						id: "astralsorcery:infused_glass",
 						Count: 1b,
@@ -1525,11 +1534,13 @@
 				{
 					id: "0000000000000C2B",
 					type: "item",
+					title: "Jukebox",
 					item: "minecraft:jukebox"
 				},
 				{
 					id: "0000000000000C2C",
 					type: "item",
+					title: "Music Disc",
 					item: "minecraft:music_disc_pigstep"
 				},
 				{

--- a/config/ftbquests/quests/chapters/blood_magic_wip.snbt
+++ b/config/ftbquests/quests/chapters/blood_magic_wip.snbt
@@ -72,6 +72,7 @@
 				{
 					id: "000000000000089D",
 					type: "item",
+					title: "Demon Will",
 					item: {
 						id: "bloodmagic:basemonstersoul",
 						Count: 1b,
@@ -117,6 +118,7 @@
 				{
 					id: "00000000000008C1",
 					type: "item",
+					title: "Sacrificial Knife",
 					item: {
 						id: "bloodmagic:sacrificialdagger",
 						Count: 1b,
@@ -160,6 +162,7 @@
 			rewards: [{
 				id: "000000000000090B",
 				type: "item",
+				title: "Sigil of the Blood Lamp",
 				item: "bloodmagic:bloodlightsigil"
 			}]
 		},
@@ -190,6 +193,7 @@
 				{
 					id: "00000000000008A5",
 					type: "item",
+					title: "Sentient Pickaxe",
 					item: {
 						id: "bloodmagic:soulpickaxe",
 						Count: 1b,
@@ -299,23 +303,27 @@
 				{
 					id: "00000000000008BB",
 					type: "item",
+					title: "Low Filter Module",
 					item: "prettypipes:low_filter_module"
 				},
 				{
 					id: "00000000000008BC",
 					type: "item",
+					title: "Low Extraction Module",
 					item: "prettypipes:low_extraction_module",
 					count: 2
 				},
 				{
 					id: "00000000000008BD",
 					type: "item",
+					title: "Stack Limiter Module",
 					item: "prettypipes:stack_size_module",
 					count: 2
 				},
 				{
 					id: "00000000000008BE",
 					type: "item",
+					title: "Pipe",
 					item: "prettypipes:pipe",
 					count: 4
 				}
@@ -340,6 +348,7 @@
 			rewards: [{
 				id: "00000000000008C3",
 				type: "item",
+				title: "Charm of Regeneration II",
 				item: {
 					id: "apotheosis:potion_charm",
 					Count: 1b,
@@ -374,6 +383,7 @@
 			rewards: [{
 				id: "00000000000008C6",
 				type: "item",
+				title: "Speed Rune",
 				item: "bloodmagic:speedrune",
 				count: 2
 			}]
@@ -411,12 +421,14 @@
 				{
 					id: "00000000000008CB",
 					type: "item",
+					title: "Sea Lantern",
 					item: "minecraft:sea_lantern",
 					count: 4
 				},
 				{
 					id: "00000000000008DA",
 					type: "item",
+					title: "Rune of Sacrifice",
 					item: "bloodmagic:sacrificerune",
 					count: 4
 				}
@@ -565,6 +577,7 @@
 			rewards: [{
 				id: "00000000000008EC",
 				type: "item",
+				title: "Rune of Capacity",
 				item: "bloodmagic:altarcapacityrune",
 				count: 8
 			}]
@@ -637,6 +650,7 @@
 			rewards: [{
 				id: "00000000000008F5",
 				type: "item",
+				title: "Demon Will Gauge",
 				item: "bloodmagic:demonwillgauge"
 			}]
 		},
@@ -738,6 +752,7 @@
 			rewards: [{
 				id: "00000000000009B1",
 				type: "item",
+				title: "Demon Will Crystal",
 				item: "bloodmagic:defaultcrystal",
 				count: 32
 			}]
@@ -884,6 +899,7 @@
 			rewards: [{
 				id: "0000000000000919",
 				type: "item",
+				title: "Divination Sigil",
 				item: "bloodmagic:divinationsigil"
 			}]
 		}

--- a/config/ftbquests/quests/chapters/botania.snbt
+++ b/config/ftbquests/quests/chapters/botania.snbt
@@ -28,6 +28,7 @@
 			rewards: [{
 				id: "0000000000000504",
 				type: "item",
+				title: "Pestle and Mortar",
 				item: "botania:pestle_and_mortar"
 			}]
 		},
@@ -61,11 +62,13 @@
 				{
 					id: "0000000000000508",
 					type: "item",
+					title: "Flower Pouch",
 					item: "botania:flower_bag"
 				},
 				{
 					id: "000000000000050D",
 					type: "item",
+					title: "Shears",
 					item: {
 						id: "minecraft:shears",
 						Count: 1b,
@@ -99,6 +102,7 @@
 			rewards: [{
 				id: "00000000000005E6",
 				type: "item",
+				title: "Floral Fertilizer",
 				item: "botania:fertilizer",
 				count: 16
 			}]
@@ -410,12 +414,18 @@
 				{
 					id: "0000000000000523",
 					type: "item",
+					title: "Open Crate",
 					item: "botania:open_crate"
 				},
 				{
 					id: "00000000000005E8",
 					type: "item",
-					item: "botania:monocle"
+					title: "Manaseer Monacle",
+					item: {
+						id: "botania:monocle",
+						Count: 1b,
+						tag: {}
+					}
 				}
 			]
 		},
@@ -714,6 +724,7 @@
 				{
 					id: "00000000000005DB",
 					type: "item",
+					title: "Managlass Vial",
 					item: "botania:vial",
 					count: 8
 				},
@@ -767,6 +778,7 @@
 				{
 					id: "0000000000000556",
 					type: "item",
+					title: "Livingwood Avatar",
 					item: "botania:avatar"
 				},
 				{
@@ -1084,6 +1096,7 @@
 			rewards: [{
 				id: "000000000000058F",
 				type: "item",
+				title: "Spark Tinkerer",
 				item: "botania:spark_changer"
 			}]
 		},
@@ -1138,6 +1151,7 @@
 			rewards: [{
 				id: "0000000000000590",
 				type: "item",
+				title: "Corporea Spark",
 				item: "botania:corporea_spark",
 				count: 8
 			}]
@@ -1183,6 +1197,7 @@
 				{
 					id: "0000000000000594",
 					type: "item",
+					title: "Green Slime Block",
 					item: "minecraft:slime_block"
 				},
 				{
@@ -1289,6 +1304,7 @@
 				{
 					id: "00000000000005CF",
 					type: "item",
+					title: "Cellular Block",
 					item: "botania:cell_block",
 					count: 8
 				},

--- a/config/ftbquests/quests/chapters/create.snbt
+++ b/config/ftbquests/quests/chapters/create.snbt
@@ -33,6 +33,7 @@
 			rewards: [{
 				id: "0000000000000CB9",
 				type: "item",
+				title: "Wrench",
 				item: "create:wrench"
 			}]
 		},
@@ -66,6 +67,7 @@
 			rewards: [{
 				id: "0000000000000D66",
 				type: "item",
+				title: "Engineer's Goggles",
 				item: "create:goggles"
 			}]
 		},
@@ -112,6 +114,7 @@
 				{
 					id: "0000000000000CC0",
 					type: "item",
+					title: "Super Glue",
 					item: {
 						id: "create:super_glue",
 						Count: 1b,
@@ -193,11 +196,13 @@
 				{
 					id: "0000000000000CCA",
 					type: "item",
+					title: "Analog Lever",
 					item: "create:analog_lever"
 				},
 				{
 					id: "0000000000000D73",
 					type: "item",
+					title: "Magma Block",
 					item: "minecraft:magma_block",
 					count: 4
 				}
@@ -241,6 +246,7 @@
 				{
 					id: "0000000000000D8A",
 					type: "item",
+					title: "Blast Furnace",
 					item: "minecraft:blast_furnace"
 				}
 			]
@@ -275,6 +281,7 @@
 				{
 					id: "0000000000000D80",
 					type: "item",
+					title: "Kelp",
 					item: "minecraft:kelp",
 					count: 16
 				}
@@ -485,6 +492,7 @@
 				{
 					id: "0000000000000D5B",
 					type: "item",
+					title: "Large Cogwheel",
 					item: "create:large_cogwheel"
 				},
 				{
@@ -544,6 +552,7 @@
 			rewards: [{
 				id: "0000000000000CF1",
 				type: "item",
+				title: "Encased Fan",
 				item: "create:encased_fan"
 			}]
 		},
@@ -1219,6 +1228,7 @@
 			rewards: [{
 				id: "0000000000000D65",
 				type: "item",
+				title: "Minecart",
 				item: "minecraft:minecart"
 			}]
 		},
@@ -1251,6 +1261,7 @@
 				{
 					id: "0000000000000D8C",
 					type: "item",
+					title: "Piston Extension Pole",
 					item: "create:piston_extension_pole",
 					count: 8
 				}
@@ -1706,6 +1717,7 @@
 			rewards: [{
 				id: "1CC172C5323EADC6",
 				type: "item",
+				title: "Empty Schematic",
 				item: "create:empty_schematic"
 			}]
 		},
@@ -1736,6 +1748,7 @@
 			rewards: [{
 				id: "123B498A6DDBFD23",
 				type: "item",
+				title: "Gunpowder",
 				item: "minecraft:gunpowder",
 				count: 16
 			}]

--- a/config/ftbquests/quests/chapters/eidolon_wip.snbt
+++ b/config/ftbquests/quests/chapters/eidolon_wip.snbt
@@ -71,12 +71,14 @@
 				{
 					id: "0000000000000ECE",
 					type: "item",
+					title: "Candle",
 					item: "eidolon:candle",
 					count: 2
 				},
 				{
 					id: "0000000000000ECF",
 					type: "item",
+					title: "Zombie Head",
 					item: "minecraft:zombie_head"
 				}
 			]
@@ -150,12 +152,14 @@
 				{
 					id: "0000000000000EC6",
 					type: "item",
+					title: "Stone Hand",
 					item: "eidolon:stone_hand",
 					count: 2
 				},
 				{
 					id: "0000000000000EC7",
 					type: "item",
+					title: "Enchanted Ash",
 					item: "eidolon:enchanted_ash",
 					count: 16
 				}
@@ -182,6 +186,7 @@
 			rewards: [{
 				id: "0000000000000EC9",
 				type: "item",
+				title: "Potion of Harming",
 				item: {
 					id: "minecraft:potion",
 					Count: 1b,
@@ -222,6 +227,7 @@
 				{
 					id: "0000000000000EBC",
 					type: "item",
+					title: "Pewter Blend",
 					item: "eidolon:pewter_blend",
 					count: 8
 				},
@@ -260,23 +266,27 @@
 				{
 					id: "0000000000000EBE",
 					type: "item",
+					title: "Redstone Dust",
 					item: "minecraft:redstone",
 					count: 2
 				},
 				{
 					id: "0000000000000EBF",
 					type: "item",
+					title: "Soul Shard",
 					item: "eidolon:soul_shard"
 				},
 				{
 					id: "0000000000000EC0",
 					type: "item",
+					title: "Gold Ingot",
 					item: "minecraft:gold_ingot",
 					count: 2
 				},
 				{
 					id: "0000000000000EC1",
 					type: "item",
+					title: "Magma Block",
 					item: "minecraft:magma_block"
 				}
 			]
@@ -368,6 +378,7 @@
 			rewards: [{
 				id: "0000000000000ED0",
 				type: "item",
+				title: "Basic Amulet",
 				item: "eidolon:basic_amulet"
 			}]
 		},
@@ -404,6 +415,7 @@
 				{
 					id: "0000000000000ED1",
 					type: "item",
+					title: "Potion of Wither",
 					item: {
 						id: "minecraft:potion",
 						Count: 1b,
@@ -415,6 +427,7 @@
 				{
 					id: "0000000000000ED2",
 					type: "item",
+					title: "Wither Skull Fragment",
 					item: "wstweaks:fragment",
 					count: 3
 				}
@@ -452,6 +465,7 @@
 			rewards: [{
 				id: "0000000000000ED3",
 				type: "item",
+				title: "Wither Skull Fragment",
 				item: "wstweaks:fragment",
 				count: 3
 			}]
@@ -506,6 +520,7 @@
 			rewards: [{
 				id: "0000000000000ED5",
 				type: "item",
+				title: "Warped Sprouts",
 				item: "eidolon:warped_sprouts",
 				count: 8
 			}]
@@ -575,6 +590,7 @@
 				{
 					id: "0000000000000EC4",
 					type: "item",
+					title: "Soul Shard",
 					item: "eidolon:soul_shard",
 					count: 16
 				},
@@ -629,18 +645,21 @@
 				{
 					id: "0000000000000ECA",
 					type: "item",
+					title: "Zombie Heart",
 					item: "eidolon:zombie_heart",
 					count: 8
 				},
 				{
 					id: "0000000000000ECB",
 					type: "item",
+					title: "Tattered Cloth",
 					item: "eidolon:tattered_cloth",
 					count: 8
 				},
 				{
 					id: "0000000000000ECC",
 					type: "item",
+					title: "Wraith Heart",
 					item: "eidolon:wraith_heart",
 					count: 8
 				}
@@ -688,6 +707,7 @@
 			rewards: [{
 				id: "0000000000000ED8",
 				type: "item",
+				title: "Wicked Weave",
 				item: "eidolon:wicked_weave",
 				count: 3
 			}]
@@ -719,6 +739,7 @@
 			rewards: [{
 				id: "0000000000000ED6",
 				type: "item",
+				title: "Obsidian",
 				item: "minecraft:obsidian",
 				count: 16
 			}]
@@ -762,6 +783,7 @@
 			rewards: [{
 				id: "0000000000000EDB",
 				type: "item",
+				title: "Music Disc",
 				item: "eidolon:music_disc_parousia"
 			}]
 		},

--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -141,6 +141,7 @@
 			rewards: [{
 				id: "00000000000006EB",
 				type: "item",
+				title: "Modded for Dummies",
 				item: {
 					id: "patchouli:guide_book",
 					Count: 1b,

--- a/config/ftbquests/quests/chapters/immersive_engineering.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering.snbt
@@ -23,6 +23,7 @@
 			rewards: [{
 				id: "3D55700B5A77131D",
 				type: "item",
+				title: "Engineer's Hammer",
 				item: {
 					id: "immersiveengineering:hammer",
 					Count: 1b,
@@ -104,6 +105,7 @@
 			rewards: [{
 				id: "000000000000060A",
 				type: "item",
+				title: "Coal Coke",
 				item: "emendatusenigmatica:coke_gem",
 				count: 8
 			}]
@@ -130,6 +132,7 @@
 			rewards: [{
 				id: "0000000000000615",
 				type: "item",
+				title: "Insulated LV Wire Coil",
 				item: "immersiveengineering:wirecoil_copper_ins",
 				count: 2
 			}]
@@ -157,6 +160,7 @@
 			rewards: [{
 				id: "000000000000060B",
 				type: "item",
+				title: "LV Wire Connector",
 				item: "immersiveengineering:connector_lv",
 				count: 4
 			}]
@@ -177,6 +181,7 @@
 			rewards: [{
 				id: "0000000000000613",
 				type: "item",
+				title: "Steel Ingot",
 				item: "emendatusenigmatica:steel_ingot",
 				count: 8
 			}]
@@ -197,6 +202,7 @@
 				{
 					id: "000000000000060C",
 					type: "item",
+					title: "Industrial Hemp Fiber",
 					item: "immersiveengineering:hemp_fiber",
 					count: 16
 				},
@@ -247,6 +253,7 @@
 			rewards: [{
 				id: "000000000000060F",
 				type: "item",
+				title: "Engineer's Blueprint",
 				item: {
 					id: "immersiveengineering:blueprint",
 					Count: 1b,
@@ -278,6 +285,7 @@
 			rewards: [{
 				id: "0000000000000617",
 				type: "item",
+				title: "Insulated LV Wire Coil",
 				item: "immersiveengineering:wirecoil_copper_ins",
 				count: 2
 			}]
@@ -399,12 +407,14 @@
 				{
 					id: "000000000000061E",
 					type: "item",
+					title: "Iron Plate",
 					item: "emendatusenigmatica:iron_plate",
 					count: 8
 				},
 				{
 					id: "000000000000061F",
 					type: "item",
+					title: "Steel Plate",
 					item: "emendatusenigmatica:steel_plate",
 					count: 4
 				}
@@ -460,6 +470,7 @@
 			rewards: [{
 				id: "0000000000000608",
 				type: "item",
+				title: "Copper Ingot",
 				item: "emendatusenigmatica:copper_ingot",
 				count: 8
 			}]
@@ -602,6 +613,7 @@
 			rewards: [{
 				id: "0000000000000618",
 				type: "item",
+				title: "Blue Ice",
 				item: "minecraft:blue_ice",
 				count: 4
 			}]
@@ -762,6 +774,7 @@
 				{
 					id: "0000000000000619",
 					type: "item",
+					title: "Industrial Hemp Seeds",
 					item: "immersiveengineering:seed",
 					count: 24
 				},
@@ -925,6 +938,7 @@
 				{
 					id: "63F8CD5DAAB0252B",
 					type: "item",
+					title: "Mineral Survey Tools",
 					item: {
 						id: "immersiveengineering:survey_tools",
 						Count: 1b,
@@ -991,6 +1005,7 @@
 			rewards: [{
 				id: "0000000000000610",
 				type: "item",
+				title: "Glowstone",
 				item: "minecraft:glowstone",
 				count: 4
 			}]

--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -40,12 +40,14 @@
 				{
 					id: "0000000000000628",
 					type: "item",
+					title: "Acacia Log",
 					item: "minecraft:acacia_log",
 					count: 32
 				},
 				{
 					id: "0000000000000CAB",
 					type: "item",
+					title: "Acacia Sapling",
 					item: "minecraft:acacia_sapling",
 					count: 8
 				}
@@ -66,6 +68,7 @@
 			rewards: [{
 				id: "0000000000000625",
 				type: "item",
+				title: "Iron Ingot",
 				item: "minecraft:iron_ingot",
 				count: 8
 			}]
@@ -128,6 +131,7 @@
 			rewards: [{
 				id: "0000000000000626",
 				type: "item",
+				title: "Meat Feeder",
 				item: "industrialforegoing:meat_feeder"
 			}]
 		},
@@ -411,6 +415,7 @@
 				{
 					id: "0000000000000F3B",
 					type: "item",
+					title: "Common Black Hole Tank",
 					item: {
 						id: "industrialforegoing:common_black_hole_tank",
 						Count: 1b,
@@ -474,18 +479,21 @@
 				{
 					id: "000000000000062C",
 					type: "item",
+					title: "Beetroot",
 					item: "minecraft:beetroot",
 					count: 8
 				},
 				{
 					id: "000000000000062D",
 					type: "item",
+					title: "Carrot",
 					item: "minecraft:carrot",
 					count: 8
 				},
 				{
 					id: "000000000000062E",
 					type: "item",
+					title: "Potato",
 					item: "minecraft:potato",
 					count: 8
 				}
@@ -522,6 +530,7 @@
 			rewards: [{
 				id: "0000000000000F36",
 				type: "item",
+				title: "Common Black Hole Tank",
 				item: {
 					id: "industrialforegoing:common_black_hole_tank",
 					Count: 1b,
@@ -566,6 +575,7 @@
 			rewards: [{
 				id: "0000000000000634",
 				type: "item",
+				title: "Fertilizer",
 				item: "industrialforegoing:fertilizer",
 				count: 16
 			}]
@@ -607,6 +617,7 @@
 			rewards: [{
 				id: "0000000000000EE0",
 				type: "item",
+				title: "Ether Gas Bucket",
 				item: "industrialforegoing:ether_gas_bucket"
 			}]
 		},
@@ -865,6 +876,7 @@
 			rewards: [{
 				id: "0000000000000F37",
 				type: "item",
+				title: "Common Black Hole Tank",
 				item: {
 					id: "industrialforegoing:common_black_hole_tank",
 					Count: 1b,
@@ -922,6 +934,7 @@
 			rewards: [{
 				id: "0000000000000F38",
 				type: "item",
+				title: "Common Black Hole Tank",
 				item: {
 					id: "industrialforegoing:common_black_hole_tank",
 					Count: 1b,
@@ -976,6 +989,7 @@
 			rewards: [{
 				id: "0000000000000F39",
 				type: "item",
+				title: "Common Black Hole Tank",
 				item: {
 					id: "industrialforegoing:common_black_hole_tank",
 					Count: 1b,
@@ -1031,6 +1045,7 @@
 			rewards: [{
 				id: "0000000000000F3A",
 				type: "item",
+				title: "Common Black Hole Tank",
 				item: {
 					id: "industrialforegoing:common_black_hole_tank",
 					Count: 1b,
@@ -1270,6 +1285,7 @@
 			rewards: [{
 				id: "0997C2E0E6DE8F76",
 				type: "item",
+				title: "Common Black Hole Tank",
 				item: {
 					id: "industrialforegoing:common_black_hole_tank",
 					Count: 1b,
@@ -1311,6 +1327,7 @@
 			rewards: [{
 				id: "24B8F1EFDCF5A2D9",
 				type: "item",
+				title: "Mob Imprisonment Tool",
 				item: "industrialforegoing:mob_imprisonment_tool"
 			}]
 		}

--- a/config/ftbquests/quests/chapters/integrated_dynamics.snbt
+++ b/config/ftbquests/quests/chapters/integrated_dynamics.snbt
@@ -79,11 +79,13 @@
 				{
 					id: "5476A59853122500",
 					type: "item",
+					title: "Armor Stand",
 					item: "minecraft:armor_stand"
 				},
 				{
 					id: "1822E8DD1641B839",
 					type: "item",
+					title: "Green Slime Block",
 					item: "minecraft:slime_block",
 					count: 2
 				}
@@ -141,6 +143,7 @@
 			rewards: [{
 				id: "43CE6F2A10A769E2",
 				type: "item",
+				title: "Coal",
 				item: "minecraft:coal",
 				count: 16
 			}]

--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -54,6 +54,7 @@
 			rewards: [{
 				id: "00000000000006CD",
 				type: "item",
+				title: "Configurator",
 				item: {
 					id: "mekanism:configurator",
 					Count: 1b,
@@ -95,6 +96,7 @@
 			rewards: [{
 				id: "0000000000000817",
 				type: "item",
+				title: "Geiger Counter",
 				item: "mekanism:geiger_counter"
 			}]
 		},
@@ -122,12 +124,14 @@
 				{
 					id: "000000000000080D",
 					type: "item",
+					title: "Block of Coal",
 					item: "minecraft:coal_block",
 					count: 32
 				},
 				{
 					id: "0000000000000CAA",
 					type: "item",
+					title: "Advanced Energy Cube",
 					item: "mekanism:advanced_energy_cube"
 				}
 			]
@@ -160,6 +164,7 @@
 				{
 					id: "0000000000000864",
 					type: "item",
+					title: "Basic Universal Cable",
 					item: "mekanism:basic_universal_cable",
 					count: 16
 				}
@@ -187,6 +192,7 @@
 			rewards: [{
 				id: "00000000000007D2",
 				type: "item",
+				title: "Quantum Entangloporter",
 				item: "mekanism:quantum_entangloporter",
 				count: 2
 			}]
@@ -234,6 +240,7 @@
 				{
 					id: "0000000000000705",
 					type: "item",
+					title: "Advanced Induction Cell",
 					item: "mekanism:advanced_induction_cell"
 				},
 				{
@@ -261,6 +268,7 @@
 			rewards: [{
 				id: "00000000000006CC",
 				type: "item",
+				title: "Network Reader",
 				item: {
 					id: "mekanism:network_reader",
 					Count: 1b,
@@ -331,6 +339,7 @@
 				{
 					id: "0000000000000860",
 					type: "item",
+					title: "Steel Casing",
 					item: "mekanism:steel_casing"
 				}
 			]
@@ -395,12 +404,14 @@
 				{
 					id: "0000000000000861",
 					type: "item",
+					title: "Enriched Redstone",
 					item: "mekanism:enriched_redstone",
 					count: 4
 				},
 				{
 					id: "0000000000000862",
 					type: "item",
+					title: "Enriched Carbon",
 					item: "mekanism:enriched_carbon",
 					count: 8
 				}
@@ -458,6 +469,7 @@
 				{
 					id: "000000000000082C",
 					type: "item",
+					title: "Orange",
 					item: "simplefarming:orange",
 					count: 16
 				}
@@ -539,6 +551,7 @@
 				{
 					id: "0000000000000CA9",
 					type: "item",
+					title: "Personal Chest",
 					item: "mekanism:personal_chest"
 				}
 			]
@@ -591,11 +604,13 @@
 				{
 					id: "0000000000000703",
 					type: "item",
+					title: "Resistive Heater",
 					item: "mekanism:resistive_heater"
 				},
 				{
 					id: "0000000000000704",
 					type: "item",
+					title: "Advanced Thermodynamic Conductor",
 					item: "mekanism:advanced_thermodynamic_conductor",
 					count: 16
 				}
@@ -621,6 +636,7 @@
 				{
 					id: "0000000000000829",
 					type: "item",
+					title: "Jetpack",
 					item: {
 						id: "mekanism:jetpack",
 						Count: 1b,
@@ -806,6 +822,7 @@
 				{
 					id: "00000000000006D5",
 					type: "item",
+					title: "Basic Tier Installer",
 					item: "mekanism:basic_tier_installer",
 					count: 3
 				},
@@ -854,6 +871,7 @@
 			rewards: [{
 				id: "000000000000070C",
 				type: "item",
+				title: "Lithium Dust",
 				item: "emendatusenigmatica:lithium_dust",
 				count: 16
 			}]
@@ -1263,24 +1281,28 @@
 				{
 					id: "000000000000082B",
 					type: "item",
+					title: "Sweet Berry Cookie",
 					item: "farmersdelight:sweet_berry_cookie",
 					count: 3
 				},
 				{
 					id: "000000000000082D",
 					type: "item",
+					title: "Honey Cookie",
 					item: "farmersdelight:honey_cookie",
 					count: 3
 				},
 				{
 					id: "000000000000082E",
 					type: "item",
+					title: "Peanut Butter Cookie",
 					item: "simplefarming:peanut_butter_cookie",
 					count: 3
 				},
 				{
 					id: "000000000000082F",
 					type: "item",
+					title: "Cookie",
 					item: "minecraft:cookie",
 					count: 3
 				},
@@ -1442,21 +1464,25 @@
 				{
 					id: "000000000000079C",
 					type: "item",
+					title: "Gravel",
 					item: "minecraft:gravel"
 				},
 				{
 					id: "000000000000079D",
 					type: "item",
+					title: "Observer",
 					item: "minecraft:observer"
 				},
 				{
 					id: "000000000000079E",
 					type: "item",
+					title: "Piston",
 					item: "minecraft:piston"
 				},
 				{
 					id: "000000000000079F",
 					type: "item",
+					title: "Redstone Dust",
 					item: "minecraft:redstone"
 				}
 			]
@@ -1484,6 +1510,7 @@
 				{
 					id: "00000000000007D3",
 					type: "item",
+					title: "Hazmat Mask",
 					item: {
 						id: "mekanism:hazmat_mask",
 						Count: 1b,
@@ -1495,6 +1522,7 @@
 				{
 					id: "00000000000007D4",
 					type: "item",
+					title: "Hazmat Gown",
 					item: {
 						id: "mekanism:hazmat_gown",
 						Count: 1b,
@@ -1506,6 +1534,7 @@
 				{
 					id: "00000000000007D5",
 					type: "item",
+					title: "Hazmat Pants",
 					item: {
 						id: "mekanism:hazmat_pants",
 						Count: 1b,
@@ -1517,6 +1546,7 @@
 				{
 					id: "00000000000007D7",
 					type: "item",
+					title: "Hazmat Boots",
 					item: {
 						id: "mekanism:hazmat_boots",
 						Count: 1b,
@@ -1528,6 +1558,7 @@
 				{
 					id: "00000000000007D8",
 					type: "item",
+					title: 'Sign "Radioactive Hazard"',
 					item: "engineersdecor:sign_radioactive",
 					count: 16
 				}
@@ -1682,6 +1713,7 @@
 				{
 					id: "00000000000007D9",
 					type: "item",
+					title: "Uranium Ore",
 					item: "emendatusenigmatica:uranium_ore",
 					count: 64
 				},
@@ -2047,6 +2079,7 @@
 				{
 					id: "00000000000007DF",
 					type: "item",
+					title: "Hohlraum",
 					item: "mekanismgenerators:hohlraum"
 				},
 				{
@@ -2060,6 +2093,7 @@
 				{
 					id: "0000000000000873",
 					type: "item",
+					title: 'Sign "Laser Hazard"',
 					item: "engineersdecor:sign_laser",
 					count: 16
 				}

--- a/config/ftbquests/quests/chapters/modular_routers.snbt
+++ b/config/ftbquests/quests/chapters/modular_routers.snbt
@@ -43,6 +43,7 @@
 				{
 					id: "6D87D14D24ACEE49",
 					type: "item",
+					title: "Modular Routers Manual",
 					item: {
 						id: "patchouli:guide_book",
 						Count: 1b,

--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -68,6 +68,7 @@
 			rewards: [{
 				id: "00000000000000A6",
 				type: "item",
+				title: "Shears",
 				item: {
 					id: "minecraft:shears",
 					Count: 1b,
@@ -284,6 +285,7 @@
 				{
 					id: "000000000000035F",
 					type: "item",
+					title: "Eir's Token",
 					item: "naturesaura:break_prevention"
 				},
 				{
@@ -395,6 +397,7 @@
 				{
 					id: "000000000000035E",
 					type: "item",
+					title: "Token of Undying Friendship",
 					item: "naturesaura:pet_reviver"
 				},
 				{
@@ -440,6 +443,7 @@
 				{
 					id: "0000000000000702",
 					type: "item",
+					title: "Ancient Log",
 					item: "naturesaura:ancient_log",
 					count: 32
 				}
@@ -489,6 +493,7 @@
 			rewards: [{
 				id: "0000000000000359",
 				type: "item",
+				title: "Gold Leaf",
 				item: "naturesaura:gold_leaf",
 				count: 32
 			}]
@@ -583,6 +588,7 @@
 			rewards: [{
 				id: "000000000000032D",
 				type: "item",
+				title: "Botanist's Pickaxe",
 				item: {
 					id: "naturesaura:infused_iron_pickaxe",
 					Count: 1b,
@@ -719,6 +725,7 @@
 			rewards: [{
 				id: "000000000000032B",
 				type: "item",
+				title: "Industrial Dimmer",
 				item: "rsgauges:industrial_dimmer"
 			}]
 		},
@@ -770,6 +777,7 @@
 			rewards: [{
 				id: "0000000000000364",
 				type: "item",
+				title: "Staff of Baldur",
 				item: "naturesaura:light_staff"
 			}]
 		},
@@ -796,11 +804,13 @@
 				{
 					id: "000000000000031E",
 					type: "item",
+					title: "Item Frame",
 					item: "minecraft:item_frame"
 				},
 				{
 					id: "000000000000031F",
 					type: "item",
+					title: "Farming Stencil",
 					item: "naturesaura:farming_stencil"
 				}
 			]
@@ -919,11 +929,13 @@
 				{
 					id: "000000000000033D",
 					type: "item",
+					title: "Ender Ocular",
 					item: "naturesaura:ender_access"
 				},
 				{
 					id: "000000000000033E",
 					type: "item",
+					title: "Eye of Ender",
 					item: "minecraft:ender_eye",
 					count: 2
 				}
@@ -945,6 +957,7 @@
 			rewards: [{
 				id: "0000000000000363",
 				type: "item",
+				title: "Portal Charm",
 				item: "darkutils:charm_portal"
 			}]
 		},
@@ -968,6 +981,7 @@
 			rewards: [{
 				id: "000000000000031D",
 				type: "item",
+				title: "Item Frame",
 				item: "minecraft:item_frame",
 				count: 4
 			}]
@@ -1169,6 +1183,7 @@
 				{
 					id: "0000000000000354",
 					type: "item",
+					title: "Powder Manipulator",
 					item: "naturesaura:powder_placer"
 				},
 				{

--- a/config/ftbquests/quests/chapters/occultism.snbt
+++ b/config/ftbquests/quests/chapters/occultism.snbt
@@ -37,6 +37,7 @@
 			rewards: [{
 				id: "0000000000000CB4",
 				type: "item",
+				title: "Demon's Dream Seeds",
 				item: "occultism:datura_seeds"
 			}]
 		},
@@ -128,12 +129,14 @@
 				{
 					id: "0000000000000DF8",
 					type: "item",
+					title: "Otherworld Wood",
 					item: "occultism:otherworld_log",
 					count: 4
 				},
 				{
 					id: "0000000000000DF9",
 					type: "item",
+					title: "Oak Sapling",
 					item: {
 						id: "occultism:otherworld_sapling_natural",
 						Count: 1b,
@@ -144,6 +147,7 @@
 				{
 					id: "0000000000000E1D",
 					type: "item",
+					title: "Otherstone",
 					item: "occultism:otherstone",
 					count: 4
 				}
@@ -182,6 +186,7 @@
 				{
 					id: "0000000000000CDE",
 					type: "item",
+					title: "Otherstone",
 					auto: "disabled",
 					item: "occultism:otherstone",
 					count: 8
@@ -189,6 +194,7 @@
 				{
 					id: "0000000000000CDF",
 					type: "item",
+					title: "Spirit Attuned Gem",
 					auto: "disabled",
 					item: "occultism:spirit_attuned_gem",
 					count: 4
@@ -259,6 +265,7 @@
 				{
 					id: "0000000000000E64",
 					type: "item",
+					title: "Crushed End Stone",
 					item: "occultism:crushed_end_stone",
 					count: 2
 				}
@@ -336,6 +343,7 @@
 				{
 					id: "0000000000000DEB",
 					type: "item",
+					title: "Purified Ink",
 					item: "occultism:purified_ink",
 					count: 4
 				},
@@ -448,6 +456,7 @@
 				{
 					id: "0000000000000E27",
 					type: "item",
+					title: "Golden Chalk",
 					item: {
 						id: "occultism:chalk_gold",
 						Count: 1b,
@@ -490,6 +499,7 @@
 				{
 					id: "0000000000000E41",
 					type: "item",
+					title: "Purple Chalk",
 					item: {
 						id: "occultism:chalk_purple",
 						Count: 1b,
@@ -564,6 +574,7 @@
 				{
 					id: "0000000000000E6B",
 					type: "item",
+					title: "Tier 1 Dimensional Storage Stabilizer",
 					item: "occultism:storage_stabilizer_tier1"
 				},
 				{
@@ -600,6 +611,7 @@
 				{
 					id: "0000000000000E59",
 					type: "item",
+					title: "Tier 1 Dimensional Storage Stabilizer",
 					item: "occultism:storage_stabilizer_tier1",
 					count: 2
 				},
@@ -625,6 +637,7 @@
 				{
 					id: "0000000000000E61",
 					type: "item",
+					title: "Tier 2 Dimensional Storage Stabilizer",
 					item: "occultism:storage_stabilizer_tier2"
 				},
 				{
@@ -657,6 +670,7 @@
 				{
 					id: "0000000000000E57",
 					type: "item",
+					title: "Tier 3 Dimensional Storage Stabilizer",
 					item: "occultism:storage_stabilizer_tier3"
 				},
 				{
@@ -686,6 +700,7 @@
 				{
 					id: "0000000000000E54",
 					type: "item",
+					title: "Tier 4 Dimensional Storage Stabilizer",
 					item: "occultism:storage_stabilizer_tier4"
 				},
 				{
@@ -762,6 +777,7 @@
 				{
 					id: "0000000000000E5C",
 					type: "item",
+					title: "Stable Wormhole",
 					item: {
 						id: "occultism:stable_wormhole",
 						Count: 1b,
@@ -831,6 +847,7 @@
 				{
 					id: "0000000000000E5F",
 					type: "item",
+					title: "Iesnium Ingot",
 					item: "occultism:iesnium_ingot",
 					count: 4
 				},
@@ -886,6 +903,7 @@
 				{
 					id: "0000000000000E2D",
 					type: "item",
+					title: "Epic Oreo",
 					item: "resourcefulbees:oreo_cookie",
 					count: 8
 				}
@@ -960,6 +978,7 @@
 				{
 					id: "0000000000000E66",
 					type: "item",
+					title: "End Stone",
 					item: "minecraft:end_stone",
 					count: 16
 				},
@@ -1008,6 +1027,7 @@
 				{
 					id: "0000000000000E65",
 					type: "item",
+					title: "Skeleton Skull",
 					item: "minecraft:skeleton_skull",
 					count: 2
 				},
@@ -1057,6 +1077,7 @@
 				{
 					id: "0000000000000E3A",
 					type: "item",
+					title: "Ender Pearl",
 					item: "minecraft:ender_pearl",
 					count: 8
 				}
@@ -1131,6 +1152,7 @@
 				{
 					id: "0000000000000E4C",
 					type: "item",
+					title: "Iesnium Block",
 					item: "occultism:iesnium_block"
 				},
 				{
@@ -1348,6 +1370,7 @@
 				{
 					id: "0000000000000E42",
 					type: "item",
+					title: "Umbrella",
 					item: "artifacts:umbrella"
 				}
 			]
@@ -1519,6 +1542,7 @@
 			rewards: [{
 				id: "0000000000000E46",
 				type: "item",
+				title: "Iesnium Ore",
 				item: "occultism:iesnium_ore",
 				count: 8
 			}]
@@ -1553,6 +1577,7 @@
 			rewards: [{
 				id: "0000000000000E03",
 				type: "item",
+				title: "Otherworld Sapling",
 				item: "occultism:otherworld_sapling",
 				count: 16
 			}]

--- a/config/ftbquests/quests/chapters/pedestals.snbt
+++ b/config/ftbquests/quests/chapters/pedestals.snbt
@@ -33,6 +33,7 @@
 			rewards: [{
 				id: "38DDD047E1FD3A07",
 				type: "item",
+				title: "Pedestal",
 				item: "pedestals:pedestal/stone333",
 				count: 2
 			}]
@@ -58,18 +59,21 @@
 				{
 					id: "098E3EA6ABFDA468",
 					type: "item",
+					title: "Red Dye",
 					item: "minecraft:red_dye",
 					count: 16
 				},
 				{
 					id: "79F92867195F75CE",
 					type: "item",
+					title: "Green Dye",
 					item: "minecraft:green_dye",
 					count: 16
 				},
 				{
 					id: "1EECE18CC58046AC",
 					type: "item",
+					title: "Blue Dye",
 					item: "minecraft:blue_dye",
 					count: 16
 				}
@@ -376,6 +380,7 @@
 				{
 					id: "06E7A9FE610657CD",
 					type: "item",
+					title: "Rich Soil Farmland",
 					item: "farmersdelight:rich_soil_farmland",
 					count: 24
 				},
@@ -652,12 +657,14 @@
 				{
 					id: "7D69D5766C6797ED",
 					type: "item",
+					title: "Memory Essence Bucket",
 					item: "pneumaticcraft:memory_essence_bucket",
 					count: 4
 				},
 				{
 					id: "0B8959A9559A7AFF",
 					type: "item",
+					title: "Small Fluid Tank",
 					item: "pneumaticcraft:small_tank"
 				}
 			]
@@ -828,6 +835,7 @@
 				{
 					id: "00EB9A9E96BE6AE7",
 					type: "item",
+					title: "Oak Log",
 					item: "minecraft:oak_log",
 					count: 32,
 					random_bonus: 32
@@ -916,16 +924,19 @@
 				{
 					id: "6B5F421D7DB51A89",
 					type: "item",
+					title: "Bee Spawn Egg",
 					item: "minecraft:bee_spawn_egg"
 				},
 				{
 					id: "4C89A90467F66E70",
 					type: "item",
+					title: "Sheep Spawn Egg",
 					item: "minecraft:sheep_spawn_egg"
 				},
 				{
 					id: "7EB80E7590BDF726",
 					type: "item",
+					title: "Cow Spawn Egg",
 					item: "minecraft:cow_spawn_egg"
 				}
 			]
@@ -1063,6 +1074,7 @@
 			rewards: [{
 				id: "17C1C8CA8C95E178",
 				type: "item",
+				title: "Gold Ingot",
 				item: "minecraft:gold_ingot",
 				count: 3,
 				random_bonus: 6,
@@ -1148,6 +1160,7 @@
 				{
 					id: "4BB47F1EBB842C15",
 					type: "item",
+					title: "Pedestal Upgrade Base",
 					item: "pedestals:coin/default",
 					count: 7
 				},

--- a/config/ftbquests/quests/chapters/pneumaticcraft_repressurized.snbt
+++ b/config/ftbquests/quests/chapters/pneumaticcraft_repressurized.snbt
@@ -28,6 +28,7 @@
 			rewards: [{
 				id: "00000000000000B1",
 				type: "item",
+				title: "Pneumatic Wrench",
 				item: {
 					id: "pneumaticcraft:pneumatic_wrench",
 					Count: 1b,
@@ -125,12 +126,14 @@
 				{
 					id: "00000000000000C1",
 					type: "item",
+					title: "Redstone Dust",
 					item: "minecraft:redstone",
 					count: 9
 				},
 				{
 					id: "00000000000000C2",
 					type: "item",
+					title: "Redstone Repeater",
 					item: "minecraft:repeater"
 				}
 			]
@@ -198,6 +201,7 @@
 			rewards: [{
 				id: "000000000000022D",
 				type: "item",
+				title: "Medium Fluid Tank",
 				item: {
 					id: "pneumaticcraft:medium_tank",
 					Count: 1b,
@@ -233,6 +237,7 @@
 				{
 					id: "00000000000000CE",
 					type: "item",
+					title: "Camouflage Applicator",
 					item: {
 						id: "pneumaticcraft:camo_applicator",
 						Count: 1b,
@@ -266,6 +271,7 @@
 			rewards: [{
 				id: "00000000000000D1",
 				type: "item",
+				title: "Heat Sink",
 				item: "pneumaticcraft:heat_sink"
 			}]
 		},
@@ -290,6 +296,7 @@
 			rewards: [{
 				id: "00000000000000D4",
 				type: "item",
+				title: "Thermal Lagging",
 				item: "pneumaticcraft:thermal_lagging",
 				count: 12
 			}]
@@ -337,6 +344,7 @@
 			rewards: [{
 				id: "00000000000000DB",
 				type: "item",
+				title: "Reinforced Chest",
 				item: "pneumaticcraft:reinforced_chest"
 			}]
 		},
@@ -360,11 +368,13 @@
 				{
 					id: "00000000000000DE",
 					type: "item",
+					title: "Block Tracker Upgrade",
 					item: "pneumaticcraft:block_tracker_upgrade"
 				},
 				{
 					id: "00000000000000DF",
 					type: "item",
+					title: "GPS Tool",
 					item: "pneumaticcraft:gps_tool"
 				}
 			]
@@ -429,6 +439,7 @@
 			rewards: [{
 				id: "00000000000000E5",
 				type: "item",
+				title: "Seismic Sensor",
 				item: "pneumaticcraft:seismic_sensor"
 			}]
 		},
@@ -489,12 +500,14 @@
 				{
 					id: "00000000000000EC",
 					type: "item",
+					title: "Cod n Chips",
 					item: "pneumaticcraft:cod_n_chips",
 					count: 16
 				},
 				{
 					id: "00000000000000ED",
 					type: "item",
+					title: "Dispenser Upgrade",
 					item: "pneumaticcraft:dispenser_upgrade",
 					count: 4
 				}
@@ -516,6 +529,7 @@
 			rewards: [{
 				id: "00000000000000F0",
 				type: "item",
+				title: "Speed Upgrade",
 				item: "pneumaticcraft:speed_upgrade",
 				count: 2
 			}]
@@ -605,12 +619,14 @@
 				{
 					id: "0000000000000105",
 					type: "item",
+					title: "Red Mushroom",
 					item: "minecraft:red_mushroom",
 					count: 16
 				},
 				{
 					id: "0000000000000106",
 					type: "item",
+					title: "Podzol",
 					item: "minecraft:podzol",
 					count: 4
 				}
@@ -756,24 +772,28 @@
 				{
 					id: "000000000000010D",
 					type: "item",
+					title: "Logistic Requester Frame",
 					item: "pneumaticcraft:logistics_frame_requester",
 					count: 8
 				},
 				{
 					id: "000000000000010E",
 					type: "item",
+					title: "Logistic Passive Provider Frame",
 					item: "pneumaticcraft:logistics_frame_passive_provider",
 					count: 8
 				},
 				{
 					id: "000000000000010F",
 					type: "item",
+					title: "Logistic Storage Frame",
 					item: "pneumaticcraft:logistics_frame_storage",
 					count: 8
 				},
 				{
 					id: "00000000000006FF",
 					type: "item",
+					title: "Logistic Active Provider Frame",
 					item: "pneumaticcraft:logistics_frame_active_provider",
 					count: 8
 				}
@@ -824,6 +844,7 @@
 				{
 					id: "0000000000000118",
 					type: "item",
+					title: "Magnet Upgrade",
 					item: "pneumaticcraft:magnet_upgrade"
 				}
 			]
@@ -852,6 +873,7 @@
 			rewards: [{
 				id: "000000000000011C",
 				type: "item",
+				title: "Speed Upgrade",
 				item: "pneumaticcraft:speed_upgrade",
 				count: 2
 			}]
@@ -989,11 +1011,13 @@
 				{
 					id: "000000000000012B",
 					type: "item",
+					title: "Collector Drone",
 					item: "pneumaticcraft:collector_drone"
 				},
 				{
 					id: "0000000000000701",
 					type: "item",
+					title: "Refined Obsidian Hoe",
 					item: {
 						id: "mekanismtools:refined_obsidian_hoe",
 						Count: 1b,
@@ -1026,11 +1050,13 @@
 				{
 					id: "000000000000012E",
 					type: "item",
+					title: "Dispenser Upgrade",
 					item: "pneumaticcraft:dispenser_upgrade"
 				},
 				{
 					id: "0000000000000700",
 					type: "item",
+					title: "Volume Upgrade",
 					item: "pneumaticcraft:volume_upgrade",
 					count: 4
 				}
@@ -1095,6 +1121,7 @@
 			rewards: [{
 				id: "0000000000000137",
 				type: "item",
+				title: "Inventory Upgrade",
 				item: "pneumaticcraft:inventory_upgrade",
 				count: 8
 			}]
@@ -1114,6 +1141,7 @@
 			rewards: [{
 				id: "000000000000013A",
 				type: "item",
+				title: "Range Upgrade",
 				item: "pneumaticcraft:range_upgrade",
 				count: 2
 			}]
@@ -1133,6 +1161,7 @@
 			rewards: [{
 				id: "000000000000013D",
 				type: "item",
+				title: "Speed Upgrade",
 				item: "pneumaticcraft:speed_upgrade",
 				count: 2
 			}]
@@ -1171,6 +1200,7 @@
 			rewards: [{
 				id: "0000000000000140",
 				type: "item",
+				title: "Programming Puzzle Piece",
 				item: "pneumaticcraft:programming_puzzle",
 				count: 64
 			}]
@@ -1218,6 +1248,7 @@
 			rewards: [{
 				id: "0000000000000147",
 				type: "item",
+				title: "Plastic Sheet",
 				item: "pneumaticcraft:plastic",
 				count: 8
 			}]
@@ -1237,6 +1268,7 @@
 			rewards: [{
 				id: "000000000000014A",
 				type: "item",
+				title: "Block of Emerald",
 				item: "minecraft:emerald_block"
 			}]
 		},
@@ -1415,12 +1447,14 @@
 				{
 					id: "0000000000000162",
 					type: "item",
+					title: "Transistor",
 					item: "pneumaticcraft:transistor",
 					count: 2
 				},
 				{
 					id: "0000000000000163",
 					type: "item",
+					title: "Capacitor",
 					item: "pneumaticcraft:capacitor",
 					count: 2
 				}
@@ -1494,6 +1528,7 @@
 			rewards: [{
 				id: "000000000000016D",
 				type: "item",
+				title: "Medium Fluid Tank",
 				item: "pneumaticcraft:medium_tank"
 			}]
 		},
@@ -1537,6 +1572,7 @@
 			rewards: [{
 				id: "0000000000000423",
 				type: "item",
+				title: "Memory Stick",
 				item: "pneumaticcraft:memory_stick"
 			}]
 		},

--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -31,6 +31,7 @@
 			rewards: [{
 				id: "413EB9C7629D2B60",
 				type: "item",
+				title: "Wrench",
 				item: {
 					id: "powah:wrench",
 					Count: 1b,
@@ -96,6 +97,7 @@
 			rewards: [{
 				id: "7698C3956B71648E",
 				type: "item",
+				title: "Dielectric Casing",
 				item: "powah:dielectric_casing",
 				count: 2
 			}]
@@ -131,6 +133,7 @@
 				{
 					id: "00000000000001B2",
 					type: "item",
+					title: "Block of Coal",
 					item: "minecraft:coal_block",
 					count: 4
 				},
@@ -203,6 +206,7 @@
 			rewards: [{
 				id: "00000000000001B4",
 				type: "item",
+				title: "Lava Bucket",
 				item: "minecraft:lava_bucket"
 			}]
 		},
@@ -238,6 +242,7 @@
 				{
 					id: "00000000000001B6",
 					type: "item",
+					title: "Sink",
 					item: "cookingforblockheads:sink"
 				},
 				{
@@ -278,6 +283,7 @@
 				{
 					id: "00000000000001B8",
 					type: "item",
+					title: "Sunglasses",
 					item: "bountifulbaubles:sunglasses"
 				},
 				{
@@ -335,6 +341,7 @@
 			rewards: [{
 				id: "00000000000001BB",
 				type: "item",
+				title: "Block of Uraninite",
 				item: "powah:uraninite_block",
 				count: 8
 			}]
@@ -375,6 +382,7 @@
 				{
 					id: "00000000000001BD",
 					type: "item",
+					title: "Uraninite",
 					item: "powah:uraninite",
 					count: 32,
 					only_one: true
@@ -382,6 +390,7 @@
 				{
 					id: "00000000000001BE",
 					type: "item",
+					title: "Blue Ice",
 					item: "minecraft:blue_ice",
 					count: 32,
 					only_one: true
@@ -406,6 +415,7 @@
 			rewards: [{
 				id: "00000000000001C2",
 				type: "item",
+				title: "Charged Snowball",
 				item: "powah:charged_snowball",
 				count: 8
 			}]
@@ -449,6 +459,7 @@
 			rewards: [{
 				id: "00000000000001C5",
 				type: "item",
+				title: "Energizing Rod (Basic)",
 				item: "powah:energizing_rod_basic",
 				count: 2
 			}]
@@ -522,6 +533,7 @@
 			rewards: [{
 				id: "0000000000000226",
 				type: "item",
+				title: "Energy Cell (Hardened)",
 				item: "powah:energy_cell_hardened"
 			}]
 		},
@@ -597,6 +609,7 @@
 			rewards: [{
 				id: "0000000000000227",
 				type: "item",
+				title: "Ender Core",
 				item: "powah:ender_core",
 				count: 4
 			}]
@@ -641,6 +654,7 @@
 			rewards: [{
 				id: "0000000000000215",
 				type: "item",
+				title: "Battery (Hardened)",
 				item: {
 					id: "powah:battery_hardened",
 					Count: 1b,
@@ -663,6 +677,7 @@
 			rewards: [{
 				id: "0000000000000217",
 				type: "item",
+				title: "Block of Energized Steel",
 				item: "powah:energized_steel_block",
 				count: 4
 			}]
@@ -686,6 +701,7 @@
 			rewards: [{
 				id: "0000000000000219",
 				type: "item",
+				title: "Energizing Rod (Niotic)",
 				item: "powah:energizing_rod_niotic",
 				count: 2
 			}]
@@ -706,18 +722,21 @@
 				{
 					id: "000000000000021B",
 					type: "item",
+					title: "Block of Uraninite",
 					item: "powah:uraninite_block",
 					count: 8
 				},
 				{
 					id: "000000000000021C",
 					type: "item",
+					title: "Block of Niotic Crystal",
 					item: "powah:niotic_crystal_block",
 					count: 8
 				},
 				{
 					id: "000000000000021D",
 					type: "item",
+					title: "Dry Ice",
 					item: "powah:dry_ice",
 					count: 8
 				}
@@ -744,6 +763,7 @@
 				{
 					id: "000000000000021F",
 					type: "item",
+					title: "Energy Cell (Nitro)",
 					item: "powah:energy_cell_nitro"
 				},
 				{

--- a/config/ftbquests/quests/chapters/refined_storage.snbt
+++ b/config/ftbquests/quests/chapters/refined_storage.snbt
@@ -25,18 +25,21 @@
 				{
 					id: "000000000000027A",
 					type: "item",
+					title: "Slimeball",
 					item: "minecraft:slime_ball",
 					count: 4
 				},
 				{
 					id: "000000000000027B",
 					type: "item",
+					title: "String",
 					item: "minecraft:string",
 					count: 4
 				},
 				{
 					id: "0000000000000F4D",
 					type: "item",
+					title: "Wrench",
 					item: "refinedstorage:wrench"
 				}
 			]
@@ -70,6 +73,7 @@
 			rewards: [{
 				id: "00000000000005AF",
 				type: "item",
+				title: "Quartz Enriched Iron",
 				item: "refinedstorage:quartz_enriched_iron",
 				count: 16
 			}]
@@ -102,6 +106,7 @@
 			rewards: [{
 				id: "00000000000005B0",
 				type: "item",
+				title: "Cable",
 				item: "refinedstorage:cable",
 				count: 16
 			}]
@@ -169,6 +174,7 @@
 				{
 					id: "00000000000005BD",
 					type: "item",
+					title: "Storage Housing",
 					item: "refinedstorage:storage_housing",
 					count: 2
 				}
@@ -214,6 +220,7 @@
 			rewards: [{
 				id: "00000000000005BB",
 				type: "item",
+				title: "256k Fluid Storage Part",
 				item: "refinedstorage:256k_fluid_storage_part"
 			}]
 		},
@@ -262,6 +269,7 @@
 			rewards: [{
 				id: "00000000000005BF",
 				type: "item",
+				title: "Advanced Bin",
 				item: "mekanism:advanced_bin"
 			}]
 		},
@@ -281,6 +289,7 @@
 			rewards: [{
 				id: "00000000000005BE",
 				type: "item",
+				title: "Cable",
 				item: "refinedstorage:cable",
 				count: 8
 			}]
@@ -304,6 +313,7 @@
 			rewards: [{
 				id: "00000000000005C0",
 				type: "item",
+				title: "Storage Housing",
 				item: "refinedstorage:storage_housing",
 				count: 4
 			}]
@@ -323,6 +333,7 @@
 			rewards: [{
 				id: "00000000000005C2",
 				type: "item",
+				title: "256k Fluid Storage Part",
 				item: "refinedstorage:256k_fluid_storage_part",
 				count: 2
 			}]
@@ -401,6 +412,7 @@
 			rewards: [{
 				id: "00000000000005C4",
 				type: "item",
+				title: "Ender Pearl",
 				item: "minecraft:ender_pearl",
 				count: 4
 			}]
@@ -495,6 +507,7 @@
 			rewards: [{
 				id: "00000000000005B5",
 				type: "item",
+				title: "Speed Upgrade",
 				item: "refinedstorage:speed_upgrade",
 				count: 2
 			}]
@@ -564,6 +577,7 @@
 			rewards: [{
 				id: "00000000000005B9",
 				type: "item",
+				title: "Interface",
 				item: "refinedstorage:interface"
 			}]
 		},
@@ -717,6 +731,7 @@
 			rewards: [{
 				id: "0000000000000F4E",
 				type: "item",
+				title: "Crafter",
 				item: "refinedstorage:crafter"
 			}]
 		},

--- a/config/ftbquests/quests/chapters/resourceful_bees.snbt
+++ b/config/ftbquests/quests/chapters/resourceful_bees.snbt
@@ -250,12 +250,14 @@
 				{
 					id: "6DA6F6AC7E54E2C9",
 					type: "item",
+					title: "Empty Bee Jar",
 					item: "resourcefulbees:bee_jar",
 					count: 8
 				},
 				{
 					id: "0C1504955F2C86AD",
 					type: "item",
+					title: "Beepedia",
 					item: "resourcefulbees:beepedia"
 				}
 			]
@@ -866,6 +868,7 @@
 			rewards: [{
 				id: "7ECD253B38639D34",
 				type: "item",
+				title: "Empty Bee Jar",
 				item: "resourcefulbees:bee_jar",
 				count: 2,
 				random_bonus: 3

--- a/config/ftbquests/quests/chapters/rftools_wip.snbt
+++ b/config/ftbquests/quests/chapters/rftools_wip.snbt
@@ -31,6 +31,7 @@
 			rewards: [{
 				id: "0000000000000C00",
 				type: "item",
+				title: "Smart Wrench",
 				item: "rftoolsbase:smartwrench"
 			}]
 		},
@@ -558,6 +559,7 @@
 				{
 					id: "0000000000000BFF",
 					type: "item",
+					title: "Tier 1 Storage Module",
 					item: "rftoolsstorage:storage_module0"
 				},
 				{
@@ -668,12 +670,14 @@
 				{
 					id: "0000000000000C03",
 					type: "item",
+					title: "Blue Network Cable",
 					item: "xnet:netcable_blue",
 					count: 32
 				},
 				{
 					id: "0000000000000C04",
 					type: "item",
+					title: "Blue Connector",
 					item: "xnet:connector_blue",
 					count: 4
 				}
@@ -824,6 +828,7 @@
 				{
 					id: "0000000000000BFE",
 					type: "item",
+					title: "Storage Control Screen Module",
 					item: {
 						id: "rftoolsstorage:storage_control_module",
 						Count: 1b,

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -57,6 +57,7 @@
 			rewards: [{
 				id: "0000000000000696",
 				type: "item",
+				title: "Pipe Wrench",
 				item: "prettypipes:wrench"
 			}]
 		},
@@ -773,6 +774,7 @@
 			rewards: [{
 				id: "0000000000000997",
 				type: "item",
+				title: "Leather",
 				icon: "minecraft:leather",
 				item: "minecraft:leather",
 				random_bonus: 3
@@ -986,6 +988,7 @@
 			rewards: [{
 				id: "36C4E2AF07DE5E40",
 				type: "item",
+				title: "Ender Chest",
 				item: "enderstorage:ender_chest"
 			}]
 		},
@@ -1017,6 +1020,7 @@
 				{
 					id: "39498CF292AB8B53",
 					type: "item",
+					title: "Glass Bottle",
 					item: "minecraft:glass_bottle",
 					count: 8
 				},

--- a/config/ftbquests/quests/chapters/tetra.snbt
+++ b/config/ftbquests/quests/chapters/tetra.snbt
@@ -63,6 +63,7 @@
 				{
 					id: "0000000000000845",
 					type: "item",
+					title: "Wooden Hammer",
 					item: {
 						id: "tetra:modular_double",
 						Count: 1b,
@@ -80,6 +81,7 @@
 				{
 					id: "0000000000000891",
 					type: "item",
+					title: "Hamburger",
 					item: "farmersdelight:hamburger"
 				}
 			]
@@ -125,6 +127,7 @@
 			rewards: [{
 				id: "000000000000088E",
 				type: "item",
+				title: "Eye of Ender",
 				item: "minecraft:ender_eye"
 			}]
 		},
@@ -199,18 +202,21 @@
 				{
 					id: "0000000000000A3E",
 					type: "item",
+					title: "Training Arrow",
 					item: "archers_paradox:training_arrow",
 					count: 64
 				},
 				{
 					id: "0000000000000A3F",
 					type: "item",
+					title: "Explosive Arrow",
 					item: "archers_paradox:explosive_arrow",
 					count: 16
 				},
 				{
 					id: "0000000000000A40",
 					type: "item",
+					title: "Arrow of Slowness",
 					item: {
 						id: "minecraft:tipped_arrow",
 						Count: 1b,
@@ -223,6 +229,7 @@
 				{
 					id: "0000000000000A41",
 					type: "item",
+					title: "Arrow",
 					item: "minecraft:arrow",
 					count: 64
 				}
@@ -290,6 +297,7 @@
 			rewards: [{
 				id: "0000000000000A4E",
 				type: "item",
+				title: "Tectonic Grenade",
 				item: "thermal:earth_grenade",
 				count: 16
 			}]
@@ -338,6 +346,7 @@
 			rewards: [{
 				id: "0000000000000853",
 				type: "item",
+				title: "Thermal Cell",
 				item: {
 					id: "tetra:magmatic_cell",
 					Count: 1b,
@@ -381,6 +390,7 @@
 				{
 					id: "0000000000000A4B",
 					type: "item",
+					title: "Lava Bucket",
 					item: "minecraft:lava_bucket"
 				},
 				{
@@ -417,6 +427,7 @@
 			rewards: [{
 				id: "000000000000085F",
 				type: "item",
+				title: "Planar Stabilizer",
 				item: "tetra:planar_stabilizer"
 			}]
 		},
@@ -440,6 +451,7 @@
 			rewards: [{
 				id: "000000000000085E",
 				type: "item",
+				title: "Combustion Chamber",
 				item: "tetra:combustion_chamber"
 			}]
 		},
@@ -546,6 +558,7 @@
 				{
 					id: "0000000000000A42",
 					type: "item",
+					title: "Copper Chunk",
 					item: "emendatusenigmatica:copper_chunk",
 					count: 8
 				},
@@ -595,12 +608,14 @@
 				{
 					id: "0000000000000A43",
 					type: "item",
+					title: "Osmium Chunk",
 					item: "emendatusenigmatica:osmium_chunk",
 					count: 8
 				},
 				{
 					id: "0000000000000A44",
 					type: "item",
+					title: "Splash Potion of Fire Resistance",
 					item: {
 						id: "minecraft:splash_potion",
 						Count: 1b,
@@ -649,11 +664,13 @@
 				{
 					id: "0000000000000A45",
 					type: "item",
+					title: "End Rod",
 					item: "minecraft:end_rod"
 				},
 				{
 					id: "0000000000000A47",
 					type: "item",
+					title: "Unbreaking II",
 					item: {
 						id: "minecraft:enchanted_book",
 						Count: 1b,
@@ -668,6 +685,7 @@
 				{
 					id: "0000000000000A48",
 					type: "item",
+					title: "Splash Potion of Swiftness",
 					item: {
 						id: "minecraft:splash_potion",
 						Count: 1b,
@@ -1113,6 +1131,7 @@
 			rewards: [{
 				id: "0000000000000A90",
 				type: "item",
+				title: "Splash Potion of Night Vision",
 				item: {
 					id: "minecraft:splash_potion",
 					Count: 1b,
@@ -1294,6 +1313,7 @@
 			rewards: [{
 				id: "0000000000000A39",
 				type: "item",
+				title: "Stone Hammer",
 				item: {
 					id: "vanillahammers:stone_hammer",
 					Count: 1b,

--- a/config/ftbquests/quests/chapters/thermal_series.snbt
+++ b/config/ftbquests/quests/chapters/thermal_series.snbt
@@ -28,6 +28,7 @@
 			rewards: [{
 				id: "00000000000004B9",
 				type: "item",
+				title: "Crescent Hammer",
 				item: "thermal:wrench"
 			}]
 		},
@@ -69,12 +70,14 @@
 				{
 					id: "00000000000004EC",
 					type: "item",
+					title: "Energy Cable (Basic)",
 					item: "powah:energy_cable_basic",
 					count: 8
 				},
 				{
 					id: "000000000000063A",
 					type: "item",
+					title: "Energy Cell (Basic)",
 					item: "powah:energy_cell_basic"
 				},
 				{
@@ -109,6 +112,7 @@
 				{
 					id: "00000000000004BA",
 					type: "item",
+					title: "Jungle Sapling",
 					auto: "disabled",
 					item: "minecraft:jungle_sapling",
 					count: 4
@@ -124,6 +128,7 @@
 				{
 					id: "0000000000000F87",
 					type: "item",
+					title: "Acacia Sapling",
 					item: "minecraft:acacia_sapling",
 					count: 4
 				}
@@ -165,6 +170,7 @@
 				{
 					id: "0000000000000639",
 					type: "item",
+					title: "Basic Mechanical Pipe",
 					item: "mekanism:basic_mechanical_pipe",
 					count: 8
 				}
@@ -269,6 +275,7 @@
 				{
 					id: "00000000000004ED",
 					type: "item",
+					title: "Sweet Berries",
 					item: "minecraft:sweet_berries",
 					count: 16
 				},
@@ -364,6 +371,7 @@
 				{
 					id: "00000000000004F6",
 					type: "item",
+					title: "Metal Press Mold: Gear",
 					item: "immersiveengineering:mold_gear"
 				},
 				{
@@ -791,6 +799,7 @@
 			rewards: [{
 				id: "0000000000000F9C",
 				type: "item",
+				title: "Expanded Tank Construction",
 				item: "thermal:fluid_tank_augment"
 			}]
 		},
@@ -823,6 +832,7 @@
 			rewards: [{
 				id: "0000000000000F88",
 				type: "item",
+				title: "Holding IV",
 				item: {
 					id: "minecraft:enchanted_book",
 					Count: 1b,

--- a/config/ftbquests/quests/chapters/tools.snbt
+++ b/config/ftbquests/quests/chapters/tools.snbt
@@ -33,6 +33,7 @@
 				{
 					id: "00000000000001C8",
 					type: "item",
+					title: "Compressed Iron Drill Bit",
 					item: "pneumaticcraft:drill_bit_compressed_iron"
 				},
 				{
@@ -61,6 +62,7 @@
 				{
 					id: "00000000000001CB",
 					type: "item",
+					title: "Volume Upgrade",
 					item: "pneumaticcraft:volume_upgrade",
 					count: 5
 				},
@@ -90,6 +92,7 @@
 				{
 					id: "00000000000001CE",
 					type: "item",
+					title: "Speed Upgrade",
 					item: "pneumaticcraft:speed_upgrade",
 					count: 2
 				},
@@ -265,6 +268,7 @@
 			rewards: [{
 				id: "0000000000000654",
 				type: "item",
+				title: "Armor Upgrade",
 				item: "pneumaticcraft:armor_upgrade",
 				count: 4
 			}]
@@ -473,6 +477,7 @@
 			rewards: [{
 				id: "0000000000000868",
 				type: "item",
+				title: "Armor-Piercing Minigun Ammo",
 				item: {
 					id: "pneumaticcraft:gun_ammo_ap",
 					Count: 1b,
@@ -501,6 +506,7 @@
 			rewards: [{
 				id: "0000000000000867",
 				type: "item",
+				title: "Minigun Ammo",
 				item: {
 					id: "pneumaticcraft:gun_ammo",
 					Count: 1b,
@@ -1135,6 +1141,7 @@
 				{
 					id: "000000000000067D",
 					type: "item",
+					title: "Upgrade: Light Placer",
 					item: "mininggadgets:upgrade_light_placer"
 				},
 				{
@@ -1211,6 +1218,7 @@
 				{
 					id: "000000000000067B",
 					type: "item",
+					title: "Upgrade: Magnet",
 					item: "mininggadgets:upgrade_magnet"
 				},
 				{
@@ -1523,6 +1531,7 @@
 				{
 					id: "000000000000065F",
 					type: "item",
+					title: "Nether Star Hook",
 					item: "aquaculture:nether_star_hook"
 				},
 				{
@@ -1590,6 +1599,7 @@
 				{
 					id: "000000000000067A",
 					type: "item",
+					title: "Unbreaking V",
 					item: {
 						id: "minecraft:enchanted_book",
 						Count: 1b,
@@ -1683,6 +1693,7 @@
 				{
 					id: "000000000000066E",
 					type: "item",
+					title: "Mana Boost V, Mana Regen V",
 					item: {
 						id: "minecraft:enchanted_book",
 						Count: 1b,
@@ -2245,6 +2256,7 @@
 				{
 					id: "4AA86E1E20DADE27",
 					type: "item",
+					title: "Advanced Fluid Tank",
 					item: {
 						id: "mekanism:advanced_fluid_tank",
 						Count: 1b,
@@ -2264,6 +2276,7 @@
 				{
 					id: "17E85BEC398930AD",
 					type: "item",
+					title: "Sawblade",
 					item: {
 						id: "immersiveengineering:sawblade",
 						Count: 1b,
@@ -2311,6 +2324,7 @@
 				{
 					id: "02E988D98405DAFB",
 					type: "item",
+					title: "Casull Cartridge",
 					item: "immersiveengineering:casull",
 					count: 64
 				}
@@ -2347,6 +2361,7 @@
 				{
 					id: "5D7232BCA248639D",
 					type: "item",
+					title: "Advanced Fluid Tank",
 					item: {
 						id: "mekanism:advanced_fluid_tank",
 						Count: 1b,
@@ -2366,6 +2381,7 @@
 				{
 					id: "7683853C5B00EE25",
 					type: "item",
+					title: "Iron Drill Head",
 					item: "immersiveengineering:drillhead_iron"
 				}
 			]
@@ -2409,6 +2425,7 @@
 				{
 					id: "6BCA8B2194807B4D",
 					type: "item",
+					title: "Iron Rod",
 					item: "emendatusenigmatica:iron_rod",
 					count: 16
 				}
@@ -2804,6 +2821,7 @@
 			rewards: [{
 				id: "2DBC321E9D2AE461",
 				type: "item",
+				title: "Focused Nozzle",
 				item: "immersiveengineering:toolupgrade_chemthrower_focus"
 			}]
 		},


### PR DESCRIPTION
Only added _reward titles_, nothing else. This allows mouseover indication of item name:

![image](https://i.imgur.com/WRl7fAD.png)

I also discovered a bug with FTB Quests - _single item_ rewards will not show mouseover names. Only item rewards with a quantity greater than 1, Enchanted Books, and those loot boxes will show up when moused over. I've added a bug report to the FTB Quests repo about this here, including a short video showing the issue: https://github.com/FTBTeam/FTB-Quests/issues/582

3rd time's the charm? :)