### PR TITLE
More progression recipes

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -224,6 +224,10 @@ events.listen('jei.information', (event) => {
             description: [
                 'Obtained by Right-Clicking a Bottle and Cork in the air in the Nether. This action removes Aura from the area.'
             ]
+        },
+        {
+            items: ['quark:root_item'],
+            description: ['Drops occasionally when breaking Cave Roots.']
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -61,7 +61,7 @@ events.listen('recipes', (event) => {
             inputs: ['#forge:chocolate_bars', 'minecraft:sugar', 'minecraft:sugar']
         },
         { output: 'minecraft:wheat_seeds', inputs: ['minecraft:wheat'] },
-        { output: 'quark:root', inputs: ['minecraft:vine', '#forge:dyes/brown'] },
+
         {
             output: Item.of('patchouli:guide_book', { 'patchouli:book': 'patchouli:modded_for_dummies' }),
             inputs: ['minecraft:book', '#forge:dyes/yellow']

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -14,7 +14,8 @@ events.listen('recipes', (event) => {
     const patchouli_safe_removals = [
         { output: 'ars_nouveau:arcane_stone', id: 'ars_nouveau:arcane_stone' },
         { output: 'ars_nouveau:crystallizer', id: 'ars_nouveau:crystallizer' },
-        { output: 'ars_nouveau:volcanic_accumulator', id: 'ars_nouveau:volcanic_accumulator' }
+        { output: 'ars_nouveau:volcanic_accumulator', id: 'ars_nouveau:volcanic_accumulator' },
+        { output: 'naturesaura:calling_spirit', id: 'naturesaura:calling_spirit' }
     ];
 
     idRemovals.forEach((id) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -375,6 +375,18 @@ events.listen('recipes', (event) => {
                 B: 'ars_nouveau:warding_stone'
             },
             id: 'botania:fabulous_pool'
+        },
+        {
+            output: 'bloodmagic:incensealtar',
+            pattern: ['CBC', 'CDC', 'EAE'],
+            key: {
+                A: { type: 'bloodmagic:bloodorb', orb_tier: 1 },
+                B: Item.of('botania:incense_stick', { brewKey: 'botania:soul_cross' }),
+                C: 'eidolon:polished_planks',
+                D: 'eidolon:crucible',
+                E: 'eidolon:polished_wood_pillar'
+            },
+            id: 'bloodmagic:incense_altar'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
@@ -18,14 +18,19 @@ events.listen('recipes', (event) => {
             inputs: ['architects_palette:sunmetal_block']
         },
         {
-            output: Item.of('ars_nouveau:potion_jar'),
+            output: 'ars_nouveau:potion_jar',
             inputs: ['ars_nouveau:mana_jar', ['minecraft:nether_wart', 'eidolon:fungus_sprouts']],
             id: 'ars_nouveau:potion_jar'
         },
         {
-            output: Item.of('naturesaura:bottle_two_the_rebottling'),
+            output: 'naturesaura:bottle_two_the_rebottling',
             inputs: ['minecraft:glass_bottle', 'farmersdelight:tree_bark'],
             id: 'naturesaura:bottle_two_the_rebottling'
+        },
+        {
+            output: 'botania:redstone_root',
+            inputs: ['quark:root_item', '#forge:dusts/redstone'],
+            id: 'botania:redstone_root'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
@@ -7,6 +7,7 @@ events.listen('recipes', (event) => {
         {
             input: '#forge:ingots/froststeel',
             output: 'botania:manasteel_ingot',
+            count: 1,
             mana: 3000,
             catalyst: 'architects_palette:sunstone',
             id: 'botania:mana_infusion/manasteel'
@@ -14,9 +15,18 @@ events.listen('recipes', (event) => {
         {
             input: '#forge:storage_blocks/froststeel',
             output: 'botania:manasteel_block',
+            count: 1,
             mana: 27000,
             catalyst: 'architects_palette:sunstone',
             id: 'botania:mana_infusion/manasteel_block'
+        },
+        {
+            input: 'betterendforge:silk_fiber',
+            output: 'botania:mana_string',
+            count: 6,
+            mana: 5000,
+            catalyst: 'architects_palette:sunstone',
+            id: 'botania:mana_infusion/mana_string'
         }
     ];
 
@@ -24,7 +34,7 @@ events.listen('recipes', (event) => {
         let constructed_recipe = {
             type: 'botania:mana_infusion',
             input: Ingredient.of(recipe.input).toJson(),
-            output: Ingredient.of(recipe.output).toJson(),
+            output: { item: recipe.output, count: recipe.count },
             mana: recipe.mana
         };
         if (recipe.catalyst) {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -59,6 +59,20 @@ events.listen('recipes', (event) => {
             output: 'botania:rune_air',
             count: 2,
             id: 'botania:runic_altar/air'
+        },
+        {
+            inputs: [
+                '#forge:ingots/manasteel',
+                '#forge:ingots/manasteel',
+                'naturesaura:sky_ingot',
+                '#forge:ingots/manasteel',
+                '#forge:ingots/manasteel',
+                'botania:mana_pearl'
+            ],
+            mana: 10400,
+            output: 'botania:rune_mana',
+            count: 1,
+            id: 'botania:runic_altar/mana'
         }
     ];
 
@@ -68,7 +82,6 @@ events.listen('recipes', (event) => {
         recipe.inputs.forEach((input) => {
             ingredients.push(Ingredient.of(input).toJson());
         });
-        console.log(ingredients);
 
         const re = event.custom({
             type: 'botania:runic_altar',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -93,6 +93,33 @@ events.listen('recipes', (event) => {
                 empty_weight: 0,
                 rolls: 1
             }
+        },
+        {
+            inputs: [
+                {
+                    type: 'forge:nbt',
+                    item: 'naturesaura:aura_bottle',
+                    count: 1,
+                    nbt: '{stored_type:"naturesaura:overworld"}'
+                },
+                { item: 'naturesaura:infused_iron', count: 1 },
+                { item: 'botania:rune_water', count: 1, return_chance: 0.75 },
+                { item: 'botania:rune_earth', count: 1, return_chance: 0.75 },
+                {
+                    type: 'forge:nbt',
+                    item: 'naturesaura:aura_bottle',
+                    count: 1,
+                    nbt: '{stored_type:"naturesaura:nether"}'
+                },
+                { item: 'naturesaura:tainted_gold', count: 1 },
+                { item: 'botania:rune_fire', count: 1, return_chance: 0.75 },
+                { item: 'botania:rune_air', count: 1, return_chance: 0.75 }
+            ],
+            output: {
+                entries: [{ result: { item: 'naturesaura:calling_spirit', count: 3 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            }
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -51,6 +51,14 @@ events.listen('recipes', (event) => {
                 aura_type: 'naturesaura:overworld',
                 aura: 15000,
                 time: 80
+            },
+            {
+                input: 'minecraft:vine',
+                output: 'quark:root',
+                aura_type: 'naturesaura:nether',
+                catalyst: 'naturesaura:conversion_catalyst',
+                aura: 30000,
+                time: 250
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -259,6 +259,20 @@ events.listen('recipes', (event) => {
                 count: 1,
                 sapling: 'quark:lavender_blossom_sapling',
                 id: 'naturesstarlight:crystal_generator'
+            },
+            {
+                inputs: [
+                    { item: 'botania:livingrock' }, //top
+                    { item: 'botania:livingrock' }, //bottom
+                    { item: 'botania:livingrock' }, //left
+                    { item: 'botania:livingrock' }, //right
+                    { item: 'minecraft:heart_of_the_sea' }, //topleft
+                    { item: 'botania:livingrock' } //bottomright
+                ],
+                output: 'botania:runic_altar',
+                count: 1,
+                sapling: 'quark:lavender_blossom_sapling',
+                id: 'botania:runic_altar'
             }
             /*
             ,

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shapeless.js
@@ -12,6 +12,10 @@ events.listen('recipes', (event) => {
         {
             output: Item.of('buildersaddition:large_candle', 4),
             inputs: ['#forge:wax', '#forge:wax', '#forge:wax', '#forge:string']
+        },
+        {
+            output: 'quark:root',
+            inputs: ['minecraft:vine', '#forge:dyes/brown']
         }
     ];
 


### PR DESCRIPTION
Incense Altar now needs access to botania brews
![image](https://user-images.githubusercontent.com/9543430/118375570-5faca480-b590-11eb-9bac-a701f86d2905.png)

Runic Altar made by the ritual of the forest:
![image](https://user-images.githubusercontent.com/9543430/118375931-f24e4300-b592-11eb-9e6d-1e85af536f98.png)

Cave Roots now crafted with Crimson Altar:
![image](https://user-images.githubusercontent.com/9543430/118376291-1dd22d00-b595-11eb-9749-716a89250991.png)

JEI Description added to help with Cave Root Item
Redstone Root now uses Cave Root
![image](https://user-images.githubusercontent.com/9543430/118376515-5fafa300-b596-11eb-8cad-fc4e99e2ae06.png)

Rune of Mana now uses Ingot of the Skies, mana cost increased
![image](https://user-images.githubusercontent.com/9543430/118377257-2da04000-b59a-11eb-883a-43d054e76979.png)

Spirit of Calling now crafted with Lightning! Involves basic Botania Runes and NA resources. Runes are returned, but have a 25% chance of being destroyed in the process.

![image](https://user-images.githubusercontent.com/9543430/118377769-5970f500-b59d-11eb-868a-4dd1772a6959.png)