### PR TITLE
Botania crafting tweaks

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -154,6 +154,8 @@ var itemsToHide = [
     'thermal:press_packing_3x3_die',
     'thermal:press_packing_2x2_die',
     'thermal:press_unpacking_die',
+    'simplefarming:apple_pie',
+    'simplefarming:blueberry_pie',
     'supplementaries:pedestal',
     'supplementaries:crank',
     'supplementaries:cog_block',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -159,6 +159,9 @@ events.listen('recipes', (event) => {
 
         'quark:building/crafting/tallow_from_block',
 
+        'simplefarming:apple_pie',
+        'simplefarming:blueberry_pie',
+
         'thermal:machine/smelter/smelter_alloy_netherite',
         'thermal:machine/press/packing2x2/press_honeycomb_packing',
         'thermal:machine/refinery/refinery_crude_oil',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -297,6 +297,201 @@ events.listen('recipes', (event) => {
                 B: 'resourcefulbees:wax',
                 A: 'minecraft:bucket'
             }
+        },
+        {
+            output: Item.of('farmersdelight:pie_crust', 3),
+            pattern: ['A A', 'AAA'],
+            key: {
+                A: 'farmersdelight:wheat_dough'
+            },
+            id: 'farmersdelight:pie_crust'
+        },
+        {
+            output: 'upgrade_aquatic:mulberry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'upgrade_aquatic:mulberry'
+            },
+            id: 'upgrade_aquatic:mulberry_pie'
+        },
+        {
+            output: 'byg:blueberry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: '#forge:fruits/blueberries'
+            },
+            id: 'byg:blueberry_pie'
+        },
+        {
+            output: 'byg:nightshade_berry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'byg:nightshade_berries'
+            },
+            id: 'byg:nightshade_berry_pie'
+        },
+        {
+            output: 'byg:crimson_berry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'byg:crimson_berries'
+            },
+            id: 'byg:crimson_berry_pie'
+        },
+        {
+            output: 'byg:green_apple_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'byg:green_apple'
+            },
+            id: 'byg:green_apple_pie'
+        },
+        {
+            output: 'farmersdelight:chocolate_pie',
+            pattern: ['DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                D: 'create:bar_of_chocolate'
+            },
+            id: 'farmersdelight:chocolate_pie'
+        },
+        {
+            output: 'farmersdelight:apple_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'minecraft:apple'
+            },
+            id: 'farmersdelight:apple_pie'
+        },
+        {
+            output: 'simplefarming:strawberry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:strawberries'
+            },
+            id: 'simplefarming:strawberry_pie'
+        },
+        {
+            output: 'simplefarming:raspberry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:raspberries'
+            },
+            id: 'simplefarming:raspberry_pie'
+        },
+        {
+            output: 'simplefarming:plum_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:plum'
+            },
+            id: 'simplefarming:plum_pie'
+        },
+        {
+            output: 'simplefarming:pear_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:pear'
+            },
+            id: 'simplefarming:pear_pie'
+        },
+        {
+            output: 'simplefarming:peanut_butter_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:peanut'
+            },
+            id: 'simplefarming:peanut_butter_pie'
+        },
+        {
+            output: 'simplefarming:cherry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:cherries'
+            },
+            id: 'simplefarming:cherry_pie'
+        },
+        {
+            output: 'simplefarming:blackberry_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:blackberries'
+            },
+            id: 'simplefarming:blackberry_pie'
+        },
+        {
+            output: 'simplefarming:apricot_pie',
+            pattern: [' C ', 'DDD', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: 'farmersdelight:wheat_dough',
+                D: 'simplefarming:apricot'
+            },
+            id: 'simplefarming:apricot_pie'
+        },
+        {
+            output: 'minecraft:pumpkin_pie',
+            pattern: ['CDC', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: 'minecraft:sugar',
+                C: '#forge:eggs',
+                D: '#forge:pumpkins'
+            },
+            id: 'minecraft:pumpkin_pie'
+        },
+        {
+            output: 'undergarden:gloomgourd_pie',
+            pattern: ['CCC', 'EDE', 'BAB'],
+            key: {
+                A: 'farmersdelight:pie_crust',
+                B: '#undergarden:mushrooms',
+                C: 'undergarden:glowing_kelp',
+                D: 'undergarden:gloomgourd',
+                E: '#forge:eggs'
+            },
+            id: 'undergarden:gloomgourd_pie'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/compacting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/compacting.js
@@ -10,59 +10,40 @@ events.listen('recipes', (event) => {
     var data = {
         recipes_unheated: [
             {
-                inputs: [
-                    Fluid.of('resourcefulbees:honey')
-                ],
+                inputs: [Fluid.of('resourcefulbees:honey')],
                 output: 'minecraft:honey_block'
             },
             {
                 inputs: [
-                    'create:wheat_flour',
-                    'create:wheat_flour',
-                    'create:wheat_flour',
-                    {fluidTag: 'forge:milk', amount: 250}
-                ],
-                output: 'farmersdelight:pie_crust'
-            },
-            {
-                inputs: [
                     '#forge:dusts/wood',
                     '#forge:dusts/wood',
                     '#forge:dusts/wood',
-                    {fluidTag: 'minecraft:water', amount: 250}
+                    { fluidTag: 'minecraft:water', amount: 250 }
                 ],
                 output: Item.of('minecraft:paper', 2)
             },
             {
-                inputs: [
-                    Fluid.of('immersiveengineering:concrete', 500)
-                ],
+                inputs: [Fluid.of('immersiveengineering:concrete', 500)],
                 output: 'immersiveengineering:slab_concrete'
             },
             {
-                inputs: [
-                    Fluid.of('thermal:latex', 1000)
-                ],
+                inputs: [Fluid.of('thermal:latex', 1000)],
                 output: Item.of('thermal:rubber', 3)
             }
         ],
         recipes_heated: [
             {
-                inputs: [
-                    'minecraft:vine'
-                ],
+                inputs: ['minecraft:vine'],
                 output: Fluid.of('thermal:latex', 50)
             },
             {
-                inputs: [
-                    'minecraft:dandelion'
-                ],
+                inputs: ['minecraft:dandelion'],
                 output: Fluid.of('thermal:latex', 50)
             }
         ],
         recipes_superheated: []
     };
-    
+
     data.recipes_unheated.forEach((recipe) => {
         event.recipes.create.compacting(recipe.output, recipe.inputs);
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/fruits.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/fruits.js
@@ -15,4 +15,5 @@ events.listen('item.tags', (event) => {
     event.add('forge:fruits/yucca_fruit', ['atmospheric:yucca_fruit']);
     event.add('forge:fruits/passionfruit', ['atmospheric:passionfruit']);
     event.add('forge:fruits/menril_berries', ['integrateddynamics:menril_berries']);
+    event.add('forge:fruits/blueberries', ['byg:blueberries']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/pies.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/pies.js
@@ -1,0 +1,3 @@
+events.listen('item.tags', (event) => {
+    event.get('forge:pies').add(/_pie$/).remove('farmersdelight:shepherds_pie');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -18,6 +18,21 @@ events.listen('recipes', (event) => {
         {
             inputs: [{ tag: 'forge:mushrooms' }, { item: 'thermal:phytogro' }],
             output: { item: 'eidolon:fungus_sprouts', count: 2 }
+        },
+        {
+            inputs: [
+                { tag: 'botania:petals/pink' },
+                { tag: 'botania:petals/pink' },
+                { tag: 'botania:petals/purple' },
+                { tag: 'botania:petals/purple' },
+                { tag: 'botania:petals/lime' },
+                { item: 'botania:life_essence' },
+                { tag: 'botania:runes/mana' },
+                { tag: 'botania:runes/mana' },
+                { tag: 'botania:runes/mana' }
+            ],
+            output: { item: 'botania:rosa_arcana' },
+            id: 'botania:petal_apothecary/rosa_arcana'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/runic_altar.js
@@ -69,10 +69,74 @@ events.listen('recipes', (event) => {
                 '#forge:ingots/manasteel',
                 'botania:mana_pearl'
             ],
-            mana: 10400,
+            mana: 16000,
             output: 'botania:rune_mana',
             count: 1,
             id: 'botania:runic_altar/mana'
+        },
+        {
+            inputs: [
+                '#botania:runes/water',
+                '#botania:runes/fire',
+                'naturesaura:birth_spirit',
+                'thermal:syrup_bucket',
+                '#minecraft:saplings',
+                '#minecraft:saplings',
+                'quark:turf',
+                'quark:turf'
+            ],
+            mana: 16000,
+            output: 'botania:rune_spring',
+            count: 1,
+            id: 'botania:runic_altar/spring'
+        },
+        {
+            inputs: [
+                '#botania:runes/earth',
+                '#botania:runes/air',
+                '#forge:sand',
+                '#forge:sand',
+                'farmersdelight:melon_popsicle',
+                'farmersdelight:melon_popsicle',
+                '#forge:pies',
+                '#forge:pies'
+            ],
+            mana: 16000,
+            output: 'botania:rune_summer',
+            count: 1,
+            id: 'botania:runic_altar/summer'
+        },
+        {
+            inputs: [
+                '#botania:runes/fire',
+                '#botania:runes/air',
+                'minecraft:carved_pumpkin',
+                'minecraft:carved_pumpkin',
+                'create:honeyed_apple',
+                'create:honeyed_apple',
+                'farmersdelight:hot_cocoa',
+                'farmersdelight:hot_cocoa'
+            ],
+            mana: 16000,
+            output: 'botania:rune_autumn',
+            count: 1,
+            id: 'botania:runic_altar/autumn'
+        },
+        {
+            inputs: [
+                '#botania:runes/water',
+                '#botania:runes/earth',
+                'farmersdelight:shepherds_pie_block',
+                '#upgrade_aquatic:bedrolls',
+                '#forge:hay_bales',
+                '#forge:hay_bales',
+                'betterendforge:dense_snow',
+                'betterendforge:dense_snow'
+            ],
+            mana: 16000,
+            output: 'botania:rune_winter',
+            count: 1,
+            id: 'botania:runic_altar/winter'
         }
     ];
 


### PR DESCRIPTION
Pies Unified and altered to this general layout:
![image](https://user-images.githubusercontent.com/9543430/118381903-d318db00-b5bd-11eb-8f05-5b5815a1718f.png)

Pie Crusts now made from dough

New recipes for Seasonal Runes. Mana cost increased as well.
Spring:
![image](https://user-images.githubusercontent.com/9543430/118382176-ca75d400-b5c0-11eb-9787-cc7661200169.png)
Would prefer Syrup bottles. With Autumnity on the chopping block, maybe @Ridanisaurus would be kind enough to make a nice bottle?

Summer:
![image](https://user-images.githubusercontent.com/9543430/118382274-ae266700-b5c1-11eb-93ad-7c75c37e1171.png)

Autumn:
![image](https://user-images.githubusercontent.com/9543430/118382226-30625b80-b5c1-11eb-94f8-2d14e2cbbc02.png)

Winter:
![image](https://user-images.githubusercontent.com/9543430/118382232-3d7f4a80-b5c1-11eb-8bd7-4b13dd98bbdd.png)

Rosa Arcana:
![image](https://user-images.githubusercontent.com/9543430/118382771-a3220580-b5c6-11eb-9173-bbb662bfe430.png)

Pushed back because this is quite simply the most powerful mana generator in the pack due to the general ease of dropping xp orbs on the floor.