### PR TITLE
Proof of Concept Magical 5x Ore Processing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -12,10 +12,27 @@ events.listen('recipes', (event) => {
         var rod = getPreferredItemInTag(Ingredient.of('#forge:rods/' + material)).id;
         var wire = getPreferredItemInTag(Ingredient.of('#forge:wires/' + material)).id;
 
+        var ore = getPreferredItemInTag(Ingredient.of('#forge:ores/' + material)).id;
+        var mana_cluster = getPreferredItemInTag(Ingredient.of('#mekanism:clumps/' + material)).id; // `#enigmatica:mana_clusters/${material}`
+        var fulminated_cluster = getPreferredItemInTag(Ingredient.of('#mekanism:crystals/' + material)).id; // `#enigmatica:fulminated_clusters/${material}`
+        var levigated_material = getPreferredItemInTag(Ingredient.of('#mekanism:dirty_dusts/' + material)).id; // `#enigmatica:levigated_material/${material}`
+        var crystalline_sliver = getPreferredItemInTag(Ingredient.of('#mekanism:shards/' + material)).id; // `#enigmatica:crystalline_sliver/${material}`
+
         gear_unification(event, material, ingot, gem, gear);
         rod_unification(event, material, ingot, gem, rod, plate);
         plate_unification(event, material, ingot, gem, plate);
         wire_unification(event, material, ingot, gem, wire, plate);
+
+        magical_ore_processing(
+            event,
+            material,
+            ore,
+            ingot,
+            mana_cluster,
+            fulminated_cluster,
+            levigated_material,
+            crystalline_sliver
+        );
     });
 
     function gear_unification(event, material, ingot, gem, gear) {
@@ -149,5 +166,164 @@ events.listen('recipes', (event) => {
             .id(`kubejs:immersiveengineering_metal_press_${material}_wire`);
 
         event.shapeless(Item.of(output, 2), [plate, plate, wireCutters]).id(`kubejs:shaped_crafting_${material}_wire`);
+    }
+    //Mock-up. Real process would use new assets to avoid mix ups with Mek processing.
+    function magical_ore_processing(
+        event,
+        material,
+        ore,
+        ingot,
+        mana_cluster,
+        fulminated_cluster,
+        levigated_material,
+        crystalline_sliver
+    ) {
+        if (
+            ore == air ||
+            ingot == air ||
+            mana_cluster == air ||
+            fulminated_cluster == air ||
+            levigated_material == air ||
+            crystalline_sliver == air
+        ) {
+            return;
+        }
+
+        // list will need to be updated. More ores available now. Should consider moving into a function "get_secondary()"
+        switch (material) {
+            case 'iron':
+                secondaryMaterial = 'nickel';
+                break;
+            case 'nickel':
+                secondaryMaterial = 'iron';
+                break;
+            case 'gold':
+                secondaryMaterial = 'zinc';
+                break;
+            case 'copper':
+                secondaryMaterial = 'gold';
+                break;
+            case 'aluminum':
+                secondaryMaterial = 'iron';
+                break;
+            case 'lead':
+                secondaryMaterial = 'silver';
+                break;
+            case 'silver':
+                secondaryMaterial = 'lead';
+                break;
+            case 'uranium':
+                secondaryMaterial = 'lead';
+                break;
+            case 'osmium':
+                secondaryMaterial = 'tin';
+                break;
+            case 'tin':
+                secondaryMaterial = 'osmium';
+                break;
+            case 'zinc':
+                secondaryMaterial = 'gold';
+                break;
+            case 'iesnium':
+                secondaryMaterial = 'iesnium';
+                break;
+            case 'cloggrum':
+                secondaryMaterial = 'cloggrum';
+                break;
+            case 'froststeel':
+                secondaryMaterial = 'froststeel';
+                break;
+            case 'regalium':
+                secondaryMaterial = 'regalium';
+                break;
+            case 'utherium':
+                secondaryMaterial = 'utherium';
+                break;
+            default:
+                return;
+        }
+
+        var secondary_fulminated_cluster = getPreferredItemInTag(
+                Ingredient.of('#mekanism:crystals/' + secondaryMaterial)
+            ).id,
+            infusing_input = `#forge:ores/${material}`,
+            zapping_input = `#mekanism:clumps/${material}`, // `#enigmatica:mana_clusters/${material}`
+            crumbling_input = `#mekanism:crystals/${material}`, // `#enigmatica:fulminated_clusters/${material}`
+            freezing_input = `#mekanism:dirty_dusts/${material}`, // `#enigmatica:levigated_material/${material}`
+            fusing_input = `#mekanism:shards/${material}`; // `#enigmatica:crystalline_sliver/${material}`
+
+        // Step One: Infuse!
+        event.custom({
+            type: 'botania:mana_infusion',
+            input: Ingredient.of(infusing_input).toJson(),
+            output: { item: mana_cluster, count: 1 },
+            catalyst: { type: 'block', block: 'naturesaura:generator_limit_remover' },
+            mana: 25000
+        });
+
+        // Step Two: Zap!
+        event.custom({
+            type: 'interactio:item_lightning',
+            inputs: [Ingredient.of(zapping_input).toJson(), Ingredient.of('#botania:runes/asgard').toJson()],
+            output: {
+                entries: [
+                    { result: { item: fulminated_cluster, count: 1 }, weight: 10 },
+                    { result: { item: secondary_fulminated_cluster, count: 1 }, weight: 5 },
+                    { result: { item: 'thermal:slag', count: 1 }, weight: 85 } // would prefer something like tiny slag here
+                ],
+                empty_weight: 0,
+                rolls: 20
+            }
+        });
+
+        // Step Three: Crumble!
+        event.custom({
+            type: 'naturesaura:altar',
+            input: Ingredient.of(crumbling_input).toJson(),
+            output: Ingredient.of(levigated_material).toJson(),
+            catalyst: Ingredient.of('naturesaura:crushing_catalyst').toJson(),
+            aura_type: 'naturesaura:overworld',
+            aura: 15000,
+            time: 80
+        });
+
+        // Step Four: Freeze!
+        event.custom({
+            type: 'interactio:item_fluid_transform',
+            inputs: [
+                Ingredient.of(freezing_input).toJson(),
+                { tag: 'botania:runes/winter', count: 1, return_chance: 0.95 }
+            ],
+            output: {
+                entries: [
+                    { result: Ingredient.of(crystalline_sliver).toJson(), weight: 75 },
+                    { result: Ingredient.of('bloodmagic:corrupted_tinydust').toJson(), weight: 25 } //placeholder item. Could be a handy place to put a byproduct required for high tier crafts
+                ],
+                empty_weight: 0,
+                rolls: 20
+            },
+            fluid: { fluid: 'astralsorcery:liquid_starlight' },
+            consume_fluid: 0.75
+        });
+
+        // Step Five: Fuse!
+        event.custom({
+            type: 'botania:runic_altar',
+            output: { item: ingot, count: 1 },
+            mana: 25000,
+            ingredients: [
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of(fusing_input).toJson(),
+                Ingredient.of('eidolon:ender_calx').toJson(),
+                Ingredient.of(`#botania:runes/muspelheim`).toJson()
+            ]
+        });
     }
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -264,7 +264,10 @@ events.listen('recipes', (event) => {
         // Step Two: Zap!
         event.custom({
             type: 'interactio:item_lightning',
-            inputs: [Ingredient.of(zapping_input).toJson(), Ingredient.of('#botania:runes/asgard').toJson()],
+            inputs: [
+                Ingredient.of(zapping_input).toJson(),
+                { tag: 'botania:runes/asgard', count: 1, return_chance: 0.5 }
+            ],
             output: {
                 entries: [
                     { result: { item: fulminated_cluster, count: 1 }, weight: 10 },


### PR DESCRIPTION
Proof of Concept Magical 5x Ore Processing.
All art assets are temporary. To be replaced later.

Drop the ore into a Mana Pool (requires Creational Catalyst under it)
![image](https://user-images.githubusercontent.com/9543430/119401142-1acbf080-bca9-11eb-95a2-54828085a240.png)

Zap result with lightning and a Rune of Asgard catalyst
![image](https://user-images.githubusercontent.com/9543430/119402991-b52d3380-bcab-11eb-940a-8f6c137617be.png)
Return chance doesn't appear to work with lightning. On the other hand, it does let you craft many sets with only 1 run as input. So it will be up to the player to decide how efficient they want to be. Drop 1 rune and 64 inputs? more? Considering the recipe for the Ingot of the sky used in this, it'll be unwise to do small batches.

This step produce roughly 3x output with a mix of the input item and a secondary such as Nickel from Iron.

Crumble in Natural Infusion Altar
![image](https://user-images.githubusercontent.com/9543430/119402151-86628d80-bcaa-11eb-9629-1f56f5753507.png)

Wash in Starlight:
![image](https://user-images.githubusercontent.com/9543430/119402204-9d08e480-bcaa-11eb-9d1d-e8564e8088af.png)
Chance to use up both starlight and the winter rune.

This is the final multiplication step, producing roughly 15x of the input material. 9 of the output goes into making an ingot.

Finally, combine in a Runic Altar. This rune, as with all runes used in Altar crafting, is always returned. Calx of the End is something that will likely be on auto craft already given it's many uses.
![image](https://user-images.githubusercontent.com/9543430/119403137-e279e180-bcab-11eb-92ea-433f53608d6d.png)