### PR TITLE
Preliminary Botania Recipes

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -206,6 +206,24 @@ events.listen('jei.information', (event) => {
         {
             items: ['quark:bottled_cloud'],
             description: ['Obtained by Right-Clicking a Glass Bottle in the air between Y Levels 126 and 132.']
+        },
+        {
+            items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:overworld' })],
+            description: [
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the Overworld. This action removes Aura from the area.'
+            ]
+        },
+        {
+            items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:end' })],
+            description: [
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the End. This action removes Aura from the area.'
+            ]
+        },
+        {
+            items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:nether' })],
+            description: [
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the Nether. This action removes Aura from the area.'
+            ]
         }
     ];
 

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -188,6 +188,20 @@ events.listen('jei.information', (event) => {
         {
             items: ['betterendforge:silk_fiber'],
             description: ['Obtained by killing Silk Moths which are spawned by Silk Moth Nests.']
+        },
+        {
+            items: [/upgrade_aquatic:\w+_coralstone$/],
+            description: ['Obtained by placing Coralstone next to living coral.']
+        },
+        {
+            items: ['upgrade_aquatic:coralstone'],
+            description: ['Place next to living coral to infuse.']
+        },
+        {
+            items: [/quark:\w+_crystal$/],
+            description: [
+                'Will grow up to four blocks tall if placed deep underground. Will emit particles while growing.'
+            ]
         }
     ];
 

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -202,6 +202,10 @@ events.listen('jei.information', (event) => {
             description: [
                 'Will grow up to four blocks tall if placed deep underground. Will emit particles while growing.'
             ]
+        },
+        {
+            items: ['quark:bottled_cloud'],
+            description: ['Obtained by Right-Clicking a Glass Bottle in the air between Y Levels 126 and 132.']
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
@@ -2,61 +2,43 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             {
-                ingredients: ['emendatusenigmatica:arcane_gem', 'naturesaura:gold_leaf'],
+                inputs: ['emendatusenigmatica:arcane_gem', 'naturesaura:gold_leaf'],
                 entity: 'ars_nouveau:carbuncle',
                 aura: 100000,
                 time: 100
             },
             {
-                ingredients: ['emendatusenigmatica:arcane_gem', 'naturesaura:ancient_sapling'],
+                inputs: ['emendatusenigmatica:arcane_gem', 'naturesaura:ancient_sapling'],
                 entity: 'ars_nouveau:sylph',
                 aura: 100000,
                 time: 100
             },
             {
-                ingredients: ['minecraft:cod', 'minecraft:iron_bars'],
+                inputs: ['minecraft:cod', 'minecraft:iron_bars'],
                 entity: 'quark:crab',
                 aura: 30000,
                 time: 40
             },
             {
-                ingredients: ['minecraft:spider_eye', 'minecraft:lily_pad'],
+                inputs: ['minecraft:spider_eye', 'minecraft:lily_pad'],
                 entity: 'quark:frog',
                 aura: 30000,
                 time: 40
             },
             {
-                ingredients: ['minecraft:leather', 'minecraft:coal'],
+                inputs: ['minecraft:leather', 'minecraft:coal'],
                 entity: 'quark:foxhound',
                 aura: 150000,
                 time: 120
             },
             {
-                ingredients: ['thermal:blitz_rod', 'thermal:blitz_powder'],
-                entity: 'thermal:blitz',
-                aura: 150000,
-                time: 120
-            },
-            {
-                ingredients: ['thermal:blizz_rod', 'thermal:blizz_powder'],
-                entity: 'thermal:blizz',
-                aura: 150000,
-                time: 120
-            },
-            {
-                ingredients: ['thermal:basalz_rod', 'thermal:basalz_powder'],
-                entity: 'thermal:basalz',
-                aura: 150000,
-                time: 120
-            },
-            {
-                ingredients: ['minecraft:coarse_dirt', 'industrialforegoing:fertilizer'],
+                inputs: ['minecraft:coarse_dirt', 'industrialforegoing:fertilizer'],
                 entity: 'alexsmobs:cockroach',
                 aura: 30000,
                 time: 40
             },
             {
-                ingredients: ['minecraft:coarse_dirt', 'minecraft:brown_mushroom'],
+                inputs: ['minecraft:coarse_dirt', 'minecraft:brown_mushroom'],
                 entity: 'alexsmobs:cockroach',
                 aura: 150000,
                 time: 120
@@ -64,22 +46,21 @@ events.listen('recipes', (event) => {
         ]
     };
     data.recipes.forEach((recipe) => {
-        event.custom({
+        let ingredients = [Ingredient.of('naturesaura:birth_spirit').toJson()];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input).toJson());
+        });
+
+        const re = event.custom({
             type: 'naturesaura:animal_spawner',
-            ingredients: [
-                {
-                    item: 'naturesaura:birth_spirit'
-                },
-                {
-                    item: recipe.ingredients[0]
-                },
-                {
-                    item: recipe.ingredients[1]
-                }
-            ],
+            ingredients: ingredients,
             entity: recipe.entity,
             aura: recipe.aura,
             time: recipe.time
         });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/upgrade_aquatic/coralstone.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/upgrade_aquatic/coralstone.js
@@ -1,0 +1,7 @@
+events.listen('item.tags', (event) => {
+    event
+        .get('upgrade_aquatic:coralstone')
+        .add('upgrade_aquatic:coralstone')
+        .add(/upgrade_aquatic:\w+_coralstone$/);
+    event.get('upgrade_aquatic:coralstone/infused').add(/upgrade_aquatic:\w+_coralstone$/);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -348,6 +348,33 @@ events.listen('recipes', (event) => {
                 C: '#forge:rods/wooden'
             },
             id: 'bloodmagic:altar/daggerofsacrifice'
+        },
+        {
+            output: 'botania:mana_pool',
+            pattern: ['   ', 'A A', 'ABA'],
+            key: {
+                A: 'botania:livingrock',
+                B: 'ars_nouveau:warding_stone'
+            },
+            id: 'botania:mana_pool'
+        },
+        {
+            output: 'botania:diluted_pool',
+            pattern: ['   ', 'A A', 'ABA'],
+            key: {
+                A: 'botania:livingrock_slab',
+                B: 'ars_nouveau:warding_stone'
+            },
+            id: 'botania:diluted_pool'
+        },
+        {
+            output: 'botania:fabulous_pool',
+            pattern: ['   ', 'A A', 'ABA'],
+            key: {
+                A: 'botania:shimmerrock',
+                B: 'ars_nouveau:warding_stone'
+            },
+            id: 'botania:fabulous_pool'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
@@ -21,6 +21,11 @@ events.listen('recipes', (event) => {
             output: Item.of('ars_nouveau:potion_jar'),
             inputs: ['ars_nouveau:mana_jar', ['minecraft:nether_wart', 'eidolon:fungus_sprouts']],
             id: 'ars_nouveau:potion_jar'
+        },
+        {
+            output: Item.of('naturesaura:bottle_two_the_rebottling'),
+            inputs: ['minecraft:glass_bottle', 'farmersdelight:tree_bark'],
+            id: 'naturesaura:bottle_two_the_rebottling'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/betterend/alloying.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/betterend/alloying.js
@@ -1,0 +1,24 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [
+            {
+                inputs: ['#forge:ingots/cobalt', 'thermal:blizz_powder'],
+                output: Item.of('undergarden:froststeel_ingot', 1),
+                experience: 2,
+                smelttime: 300
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        event.custom({
+            type: 'betterendforge:alloying',
+            ingredients: [Ingredient.of(recipe.inputs[0]).toJson(), Ingredient.of(recipe.inputs[1]).toJson()],
+            result: recipe.output,
+            experience: recipe.experience,
+            smelttime: recipe.smelttime
+        });
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
@@ -1,0 +1,41 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            input: '#forge:ingots/froststeel',
+            output: 'botania:manasteel_ingot',
+            mana: 3000,
+            catalyst: 'architects_palette:sunstone',
+            id: 'botania:mana_infusion/manasteel'
+        },
+        {
+            input: '#forge:storage_blocks/froststeel',
+            output: 'botania:manasteel_block',
+            mana: 27000,
+            catalyst: 'architects_palette:sunstone',
+            id: 'botania:mana_infusion/manasteel_block'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        let constructed_recipe = {
+            type: 'botania:mana_infusion',
+            input: Ingredient.of(recipe.input).toJson(),
+            output: Ingredient.of(recipe.output).toJson(),
+            mana: recipe.mana
+        };
+        if (recipe.catalyst) {
+            constructed_recipe.catalyst = {
+                type: 'block',
+                block: recipe.catalyst
+            };
+        }
+        const re = event.custom(constructed_recipe);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -1,0 +1,83 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            inputs: [
+                '#forge:dusts/mana',
+                '#forge:ingots/manasteel',
+                '#forge:dusts/lapis',
+                '#upgrade_aquatic:coralstone/infused',
+                'minecraft:kelp',
+                'aquaculture:diamond_hook'
+            ],
+            mana: 10400,
+            output: 'botania:rune_water',
+            count: 2,
+            id: 'botania:runic_altar/water'
+        },
+        {
+            inputs: [
+                '#forge:dusts/mana',
+                '#forge:ingots/manasteel',
+                '#forge:dusts/sulfur',
+                'quark:magma_bricks',
+                'undergarden:ditchbulb',
+                'buildersaddition:large_soul_candle'
+            ],
+            mana: 10400,
+            output: 'botania:rune_fire',
+            count: 2,
+            id: 'botania:runic_altar/fire'
+        },
+        {
+            inputs: [
+                '#forge:dusts/mana',
+                '#forge:ingots/manasteel',
+                '#forge:dusts/apatite',
+                'undergarden:tremblecrust',
+                '#quark:runes',
+                'aquaculture:worm'
+            ],
+            mana: 10400,
+            output: 'botania:rune_earth',
+            count: 2,
+            id: 'botania:runic_altar/earth'
+        },
+        {
+            inputs: [
+                '#forge:dusts/mana',
+                '#forge:ingots/manasteel',
+                '#forge:dusts/fluorite',
+                'betterendforge:silk_fiber',
+                'quark:bottled_cloud',
+                'alexsmobs:guster_eye'
+            ],
+            mana: 10400,
+            output: 'botania:rune_air',
+            count: 2,
+            id: 'botania:runic_altar/air'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        let ingredients = [];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input).toJson());
+        });
+        console.log(ingredients);
+
+        const re = event.custom({
+            type: 'botania:runic_altar',
+            output: { item: recipe.output, count: recipe.count },
+            mana: recipe.mana,
+            ingredients: ingredients
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mixing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mixing.js
@@ -1,5 +1,15 @@
 events.listen('recipes', (event) => {
-    const recipes = [];
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            heated: true,
+            inputs: ['#forge:ingots/cobalt', '#forge:ingots/cobalt', '#forge:ingots/cobalt', 'thermal:blizz_powder'],
+            output: Item.of('undergarden:froststeel_ingot', 3)
+        }
+    ];
 
     recipes.forEach((recipe) => {
         if (recipe.heated) {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/alloy.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/alloy.js
@@ -1,0 +1,22 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [
+            {
+                input1: Item.of('#forge:ingots/cobalt', 3),
+                input2: 'thermal:blizz_powder',
+                output: Item.of('undergarden:froststeel_ingot', 3)
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.immersiveengineering.alloy(recipe.output, recipe.input1, recipe.input2);
+
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/arc_furnace.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/arc_furnace.js
@@ -1,0 +1,21 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [
+            {
+                input1: Item.of('#forge:ingots/cobalt', 3),
+                secondaries: ['thermal:blizz_powder'],
+                outputs: [Item.of('undergarden:froststeel_ingot', 3)]
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.immersiveengineering.arc_furnace(recipe.outputs, recipe.input1, recipe.secondaries);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
@@ -1,0 +1,59 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    var data = {
+        recipes: [
+            {
+                inputs: ['quark:bottled_cloud', 'resourcefulbees:sand_honeycomb', 'minecraft:sand'],
+                entity: 'alexsmobs:guster',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['#forge:dusts/fluorite', 'resourcefulbees:electrum_honeycomb', 'powah:charged_snowball'],
+                entity: 'thermal:blitz',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['#forge:dusts/lapis', 'resourcefulbees:icy_honeycomb', 'minecraft:blue_ice'],
+                entity: 'thermal:blizz',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['#forge:dusts/apatite', 'resourcefulbees:rocky_honeycomb', 'minecraft:basalt'],
+                entity: 'thermal:basalz',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['#forge:dusts/sulfur', 'resourcefulbees:coal_honeycomb', 'minecraft:nether_bricks'],
+                entity: 'minecraft:blaze',
+                aura: 150000,
+                time: 120,
+                id: 'naturesaura:animal_spawner/blaze'
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        let ingredients = [Ingredient.of('naturesaura:birth_spirit').toJson()];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input).toJson());
+        });
+
+        const re = event.custom({
+            type: 'naturesaura:animal_spawner',
+            ingredients: ingredients,
+            entity: recipe.entity,
+            aura: recipe.aura,
+            time: recipe.time
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/induction_smelter.js
@@ -1,0 +1,20 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [
+            {
+                inputs: [Item.of('#forge:ingots/cobalt', 3), 'thermal:blizz_powder'],
+                outputs: [Item.of('undergarden:froststeel_ingot', 3)]
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.thermal.smelter(recipe.outputs, recipe.inputs);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/animal_spawner.js
@@ -1,0 +1,42 @@
+events.listen('recipes', (event) => {
+    var data = {
+        recipes: [
+            {
+                inputs: ['thermal:blitz_rod', 'thermal:blitz_powder'],
+                entity: 'thermal:blitz',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['thermal:blizz_rod', 'thermal:blizz_powder'],
+                entity: 'thermal:blizz',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['thermal:basalz_rod', 'thermal:basalz_powder'],
+                entity: 'thermal:basalz',
+                aura: 150000,
+                time: 120
+            }
+        ]
+    };
+    data.recipes.forEach((recipe) => {
+        let ingredients = [Ingredient.of('naturesaura:birth_spirit').toJson()];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input).toJson());
+        });
+
+        const re = event.custom({
+            type: 'naturesaura:animal_spawner',
+            ingredients: ingredients,
+            entity: recipe.entity,
+            aura: recipe.aura,
+            time: recipe.time
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/animal_spawner.js
@@ -1,4 +1,7 @@
 events.listen('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
     var data = {
         recipes: [
             {


### PR DESCRIPTION
Mana Steel now crafted from Froststeel. Sunstone catalyst required.

![image](https://user-images.githubusercontent.com/9543430/118346148-66dba000-b507-11eb-82b4-4c78125500f5.png)

Froststeel may now be crafted as any alloy using Cobalt and Blizz powder. This is an optional tech recipe that may be used to replace mining Froststeel in the Undergarden.

Mana Pools now use 1 Warding Stone

![image](https://user-images.githubusercontent.com/9543430/118347353-9f33ac00-b510-11eb-87ea-8734dd67d9d1.png)

New recipes for the four basic Botania Runes, using many of the items used so far in magic progression. Mana cost increased.

Water:
![image](https://user-images.githubusercontent.com/9543430/118349188-330b7500-b51d-11eb-87d1-d4c0fd42f7e2.png)

Fire:
![image](https://user-images.githubusercontent.com/9543430/118349201-41f22780-b51d-11eb-88e7-7f0ec39f1411.png)

Earth:
![image](https://user-images.githubusercontent.com/9543430/118349210-5504f780-b51d-11eb-840d-18a0f5ad0455.png)

Air:
![image](https://user-images.githubusercontent.com/9543430/118349220-63531380-b51d-11eb-8c3f-6c89534c2a16.png)

Adds some helper JEI descriptions so people know how to get things like infused coralstone and corundum for runes.