### PR TITLE
More Valid Apiary Blocks

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
@@ -21,7 +21,24 @@ const validApiaryBlocks = [
     /minecraft:(|\w+)terracotta$/,
 
     'minecraft:soul_sand',
-    '#minecraft:stone_bricks'
+    '#minecraft:stone_bricks',
+
+    '#enigmatica:stonecuttables',
+
+    /bloodmagic:\w+rune$/,
+    /bloodmagic:(|\w+)ritualstone$/,
+    /bloodmagic:\w+path$/,
+    'bloodmagic:largebloodstonebrick',
+    'bloodmagic:bloodstonebrick',
+    'bloodmagic:dungeon_brick1',
+    'bloodmagic:dungeon_brick2',
+    'bloodmagic:dungeon_brick3',
+    'bloodmagic:dungeon_smallbrick',
+    'bloodmagic:dungeon_brick_assorted',
+
+    /botania:\w+grass$/,
+
+    '#forge:treated_wood'
 ];
 
 const honeyVarieties = [

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
@@ -38,7 +38,19 @@ const validApiaryBlocks = [
 
     /botania:\w+grass$/,
 
-    '#forge:treated_wood'
+    '#forge:treated_wood',
+
+    /engineersdecor:dense\w+/,
+    'engineersdecor:clinker_brick_block',
+    'engineersdecor:clinker_brick_stained_block',
+    'engineersdecor:clinker_brick_sastor_corner_block',
+    'engineersdecor:slag_brick_block',
+    'engineersdecor:rebar_concrete',
+    'engineersdecor:rebar_concrete_tile',
+    'engineersdecor:gas_concrete',
+    'engineersdecor:rebar_concrete',
+    'engineersdecor:dark_shingle_roof_block',
+    'engineersdecor:old_industrial_wood_planks'
 ];
 
 const honeyVarieties = [


### PR DESCRIPTION
Making Apiaries pretty one block at a time. Addresses #2249.

Adds all stonecuttables (covers Basalt and Blackstone variants).
Add various Blood Magic blocks (Runes, Ritual Stones, Paths, Bricks).
Add Botania Grasses.
Add Treated Wood.