### PR TITLE
Astral Sorcery and Blood Magic Progression

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
@@ -2,8 +2,7 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             { inputTag: '#forge:ores/iron', output: 'astralsorcery:starmetal_ore', starlight: 100 },
-            { inputTag: '#forge:ores/diamond', output: 'emendatusenigmatica:emerald_ore', starlight: 1000 },
-            { inputTag: '#forge:workbench', output: 'astralsorcery:altar_discovery', starlight: 60 }
+            { inputTag: '#forge:ores/diamond', output: 'emendatusenigmatica:emerald_ore', starlight: 1000 }
         ]
     };
     data.recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -9,7 +9,8 @@ events.listen('recipes', (event) => {
         'quark:building/crafting/candles/candle_basic',
         'betterendforge:leather_to_stripes',
         'astralsorcery:shaped/black_marble/black_marble_raw',
-        'astralsorcery:altar/black_marble_raw'
+        'astralsorcery:altar/black_marble_raw',
+        'astralsorcery:shaped/wand'
     ];
 
     const outputRemovals = ['create:andesite_alloy', 'tiab:timeinabottle'];

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -7,7 +7,9 @@ events.listen('recipes', (event) => {
         'ars_nouveau:stone_2',
         'minecraft:leather_to_stripes',
         'quark:building/crafting/candles/candle_basic',
-        'betterendforge:leather_to_stripes'
+        'betterendforge:leather_to_stripes',
+        'astralsorcery:shaped/black_marble/black_marble_raw',
+        'astralsorcery:altar/black_marble_raw'
     ];
 
     const outputRemovals = ['create:andesite_alloy', 'tiab:timeinabottle'];

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -611,6 +611,73 @@ events.listen('recipes', (event) => {
                 D: 'ars_nouveau:purple_archwood_wood'
             },
             id: 'eidolon:worktable'
+        },
+        {
+            output: 'astralsorcery:wand',
+            pattern: [' CD', ' AC', 'AB '],
+            key: {
+                A: '#forge:rods/silver',
+                B: 'betterendforge:leather_stripe',
+                C: '#forge:gems/aquamarine',
+                D: 'eidolon:ender_calx'
+            },
+            id: 'astralsorcery:altar/wand'
+        },
+        {
+            output: 'astralsorcery:blink_wand',
+            pattern: [' EC', 'EAD', 'AB '],
+            key: {
+                A: '#forge:rods/silver',
+                B: 'betterendforge:leather_stripe',
+                C: '#forge:gems/aquamarine',
+                D: 'bloodmagic:reagentair',
+                E: 'integrateddynamics:crystalized_menril_chunk'
+            },
+            id: 'astralsorcery:altar/blink_wand'
+        },
+        {
+            output: 'astralsorcery:exchange_wand',
+            pattern: [' DC', 'CA ', 'AB '],
+            key: {
+                A: '#forge:rods/silver',
+                B: 'betterendforge:leather_stripe',
+                C: 'byg:warped_coral_block',
+                D: '#forge:ingots/lead'
+            },
+            id: 'astralsorcery:altar/exchange_wand'
+        },
+        {
+            output: 'astralsorcery:grapple_wand',
+            pattern: [' CD', 'CA ', 'AB '],
+            key: {
+                A: '#forge:rods/silver',
+                B: 'betterendforge:leather_stripe',
+                C: '#forge:gems/aquamarine',
+                D: 'alexsmobs:guster_eye'
+            },
+            id: 'astralsorcery:altar/grapple_wand'
+        },
+        {
+            output: 'astralsorcery:illumination_wand',
+            pattern: [' CD', ' AC', 'AB '],
+            key: {
+                A: '#forge:rods/silver',
+                B: 'betterendforge:leather_stripe',
+                C: '#forge:gems/aquamarine',
+                D: 'astralsorcery:illumination_powder'
+            },
+            id: 'astralsorcery:altar/illumination_wand'
+        },
+        {
+            output: 'astralsorcery:architect_wand',
+            pattern: [' CD', ' AC', 'AB '],
+            key: {
+                A: '#forge:rods/silver',
+                B: 'betterendforge:leather_stripe',
+                C: 'integrateddynamics:crystalized_chorus_chunk',
+                D: '#forge:gems/aquamarine'
+            },
+            id: 'astralsorcery:altar/architect_wand'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -223,7 +223,7 @@ events.listen('recipes', (event) => {
                 A: 'ars_nouveau:warding_stone',
                 B: '#forge:nuggets/gold_brass',
                 C: '#forge:ingots/gold_brass',
-                D: 'minecraft:heart_of_the_sea'
+                D: 'minecraft:conduit'
             },
             id: 'ars_nouveau:enchanting_apparatus'
         },
@@ -507,7 +507,8 @@ events.listen('recipes', (event) => {
             },
             id: 'bloodmagic:blood_rune_charging'
         },
-        { //Gate Beehive behind starting Nature's Aura
+        {
+            //Gate Beehive behind starting Nature's Aura
             output: 'resourcefulbees:t1_beehive',
             pattern: ['ACA', 'ABA', 'ACA'],
             key: {
@@ -541,7 +542,7 @@ events.listen('recipes', (event) => {
             id: 'resourcefulbees:centrifuge'
         },
         {
-            output: Item.of('resourcefulbees:centrifuge_casing',4),
+            output: Item.of('resourcefulbees:centrifuge_casing', 4),
             pattern: ['CBC', 'BAB', 'CBC'],
             key: {
                 A: 'rftoolsbase:machine_frame',
@@ -583,6 +584,33 @@ events.listen('recipes', (event) => {
                 E: 'resourcefulbees:elite_centrifuge_casing'
             },
             id: 'resourcefulbees:elite_centrifuge_controller'
+        },
+        {
+            output: 'astralsorcery:linking_tool',
+            pattern: [' CD', ' AC', 'AB '],
+            key: {
+                A: 'betterendforge:leather_wrapped_stick',
+                B: '#forge:gems/aquamarine',
+                C: '#forge:rods/brass',
+                D: [
+                    'astralsorcery:rock_crystal',
+                    'astralsorcery:celestial_crystal',
+                    'astralsorcery:attuned_rock_crystal',
+                    'astralsorcery:attuned_celestial_crystal'
+                ]
+            },
+            id: 'astralsorcery:altar/linking_tool'
+        },
+        {
+            output: 'eidolon:worktable',
+            pattern: ['AAA', 'BCB', 'DDD'],
+            key: {
+                A: 'minecraft:red_carpet',
+                B: 'eidolon:pewter_inlay',
+                C: 'minecraft:conduit',
+                D: 'ars_nouveau:purple_archwood_wood'
+            },
+            id: 'eidolon:worktable'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -624,29 +624,6 @@ events.listen('recipes', (event) => {
             id: 'astralsorcery:altar/wand'
         },
         {
-            output: 'astralsorcery:blink_wand',
-            pattern: [' EC', 'EAD', 'AB '],
-            key: {
-                A: '#forge:rods/silver',
-                B: 'betterendforge:leather_stripe',
-                C: '#forge:gems/aquamarine',
-                D: 'bloodmagic:reagentair',
-                E: 'integrateddynamics:crystalized_menril_chunk'
-            },
-            id: 'astralsorcery:altar/blink_wand'
-        },
-        {
-            output: 'astralsorcery:exchange_wand',
-            pattern: [' DC', 'CA ', 'AB '],
-            key: {
-                A: '#forge:rods/silver',
-                B: 'betterendforge:leather_stripe',
-                C: 'byg:warped_coral_block',
-                D: '#forge:ingots/lead'
-            },
-            id: 'astralsorcery:altar/exchange_wand'
-        },
-        {
             output: 'astralsorcery:grapple_wand',
             pattern: [' CD', 'CA ', 'AB '],
             key: {
@@ -656,28 +633,6 @@ events.listen('recipes', (event) => {
                 D: 'alexsmobs:guster_eye'
             },
             id: 'astralsorcery:altar/grapple_wand'
-        },
-        {
-            output: 'astralsorcery:illumination_wand',
-            pattern: [' CD', ' AC', 'AB '],
-            key: {
-                A: '#forge:rods/silver',
-                B: 'betterendforge:leather_stripe',
-                C: '#forge:gems/aquamarine',
-                D: 'astralsorcery:illumination_powder'
-            },
-            id: 'astralsorcery:altar/illumination_wand'
-        },
-        {
-            output: 'astralsorcery:architect_wand',
-            pattern: [' CD', ' AC', 'AB '],
-            key: {
-                A: '#forge:rods/silver',
-                B: 'betterendforge:leather_stripe',
-                C: 'integrateddynamics:crystalized_chorus_chunk',
-                D: '#forge:gems/aquamarine'
-            },
-            id: 'astralsorcery:altar/architect_wand'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
@@ -42,6 +42,17 @@ events.listen('recipes', (event) => {
                 { type: 'bloodmagic:bloodorb', orb_tier: 2 }
             ],
             id: 'bloodmagic:path/path_wood'
+        },
+        {
+            output: Item.of('bloodmagic:largebloodstonebrick', 4),
+            inputs: [
+                'naturesaura:infused_stone',
+                'naturesaura:infused_stone',
+                'naturesaura:infused_stone',
+                'naturesaura:infused_stone',
+                'bloodmagic:weakbloodshard'
+            ],
+            id: 'bloodmagic:largebloodstonebrick'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar.js
@@ -1,0 +1,116 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('astralsorcery:well', 1),
+            altar_type: 0,
+            duration: 100,
+            starlight: 200,
+            effects: ['astralsorcery:built_in_effect_discovery_central_beam'],
+            pattern: ['_____', '_B_B_', '_CDC_', '_ABA_', '_____'],
+            key: {
+                A: { item: 'astralsorcery:resonating_gem' },
+                B: { item: 'astralsorcery:marble_runed' },
+                C: { item: 'create:refined_radiance' },
+                D: { tag: 'botania:runes/winter' }
+            },
+            id: 'astralsorcery:altar/well'
+        },
+        {
+            output: Item.of('astralsorcery:spectral_relay', 1),
+            altar_type: 0,
+            duration: 100,
+            starlight: 200,
+            effects: ['astralsorcery:built_in_effect_discovery_central_beam'],
+            pattern: ['_____', '_ABA_', '_DCD_', '_____', '_____'],
+            key: {
+                A: { item: 'eidolon:gold_inlay' },
+                B: { item: 'astralsorcery:glass_lens' },
+                C: { item: 'create:refined_radiance' },
+                D: { tag: 'botania:runes/air' }
+            },
+            id: 'astralsorcery:altar/spectral_relay'
+        },
+        {
+            output: Item.of('astralsorcery:glass_lens', 1),
+            altar_type: 0,
+            duration: 100,
+            starlight: 200,
+            effects: ['astralsorcery:built_in_effect_discovery_central_beam'],
+            pattern: ['_____', '__A__', '_ABA_', '__A__', '_____'],
+            key: {
+                A: { item: 'astralsorcery:resonating_gem' },
+                B: { item: 'botania:mana_glass_pane' }
+            },
+            id: 'astralsorcery:altar/glass_lens'
+        },
+        {
+            output: Item.of('astralsorcery:altar_attunement', 1),
+            altar_type: 0,
+            duration: 100,
+            starlight: 700,
+            effects: ['astralsorcery:built_in_effect_discovery_central_beam', 'astralsorcery:upgrade_altar'],
+            pattern: ['_____', '_ABA_', '_CDC_', '_AEA_', '_____'],
+            key: {
+                A: { item: 'astralsorcery:marble_pillar' },
+                B: {
+                    type: 'astralsorcery:crystal',
+                    hasToBeAttuned: false,
+                    hasToBeCelestial: false,
+                    canBeAttuned: true,
+                    canBeCelestialCrystal: true
+                },
+                C: { item: 'create:refined_radiance' },
+                D: {
+                    type: 'astralsorcery:fluid',
+                    fluid: [{ fluid: 'astralsorcery:liquid_starlight', amount: 1000 }]
+                },
+                E: { tag: 'botania:runes/spring' }
+            },
+            id: 'astralsorcery:altar/altar_attunement'
+        },
+        {
+            output: Item.of('astralsorcery:attunement_altar', 1),
+            altar_type: 1,
+            duration: 200,
+            starlight: 1600,
+            effects: [
+                'astralsorcery:pillar_sparkle',
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:altar_default_lightbeams',
+                'astralsorcery:altar_default_sparkle',
+                'astralsorcery:built_in_effect_attunement_sparkle'
+            ],
+            pattern: ['A___A', '_BCB_', '_DED_', '_FGF_', 'A___A'],
+            key: {
+                A: { item: 'astralsorcery:marble_runed' },
+                B: { item: 'astralsorcery:resonating_gem' },
+                C: { item: 'bloodmagic:weakbloodshard' },
+                D: { tag: 'forge:ingots/starmetal' },
+                E: { item: 'astralsorcery:spectral_relay' },
+                F: { item: 'eidolon:gold_inlay' },
+                G: { item: 'create:shadow_steel' }
+            },
+            id: 'astralsorcery:altar/attunement_altar'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'astralsorcery:altar',
+            altar_type: recipe.altar_type,
+            duration: recipe.duration,
+            starlight: recipe.starlight,
+            pattern: recipe.pattern,
+            key: recipe.key,
+            output: [recipe.output.toResultJson()],
+            effects: recipe.effects
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/block_transmutation.js
@@ -1,0 +1,38 @@
+function blockTransmutationRecipe(input, output, starlight) {
+    return {
+        type: 'astralsorcery:block_transmutation',
+        input: [{ block: input, display: { item: input, count: 1 } }],
+        output: { block: output },
+        display: { item: output, count: 1 },
+        starlight: starlight
+    };
+}
+
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const recipes = [
+        {
+            input: 'eidolon:worktable',
+            output: 'astralsorcery:altar_discovery',
+            starlight: 60,
+            id: 'astralsorcery:block_transmutation/craftingtable_altar'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.input.charAt(0) == '#') {
+            Ingredient.of(recipe.input).stacks.forEach((input) => {
+                if (!input.id.includes('chunk')) {
+                    const re = event.custom(blockTransmutationRecipe(input.id, recipe.output, recipe.starlight));
+                }
+            });
+        } else {
+            const re = event.custom(blockTransmutationRecipe(recipe.input, recipe.output, recipe.starlight));
+            if (recipe.id) {
+                re.id(recipe.id);
+            }
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -195,6 +195,19 @@ events.listen('recipes', (event) => {
                 ticks: 200,
                 orbLevel: 3,
                 id: 'bloodmagic:alchemytable/reagent_magnetism'
+            },
+            {
+                inputs: [
+                    'occultism:afrit_essence',
+                    Item.of('botania:incense_stick', { brewKey: 'botania:bloodthirst' }),
+                    'eidolon:crimson_essence'
+                ],
+                output: 'bloodmagic:weakbloodshard',
+                count: 2,
+                syphon: 20000,
+                ticks: 200,
+                orbLevel: 3,
+                id: 'bloodmagic:arc/weakbloodshard'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -101,6 +101,15 @@ events.listen('recipes', (event) => {
                 consumptionRate: 5,
                 drainRate: 5,
                 id: 'bloodmagic:sacrificial_dagger'
+            },
+            {
+                input: 'create:shadow_steel',
+                output: 'bloodmagic:masterbloodorb',
+                syphon: 80000,
+                altarLevel: 3,
+                consumptionRate: 30,
+                drainRate: 50,
+                id: 'altar:masterbloodorb'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/arc.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/arc.js
@@ -1,0 +1,56 @@
+events.listen('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    var data = {
+        recipes: [
+            {
+                input: 'bloodmagic:weakbloodorb',
+                output: 'eidolon:unholy_symbol',
+                tool: '#bloodmagic:arc/reverter',
+                extraOutputs: [],
+                consume: false,
+                id: 'bloodmagic:arc/reversion/weak_blood_orb'
+            },
+            {
+                input: 'bloodmagic:apprenticebloodorb',
+                output: 'meetyourfight:caged_heart',
+                tool: '#bloodmagic:arc/reverter',
+                extraOutputs: [],
+                consume: false,
+                id: 'bloodmagic:arc/reversion/apprentice_blood_orb'
+            },
+            {
+                input: 'bloodmagic:magicianbloodorb',
+                output: 'occultism:iesnium_block',
+                tool: '#bloodmagic:arc/reverter',
+                extraOutputs: [],
+                consume: false,
+                id: 'bloodmagic:arc/reversion/magician_blood_orb'
+            },
+            {
+                input: 'bloodmagic:masterbloodorb',
+                output: 'create:shadow_steel',
+                tool: '#bloodmagic:arc/reverter',
+                extraOutputs: [],
+                consume: false,
+                id: 'bloodmagic:arc/reversion/master_blood_orb'
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.bloodmagic
+            .arc(recipe.output, recipe.input, recipe.tool, recipe.extraOutputs)
+            .consumeIngredient(recipe.consume);
+
+        if (recipe.fluidOutput) {
+            re.outputFluid(recipe.fluidOutput);
+        }
+
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/array.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/array.js
@@ -11,7 +11,7 @@ events.listen('recipes', (event) => {
                 texture: 'bindinglightningarray'
             },
             {
-                inputs: ['architects_palette:algal_lamp', '#forge:dusts/lapis'],
+                inputs: ['architects_palette:algal_lamp', '#forge:gems/aquamarine'],
                 output: 'minecraft:heart_of_the_sea',
                 texture: 'watersigil'
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
@@ -33,7 +33,7 @@ events.listen('recipes', (event) => {
                     'eidolon:soul_shard',
                     'naturesaura:infused_iron',
                     'glassential:glass_ghostly',
-                    'minecraft:heart_of_the_sea'
+                    'minecraft:conduit'
                 ],
                 output: 'bloodmagic:soulgempetty',
                 minimumDrain: 1.0,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mana_infusion.js
@@ -27,6 +27,14 @@ events.listen('recipes', (event) => {
             mana: 5000,
             catalyst: 'architects_palette:sunstone',
             id: 'botania:mana_infusion/mana_string'
+        },
+        {
+            input: '#forge:gems/aquamarine',
+            output: 'astralsorcery:resonating_gem',
+            count: 1,
+            mana: 50000,
+            catalyst: 'architects_palette:moonstone',
+            id: 'astralsorcery:infuser/aquamarine'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -10,10 +10,47 @@ events.listen('recipes', (event) => {
                 { tag: 'botania:petals/white' },
                 { tag: 'botania:petals/white' },
                 { tag: 'botania:petals/white' },
+                { tag: 'forge:dusts/fluorite' },
                 { item: 'thermal:phytogro' }
             ],
             output: { item: 'botania:pure_daisy' },
             id: 'botania:petal_apothecary/pure_daisy'
+        },
+        {
+            inputs: [
+                { tag: 'botania:petals/brown' },
+                { tag: 'botania:petals/brown' },
+                { tag: 'botania:petals/red' },
+                { tag: 'botania:petals/light_gray' },
+                { item: 'naturesaura:crimson_aura_mushroom' },
+                { item: 'thermal:phytogro' }
+            ],
+            output: { item: 'botania:endoflame' },
+            id: 'botania:petal_apothecary/endoflame'
+        },
+        {
+            inputs: [
+                { tag: 'botania:petals/blue' },
+                { tag: 'botania:petals/blue' },
+                { tag: 'botania:petals/cyan' },
+                { tag: 'botania:petals/cyan' },
+                { tag: 'forge:nuggets/neptunium' },
+                { item: 'thermal:phytogro' }
+            ],
+            output: { item: 'botania:hydroangeas' },
+            id: 'botania:petal_apothecary/hydroangeas'
+        },
+        {
+            inputs: [
+                { tag: 'botania:petals/light_blue' },
+                { tag: 'botania:petals/green' },
+                { tag: 'botania:petals/red' },
+                { tag: 'botania:petals/cyan' },
+                { tag: 'forge:dusts/mana' },
+                { item: 'thermal:phytogro' }
+            ],
+            output: { item: 'botania:manastar' },
+            id: 'botania:petal_apothecary/manastar'
         },
         {
             inputs: [{ tag: 'forge:mushrooms' }, { item: 'thermal:phytogro' }],

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -14,6 +14,39 @@ events.listen('recipes', (event) => {
                 D: '#botania:runes/autumn'
             },
             id: 'astralsorcery:altar/hand_telescope'
+        },
+        {
+            output: 'astralsorcery:observatory',
+            pattern: [
+                '      ABC',
+                '     DBPB',
+                '    EBCBA',
+                '   FBJBG ',
+                '  ABKBH  ',
+                ' LB BI   ',
+                'M CBAO   ',
+                'MN L O   ',
+                'MMMOOO   '
+            ],
+            key: {
+                A: '#forge:rods/brass',
+                B: 'astralsorcery:marble_runed',
+                C: 'astralsorcery:glass_lens',
+                D: 'quark:lime_rune',
+                E: 'quark:orange_rune',
+                F: 'quark:red_rune',
+                G: 'quark:magenta_rune',
+                H: 'quark:blue_rune',
+                I: 'quark:light_blue_rune',
+                J: 'quark:black_rune',
+                K: 'mythicbotany:asgard_rune',
+                L: '#forge:nuggets/brass',
+                M: '#forge:plates/brass',
+                N: '#create:seats',
+                O: 'create:brass_casing',
+                P: 'astralsorcery:infused_glass'
+            },
+            id: 'astralsorcery:altar/observatory'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -1,7 +1,26 @@
 events.listen('recipes', (event) => {
-    const recipes = [];
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: 'astralsorcery:hand_telescope',
+            pattern: [' A    ', 'ABA   ', ' ABC  ', '  CDC ', '   CCA', '    AB'],
+            key: {
+                A: '#forge:plates/brass',
+                B: 'astralsorcery:glass_lens',
+                C: 'botania:livingwood_planks',
+                D: '#botania:runes/autumn'
+            },
+            id: 'astralsorcery:altar/hand_telescope'
+        }
+    ];
 
     recipes.forEach((recipe) => {
-        event.recipes.create.mechanical_crafting(recipe.result, recipe.pattern, recipe.key);
+        const re = event.recipes.create.mechanical_crafting(recipe.output, recipe.pattern, recipe.key);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -25,7 +25,7 @@ events.listen('recipes', (event) => {
                 '  ABKBH  ',
                 ' LB BI   ',
                 'M CBAO   ',
-                'MN L O   ',
+                'MN LQO   ',
                 'MMMOOO   '
             ],
             key: {
@@ -44,7 +44,8 @@ events.listen('recipes', (event) => {
                 M: '#forge:plates/brass',
                 N: '#create:seats',
                 O: 'create:brass_casing',
-                P: 'astralsorcery:infused_glass'
+                P: 'astralsorcery:infused_glass',
+                Q: 'immersiveengineering:furnace_heater'
             },
             id: 'astralsorcery:altar/observatory'
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mixing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mixing.js
@@ -8,16 +8,26 @@ events.listen('recipes', (event) => {
             heated: true,
             inputs: ['#forge:ingots/cobalt', '#forge:ingots/cobalt', '#forge:ingots/cobalt', 'thermal:blizz_powder'],
             output: Item.of('undergarden:froststeel_ingot', 3)
+        },
+        {
+            superheated: true,
+            inputs: ['#forge:stones/marble', '#forge:stones/marble', '#forge:stones/marble', '#forge:stones/marble'],
+            output: Item.of('astralsorcery:black_marble_raw', 4)
         }
     ];
 
     recipes.forEach((recipe) => {
+        const re = event.recipes.create.mixing(recipe.output, recipe.inputs);
+
         if (recipe.heated) {
-            event.recipes.create.mixing(recipe.output, recipe.inputs).heated();
+            re.heated();
         } else if (recipe.superheated) {
-            event.recipes.create.mixing(recipe.output, recipe.inputs).superheated();
+            re.superheated();
         } else {
-            event.recipes.create.mixing(recipe.output, recipe.inputs);
+            //unheated
+        }
+        if (recipe.id) {
+            re.id(recipe.id);
         }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -41,7 +41,7 @@ events.listen('recipes', (event) => {
                 input: 'eidolon:candle',
                 output: 'occultism:candle_white',
                 aura_type: 'naturesaura:nether',
-                aura: 5000,
+                aura: 50000,
                 time: 60,
                 id: 'occultism:crafting/candle'
             },
@@ -59,6 +59,14 @@ events.listen('recipes', (event) => {
                 catalyst: 'naturesaura:conversion_catalyst',
                 aura: 30000,
                 time: 250
+            },
+            {
+                input: 'kubejs:firmament',
+                output: 'naturesaura:infused_stone',
+                aura_type: 'naturesaura:nether',
+                aura: 15000,
+                time: 40,
+                id: 'naturesaura:altar/infused_stone'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -266,7 +266,7 @@ events.listen('recipes', (event) => {
                     { item: 'botania:livingrock' }, //bottom
                     { item: 'botania:livingrock' }, //left
                     { item: 'botania:livingrock' }, //right
-                    { item: 'minecraft:heart_of_the_sea' }, //topleft
+                    { item: 'minecraft:conduit' }, //topleft
                     { item: 'botania:livingrock' } //bottomright
                 ],
                 output: 'botania:runic_altar',

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/astralsorcery/block_transmutation.js
@@ -1,0 +1,24 @@
+events.listen('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [{ inputTag: '#forge:workbench', output: 'astralsorcery:altar_discovery', starlight: 60 }]
+    };
+    data.recipes.forEach((recipe) => {
+        Ingredient.of(recipe.inputTag).stacks.forEach((input) => {
+            if (!input.id.includes('chunk')) {
+                event.recipes.astralsorcery.block_transmutation({
+                    type: 'astralsorcery.block_transmutation',
+                    input: {
+                        block: input.id
+                    },
+                    output: {
+                        block: recipe.output
+                    },
+                    starlight: recipe.starlight
+                });
+            }
+        });
+    });
+});


### PR DESCRIPTION
Aquamarine criminally underused, changed heart of the sea recipe to use that instead of lapis dust
![image](https://user-images.githubusercontent.com/9543430/119189203-c414ab80-ba49-11eb-84c7-4592e6f54409.png)

Shifted some recipes using Heart of the Sea to use Conduit instead.

Blood Shards, still used for tier 4 blood orb and tier 4 altar
![image](https://user-images.githubusercontent.com/9543430/119054270-5b6bf700-b995-11eb-8ee5-93a3ee33aca0.png)

Blood Stone Brick used to expand the blood altar:
![image](https://user-images.githubusercontent.com/9543430/119065693-18694e00-b9ac-11eb-810b-22afe4a7281f.png)

Final Blood Orb:
![image](https://user-images.githubusercontent.com/9543430/119210266-4e283880-ba79-11eb-8ae6-a0e2d381af44.png)

Arc Reverter recipes changed to reflect the current blood orb crafts
![image](https://user-images.githubusercontent.com/9543430/119210365-c131af00-ba79-11eb-8b2a-80dc3e7d335b.png)

Update to Endoflame recipe
![image](https://user-images.githubusercontent.com/9543430/119071609-21601c80-b9b8-11eb-9c62-651ca95bb453.png)

Update to Hydroangea recipe
![image](https://user-images.githubusercontent.com/9543430/119071643-2e7d0b80-b9b8-11eb-9842-23979ae557e4.png)

Both of these contain non-farmable items. Crimson Aura Fungus are found in the nether and Neptunium ingots from fishing. The intent is to make them accessible but not something that can auto farmed and made en masse.

Astral Progression
Linking Tool moved to standard crafting
![image](https://user-images.githubusercontent.com/9543430/119189347-f4f4e080-ba49-11eb-90d6-ca8ca6582ee3.png)

Eidolon Workbench
![image](https://user-images.githubusercontent.com/9543430/119207247-8f195080-ba6b-11eb-8bdf-3f8d8e10043c.png)

Luminous Crafting Table
![image](https://user-images.githubusercontent.com/9543430/119203390-e960e400-ba60-11eb-8609-d46fc5132ad8.png)

Sooty Marble now made with a Create Mixing recipe
![image](https://user-images.githubusercontent.com/9543430/119071871-93386600-b9b8-11eb-8c7c-9ba2479373f7.png)

Mechanical Crafting for Looking Glass
![image](https://user-images.githubusercontent.com/9543430/119206299-bde1f780-ba68-11eb-9cfa-d1b31fac0c50.png)

Resonating Gem moved to Mana Infusion. Costly. Moonstone catalyst required
![image](https://user-images.githubusercontent.com/9543430/119207961-3d25fa00-ba6e-11eb-9bad-ca45e8659e03.png)

Lightwell. Hello Create:
![image](https://user-images.githubusercontent.com/9543430/119207996-575fd800-ba6e-11eb-93d0-fadd61e48d02.png)

Tier 2 Altar:
![image](https://user-images.githubusercontent.com/9543430/119209866-2afc8980-ba77-11eb-8cc7-8ad5712c3a0f.png)

Glass Lens:
Hard to tell, but it uses mana glass panes
![image](https://user-images.githubusercontent.com/9543430/119209981-e3c2c880-ba77-11eb-9606-5832a64c3ca8.png)

Spectral Relay:
![image](https://user-images.githubusercontent.com/9543430/119209871-35b71e80-ba77-11eb-903a-9d4840956e73.png)

Attunement Altar
![image](https://user-images.githubusercontent.com/9543430/119211018-cdb80680-ba7d-11eb-919f-2f7d25d0cdc9.png)

Observatory:
![image](https://user-images.githubusercontent.com/9543430/119212163-8da85200-ba84-11eb-88a2-f61c97f53a95.png)
