### PR TITLE
Bloody & Starry Bee

### DIFF
--- a/config/resourcefulbees/bees/magic/Bloody.json
+++ b/config/resourcefulbees/bees/magic/Bloody.json
@@ -29,11 +29,11 @@
         "hasCentrifugeOutput": true,
 
         "mainOutput": "bloodmagic:slate_ampoule",
-        "mainOutputWeight": 0.02,
+        "mainOutputWeight": 0.10,
         "mainOutputCount": 1,
 
         "secondaryOutput": "bloodmagic:blankslate",
-        "secondaryOutputWeight": 0.005,
+        "secondaryOutputWeight": 0.03,
         "secondaryOutputCount": 1,
 
         "mainInputCount": 1

--- a/config/resourcefulbees/bees/magic/Bloody.json
+++ b/config/resourcefulbees/bees/magic/Bloody.json
@@ -1,6 +1,6 @@
 {
-    "flower": "tag:minecraft:flowers",
-    "maxTimeInHive": 4800,
+    "flower": "undergarden:blood_mushroom",
+    "maxTimeInHive": 6000,
     "hasHoneycomb": true,
     "traits": ["can_swim"],
     "ColorData": {
@@ -11,12 +11,33 @@
     },
     "CombatData": {
         "isPassive": false,
-        "removeStingerOnAttack": true,
+        "removeStingerOnAttack": false,
         "inflictsPoison": true,
-        "attackDamage": 1
+        "attackDamage": 3
     },
-    "MutationData": {"hasMutation": false},
-    "CentrifugeData": {"hasCentrifugeOutput": false},
+    "MutationData": {
+        "hasMutation": true,
+        "mutations": [
+            {
+                "type": "BLOCK",
+                "inputID": "minecraft:water",
+                "outputs": [{ "outputID": "bloodmagic:life_essence_fluid", "weight": 10 }]
+            }
+        ]
+    },
+    "CentrifugeData": {
+        "hasCentrifugeOutput": true,
+
+        "mainOutput": "bloodmagic:slate_ampoule",
+        "mainOutputWeight": 0.02,
+        "mainOutputCount": 1,
+
+        "secondaryOutput": "bloodmagic:blankslate",
+        "secondaryOutputWeight": 0.005,
+        "secondaryOutputCount": 1,
+
+        "mainInputCount": 1
+    },
     "SpawnData": {"canSpawnInWorld": false},
     "BreedData": {"isBreedable": false},
     "TraitData": {"hasTraits": true}

--- a/config/resourcefulbees/bees/magic/Starry.json
+++ b/config/resourcefulbees/bees/magic/Starry.json
@@ -1,5 +1,5 @@
 {
-    "flower": "tag:minecraft:flowers",
+    "flower": "astralsorcery:glow_flower",
     "maxTimeInHive": 4800,
     "hasHoneycomb": true,
     "traits": ["can_swim"],

--- a/config/resourcefulbees/bees/natural/Icy.json
+++ b/config/resourcefulbees/bees/natural/Icy.json
@@ -24,7 +24,7 @@
             {
                 "type": "BLOCK",
                 "inputID": "minecraft:water",
-                "outputs": [{ "outputID": "minecraft:ice", "weight": 10 }]
+                "outputs": [{ "outputID": "minecraft:blue_ice", "weight": 10 }]
             }
         ]
     },

--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -32,5 +32,7 @@
 
     "fluid.undergarden.virulent_mix_source": "Virulent Mix",
 
