### PR TITLE
Altar of Birthing tweaks

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
@@ -44,22 +44,55 @@ events.listen('recipes', (event) => {
                 time: 120
             },
             {
-                inputs: ['resourcefulbees:iron_bee_spawn_egg', 'resourcefulbees:iron_honeycomb','naturesaura:infused_iron_block'],
+                inputs: [
+                    'resourcefulbees:iron_bee_spawn_egg',
+                    'resourcefulbees:iron_honeycomb',
+                    'naturesaura:infused_iron_block'
+                ],
                 entity: 'resourcefulbees:infused_bee',
                 aura: 400000,
                 time: 320
             },
             {
-                inputs: ['resourcefulbees:gold_bee_spawn_egg', 'resourcefulbees:gold_honeycomb','naturesaura:tainted_gold_block'],
+                inputs: [
+                    'resourcefulbees:gold_bee_spawn_egg',
+                    'resourcefulbees:gold_honeycomb',
+                    'naturesaura:tainted_gold_block'
+                ],
                 entity: 'resourcefulbees:tainted_bee',
                 aura: 500000,
                 time: 400
             },
             {
-                inputs: ['resourcefulbees:gold_bee_spawn_egg', 'resourcefulbees:tainted_honeycomb','naturesaura:sky_ingot'],
+                inputs: [
+                    'resourcefulbees:gold_bee_spawn_egg',
+                    'resourcefulbees:tainted_honeycomb',
+                    'naturesaura:sky_ingot'
+                ],
                 entity: 'resourcefulbees:sky_bee',
                 aura: 600000,
                 time: 480
+            },
+            {
+                inputs: ['farmersdelight:cabbage_leaf', 'simplefarming:lettuce', 'minecraft:carrot'],
+                entity: 'minecraft:rabbit',
+                aura: 30000,
+                time: 40,
+                id: 'naturesaura:animal_spawner/rabbit'
+            },
+            {
+                inputs: ['astralsorcery:nocturnal_powder'],
+                entity: 'minecraft:phantom',
+                aura: 200000,
+                time: 200,
+                id: 'naturesaura:animal_spawner/phantom'
+            },
+            {
+                inputs: ['minecraft:feather', 'minecraft:jungle_sapling'],
+                entity: 'minecraft:parrot',
+                aura: 50000,
+                time: 60,
+                id: 'naturesaura:animal_spawner/parrot'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -16,7 +16,8 @@ events.listen('recipes', (event) => {
         { output: 'ars_nouveau:arcane_stone', id: 'ars_nouveau:arcane_stone' },
         { output: 'ars_nouveau:crystallizer', id: 'ars_nouveau:crystallizer' },
         { output: 'ars_nouveau:volcanic_accumulator', id: 'ars_nouveau:volcanic_accumulator' },
-        { output: 'naturesaura:calling_spirit', id: 'naturesaura:calling_spirit' }
+        { output: 'naturesaura:calling_spirit', id: 'naturesaura:calling_spirit' },
+        { output: 'naturesaura:animal_spawner', id: 'naturesaura:animal_spawner' }
     ];
 
     idRemovals.forEach((id) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -190,6 +190,22 @@ events.listen('recipes', (event) => {
                 count: 1,
                 id: 'ars_nouveau:wand'
             },
+            {
+                inputs: [
+                    '#resourcefulbees:resourceful_honeycomb_block',
+                    'ars_nouveau:summoning_crystal',
+                    '#resourcefulbees:resourceful_honeycomb_block',
+                    'naturesaura:token_joy',
+                    'naturesaura:token_anger',
+                    '#resourcefulbees:resourceful_honeycomb_block',
+                    'ars_nouveau:summoning_crystal',
+                    '#resourcefulbees:resourceful_honeycomb_block'
+                ],
+                reagent: 'minecraft:spawner',
+                output: 'naturesaura:animal_spawner',
+                count: 1,
+                id: 'naturesaura:animal_spawner'
+            },
 
             /// Patchouli Removals
             {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
@@ -35,6 +35,24 @@ events.listen('recipes', (event) => {
                 aura: 150000,
                 time: 120,
                 id: 'naturesaura:animal_spawner/blaze'
+            },
+            {
+                inputs: ['resourcefulbees:bloody_honeycomb', 'minecraft:blue_ice'],
+                entity: 'ars_nouveau:wilden_guardian',
+                aura: 250000,
+                time: 120
+            },
+            {
+                inputs: ['resourcefulbees:bloody_honeycomb', 'valhelsia_structures:bone_pile'],
+                entity: 'ars_nouveau:wilden_hunter',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['resourcefulbees:bloody_honeycomb', 'astralsorcery:nocturnal_powder'],
+                entity: 'ars_nouveau:wilden_stalker',
+                aura: 150000,
+                time: 120
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/animal_spawner.js
@@ -21,6 +21,24 @@ events.listen('recipes', (event) => {
                 entity: 'thermal:basalz',
                 aura: 150000,
                 time: 120
+            },
+            {
+                inputs: ['ars_nouveau:wilden_spike', 'minecraft:snow_block'],
+                entity: 'ars_nouveau:wilden_guardian',
+                aura: 250000,
+                time: 120
+            },
+            {
+                inputs: ['ars_nouveau:wilden_horn', 'minecraft:bone'],
+                entity: 'ars_nouveau:wilden_hunter',
+                aura: 150000,
+                time: 120
+            },
+            {
+                inputs: ['ars_nouveau:wilden_wing', 'astralsorcery:nocturnal_powder'],
+                entity: 'ars_nouveau:wilden_stalker',
+                aura: 150000,
+                time: 120
             }
         ]
     };


### PR DESCRIPTION
Altar of Birthing made obtainable a little earlier in expert. Accepts any comb block.
![image](https://user-images.githubusercontent.com/9543430/118746951-1de95b80-b827-11eb-8c68-f75d82597a37.png)

More Altar of Birthing summons for normal mode:
![image](https://user-images.githubusercontent.com/9543430/118900678-8dbb1d00-b8df-11eb-9a05-9a06bd57c64a.png)
![image](https://user-images.githubusercontent.com/9543430/118900703-97dd1b80-b8df-11eb-8527-acf5f5ca3936.png)
![image](https://user-images.githubusercontent.com/9543430/118900759-bba06180-b8df-11eb-90b0-012198928480.png)

All modes:
![image](https://user-images.githubusercontent.com/9543430/118901129-8cd6bb00-b8e0-11eb-98cc-20f8a981e4f9.png)
![image](https://user-images.githubusercontent.com/9543430/118901176-9fe98b00-b8e0-11eb-9e5d-95f7a1237fd5.png)
![image](https://user-images.githubusercontent.com/9543430/118901272-d9ba9180-b8e0-11eb-8874-2bcac673f8db.png)

Expert:
![image](https://user-images.githubusercontent.com/9543430/118901296-ea6b0780-b8e0-11eb-95d0-31eb618ef020.png)