### PR TITLE
Found error in adventuring_time.json and corrected it

### DIFF
--- a/kubejs/data/minecraft/advancements/adventure/adventuring_time.json
+++ b/kubejs/data/minecraft/advancements/adventure/adventuring_time.json
@@ -276,14 +276,6 @@
         }
       }
     },
-    "minecraft:wooded_mountains": {
-      "trigger": "minecraft:location",
-      "conditions": {
-        "location": {
-          "biome": "minecraft:wooded_mountains"
-        }
-      }
-    },
     "minecraft:warm_ocean": {
       "trigger": "minecraft:location",
       "conditions": {
@@ -445,9 +437,6 @@
     ],
     [
       "minecraft:mushroom_fields"
-    ],
-    [
-      "minecraft:wooded_mountains"
     ],
     [
       "minecraft:warm_ocean"


### PR DESCRIPTION
Current Version: 0.4.13
Related to: NillerMedDild#2136

So I gathered the required biomes for the advancement from the following files:

> \kubejs\data\minecraft\advancements\adventure\adventuring_time.json
> \mods\atmospheric-1.16.5-3.1.0.jar\data\atmospheric\modifiers\advancements\adventuring_time.json
> \mods\autumnity-1.16.5-2.1.1.jar\data\autumnity\modifiers\advancements\adventuring_time.json

And compared them to the biome weights from the following files:

> \config\terraforged\biome_weights.conf (overrides the following)
> \config\atmospheric-common.toml
> \config\autumnity-common.toml

I only found one error:

"minecraft:wooded_mountains" is needed for the advancement, but has a biome weight of 0

As attaching the text file throws an error, I pasted the biomes I checked to [Pastebin](https://pastebin.com/rzBSndXa)
I do not believe to have missed any biomes, as I found 59 of them and the advancement ingame requires 59