+    "fluid.bloodmagic.life_essence_fluid": "Life Essence",
+
     "": ""
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/altar.js
@@ -1,0 +1,72 @@
+events.listen('recipes', (event) => {
+
+    const recipes = [
+        {
+            output: Item.of('resourcefulbees:starry_bee_spawn_egg', 1),
+            pattern: [
+                '_____',
+                '__E__',
+                '_DCB_',
+                '__A__',
+                '_____'],
+            key: {
+                A: {
+                    type: 'astralsorcery:crystal',
+                    hasToBeAttuned: false,
+                    hasToBeCelestial: false,
+                    canBeAttuned: true,
+                    canBeCelestialCrystal: true
+                },
+                B: { item: 'resourcefulbees:gold_honeycomb' },
+                C: { item: 'resourcefulbees:iron_bee_spawn_egg' },
+                D: { item: 'resourcefulbees:iron_honeycomb' },
+                E: { item: 'astralsorcery:colored_lens_spectral' }
+            },
+            relay_inputs: [
+                { item: 'astralsorcery:resonating_gem' },
+                { item: 'astralsorcery:illumination_powder' },
+                { tag: 'astralsorcery:stardust' },
+                { item: 'resourcefulbees:iron_honey_block' }
+            ],
+            altar_type: 3,
+            duration: 400,
+            starlight: 3200,
+            effects: [
+                'astralsorcery:built_in_effect_constellation_finish',
+                'astralsorcery:built_in_effect_trait_relay_highlight',
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:built_in_effect_trait_focus_circle',
+                'astralsorcery:altar_default_sparkle',
+                'astralsorcery:built_in_effect_constellation_lines'
+            ]
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        let constructed_recipe = {
+            type: 'astralsorcery:altar',
+            altar_type: recipe.altar_type,
+            duration: recipe.duration,
+            starlight: recipe.starlight,
+            pattern: recipe.pattern,
+            key: recipe.key,
+            output: [recipe.output.toResultJson()],
+            effects: recipe.effects
+        };
+
+        if (recipe.relay_inputs) {
+            constructed_recipe.relay_inputs = recipe.relay_inputs;
+        }
+        if (recipe.focus_constellation) {
+            constructed_recipe.focus_constellation = recipe.focus_constellation;
+        }
+        if (recipe.recipe_class) {
+            constructed_recipe.recipe_class = recipe.recipe_class;
+        }
+
+        const re = event.custom(constructed_recipe);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/block_transmutation.js
@@ -2,7 +2,8 @@ events.listen('recipes', (event) => {
     var data = {
         recipes: [
             { inputTag: '#forge:ores/iron', output: 'astralsorcery:starmetal_ore', starlight: 100 },
-            { inputTag: '#forge:ores/diamond', output: 'emendatusenigmatica:emerald_ore', starlight: 1000 }
+            { inputTag: '#forge:ores/diamond', output: 'emendatusenigmatica:emerald_ore', starlight: 1000 },
+            { inputTag: 'resourcefulbees:starry_honeycomb_block', output: 'astralsorcery:rock_crystal_ore', starlight: 1000 }
         ]
     };
     data.recipes.forEach((recipe) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
@@ -54,6 +54,22 @@ events.listen('recipes', (event) => {
                 output: 'astralsorcery:glow_flower',
                 count: 1,
                 duration: 100
+            },
+            {
+                input: { item: 'resourcefulbees:starry_honeycomb' },
+                fluid: 'astralsorcery:liquid_starlight',
+                consumptionChance: 0.1,
+                output: 'astralsorcery:starmetal_ingot',
+                count: 1,
+                duration: 100
+            },
+            {
+                input: { item: 'resourcefulbees:starry_honeycomb_block' },
+                fluid: 'astralsorcery:liquid_starlight',
+                consumptionChance: 0.1,
+                output: 'astralsorcery:starmetal',
+                count: 1,
+                duration: 100
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/infuser.js
@@ -60,7 +60,7 @@ events.listen('recipes', (event) => {
                 fluid: 'astralsorcery:liquid_starlight',
                 consumptionChance: 0.1,
                 output: 'astralsorcery:starmetal_ingot',
-                count: 1,
+                count: 3,
                 duration: 100
             },
             {
@@ -68,7 +68,7 @@ events.listen('recipes', (event) => {
                 fluid: 'astralsorcery:liquid_starlight',
                 consumptionChance: 0.1,
                 output: 'astralsorcery:starmetal',
-                count: 1,
+                count: 3,
                 duration: 100
             }
         ]

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
@@ -1,0 +1,38 @@
+events.listen('recipes', (event) => {
+
+    data = {
+        recipes: [
+
+            /*{
+                input: 'input item here',
+                output: 'output item here',
+                syphon: 1000,                       //Recipe LP Cost
+                altarLevel: 0,                      //Altar Level is zero idexed
+                consumptionRate: 5,                 //How much LP is infused per operation
+                drainRate: 5,                       //How much LP is lost per operation when the altar is empty
+                id: 'input item here'
+            }*/
+
+            {
+                input: 'resourcefulbees:bronze_bee_spawn_egg',
+                output: 'resourcefulbees:bloody_bee_spawn_egg',
+                syphon: 50000,
+                altarLevel: 3,
+                consumptionRate: 50,
+                drainRate: 50
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.bloodmagic
+            .altar(recipe.output, recipe.input)
+            .upgradeLevel(recipe.altarLevel)
+            .altarSyphon(recipe.syphon)
+            .consumptionRate(recipe.consumptionRate)
+            .drainRate(recipe.drainRate);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/laser_drill_ore.js
@@ -814,7 +814,7 @@ events.listen('recipes', (event) => {
                         type: 'minecraft:worldgen/biome',
                         values: nether_end_biomes
                     },
-                    depth_min: 0,
+                    depth_min: 10,
                     depth_max: 255,
                     weight: 1
                 }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -4,6 +4,17 @@ events.listen('recipes', (event) => {
     }
     data = {
         recipes: [
+
+            /*{
+                input: 'input item here',
+                output: 'output item here',
+                syphon: 1000,                       //Recipe LP Cost
+                altarLevel: 0,                      //Altar Level is zero idexed
+                consumptionRate: 5,                 //How much LP is infused per operation
+                drainRate: 5,                       //How much LP is lost per operation when the altar is empty
+                id: 'input item here'
+            }*/
+
             {
                 input: 'eidolon:unholy_symbol',
                 output: 'bloodmagic:weakbloodorb',


### PR DESCRIPTION
Further implement these bees:

1. Implement crafting recipes (Blood Altar and Starlight Crafting respectively) for their eggs.

<img width="333" alt="image" src="https://user-images.githubusercontent.com/13169307/119540907-f5e48580-bd5b-11eb-8d51-e29e5378649d.png">

<img width="333" alt="image" src="https://user-images.githubusercontent.com/13169307/119541017-17de0800-bd5c-11eb-9c69-221286f4f667.png">

2. Add uses for their combs - Bloody combs are going to the centrifuge currently, Starry combs can be used with Astral processes.

<img width="290" alt="image" src="https://user-images.githubusercontent.com/13169307/119541143-41972f00-bd5c-11eb-9474-511a2fe8c7fe.png">
*Note the 0% chance for slates is because it is less than 1%.

<img width="253" alt="image" src="https://user-images.githubusercontent.com/13169307/119541392-6e4b4680-bd5c-11eb-97a7-d2bba266791e.png">

<img width="253" alt="image" src="https://user-images.githubusercontent.com/13169307/119541220-5bd10d00-bd5c-11eb-9fd3-b4f179ff6799.png">

<img width="253" alt="image" src="https://user-images.githubusercontent.com/13169307/119541236-61c6ee00-bd5c-11eb-8c9b-ebeea83060a3.png">

Took the opportunity to stick in 2 QoL fixes - added Life Essence to the Kube lang file, and adjusted the laser ore drill recipe for Aquamarine Shale.