### PR TITLE
Latex Unification

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -148,6 +148,9 @@ var itemsToHide = [
     'supplementaries:stone_lamp',
     'supplementaries:sack',
     'supplementaries:blackboard',
+
+    'thermal:rubber',
+
     'quark:bonded_ravager_hide',
     'quark:ravager_hide',
     'quark:backpack',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -161,6 +161,8 @@ events.listen('recipes', (event) => {
         'thermal:devices/plugins/byg/tree_extractor_byg_baobab',
         'thermal:devices/tree_extractor/tree_extractor_jungle',
         'thermal:signalum_dust_4',
+        'thermal:rubber_3',
+        'thermal:smelting/cured_rubber_from_smelting',
 
         'powah:crafting/energy_cell_basic_2',
         'powah:crafting/cable_basic',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -7,6 +7,7 @@ events.listen('recipes', (event) => {
     event.replaceInput({}, 'betterendforge:thallasium_ore', '#forge:ores/thallasium');
     event.replaceInput({}, 'astralsorcery:starmetal_ore', '#forge:ores/starmetal');
     event.replaceInput({}, 'mythicbotany:elementium_ore', '#forge:ores/elementium');
+    event.replaceInput({}, 'thermal:rubber', 'industrialforegoing:dryrubber');
     event.replaceInput({}, 'thermal:cinnabar', '#forge:gems/cinnabar');
     event.replaceInput({}, 'thermal:sulfur', '#forge:gems/sulfur');
     event.replaceInput({}, 'thermal:apatite', '#forge:gems/apatite');

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_output.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_output.js
@@ -9,11 +9,16 @@ events.listen('recipes', (event) => {
     event.replaceOutput({}, 'refinedstorage:silicon', '#forge:gems/silicon');
     event.replaceOutput({}, 'create:dough', 'farmersdelight:wheat_dough');
     event.replaceOutput({}, 'simplefarming:chocolate', 'create:bar_of_chocolate');
+    event.replaceOutput({}, 'thermal:rubber', 'industrialforegoing:dryrubber');
 
     event.replaceOutput({ mod: 'dustrial_decor' }, 'minecraft:iron_ingot', 'dustrial_decor:rusty_iron_ingot');
     event.replaceOutput({ mod: 'dustrial_decor' }, 'minecraft:iron_nugget', 'dustrial_decor:rusty_iron_nugget');
 
     sharedDies.forEach((die) => {
-        event.replaceOutput({}, `thermal:press_${die.thermalName}_die`, `immersiveengineering:mold_${die.immersiveEngineeringName}`);
+        event.replaceOutput(
+            {},
+            `thermal:press_${die.thermalName}_die`,
+            `immersiveengineering:mold_${die.immersiveEngineeringName}`
+        );
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -948,6 +948,24 @@ events.listen('recipes', (event) => {
                 E: '#forge:ingots/elementium'
             },
             id: 'mythicbotany:modified_gaia_pylon_with_alfsteel'
+        },
+        {
+            output: Item.of('industrialforegoing:tinydryrubber', 3),
+            pattern: ['AAA', 'ABA', 'AAA'],
+            key: {
+                A: 'minecraft:vine',
+                B: 'minecraft:water_bucket'
+            },
+            id: 'thermal:rubber_from_vine'
+        },
+        {
+            output: Item.of('industrialforegoing:tinydryrubber', 3),
+            pattern: ['AAA', 'ABA', 'AAA'],
+            key: {
+                A: 'minecraft:dandelion',
+                B: 'minecraft:water_bucket'
+            },
+            id: 'thermal:rubber_from_dandelion'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/compacting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/compacting.js
@@ -27,18 +27,18 @@ events.listen('recipes', (event) => {
                 output: 'immersiveengineering:slab_concrete'
             },
             {
-                inputs: [Fluid.of('thermal:latex', 1000)],
-                output: Item.of('thermal:rubber', 3)
+                inputs: [Fluid.of('industrialforegoing:latex', 900)],
+                output: Item.of('industrialforegoing:dryrubber', 1)
             }
         ],
         recipes_heated: [
             {
                 inputs: ['minecraft:vine'],
-                output: Fluid.of('thermal:latex', 50)
+                output: Fluid.of('industrialforegoing:latex', 50)
             },
             {
                 inputs: ['minecraft:dandelion'],
-                output: Fluid.of('thermal:latex', 50)
+                output: Fluid.of('industrialforegoing:latex', 50)
             }
         ],
         recipes_superheated: []

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
@@ -72,11 +72,19 @@ events.listen('recipes', (event) => {
             {
                 inputs: ['byg:quartzite_sand'],
                 outputs: [Item.of('minecraft:quartz'), Item.of('thermal:slag')]
+            },
+            {
+                inputs: [Item.of('industrialforegoing:dryrubber', 2), '#forge:gems/sulfur'],
+                outputs: [Item.of('thermal:cured_rubber', 2)],
+                id: 'thermal:machine/smelter/smeler_cured_rubber'
             }
         ]
     };
 
     data.recipes.forEach((recipe) => {
-        event.recipes.thermal.smelter(recipe.outputs, recipe.inputs);
+        const re = event.recipes.thermal.smelter(recipe.outputs, recipe.inputs);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/press.js
@@ -2,101 +2,134 @@ events.listen('recipes', (event) => {
     const recipes = [
         {
             inputs: [Ingredient.of('#forge:plates/steel', 3), Ingredient.of('#forge:plates/steel')],
-            output: Item.of('immersiveengineering:mold_plate', 1)
+            outputs: [Item.of('immersiveengineering:mold_plate', 1)],
+            energy: 2400
         },
         {
             inputs: [Ingredient.of('#forge:plates/steel', 3), Ingredient.of('#forge:wires/steel')],
-            output: Item.of('immersiveengineering:mold_wire', 1)
+            outputs: [Item.of('immersiveengineering:mold_wire', 1)],
+            energy: 2400
         },
         {
             inputs: [Ingredient.of('#forge:plates/steel', 3), Ingredient.of('#forge:gears/steel')],
-            output: Item.of('immersiveengineering:mold_gear', 1)
+            outputs: [Item.of('immersiveengineering:mold_gear', 1)],
+            energy: 2400
         },
         {
             inputs: [Ingredient.of('#forge:plates/steel', 3), Ingredient.of('#forge:rods/steel')],
-            output: Item.of('immersiveengineering:mold_rod', 1)
+            outputs: [Item.of('immersiveengineering:mold_rod', 1)],
+            energy: 2400
         },
         {
             inputs: [Ingredient.of('#forge:ingots/copper'), Ingredient.of('#thermal:crafting/dies/bullet_casing')],
-            output: Item.of('immersiveengineering:empty_casing', 2)
+            outputs: [Item.of('immersiveengineering:empty_casing', 2)],
+            energy: 2400
         },
         {
             inputs: [Item.of('byg:pink_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('byg:pink_sand', 4)
+            outputs: [Item.of('byg:pink_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('byg:purple_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('byg:purple_sand', 4)
+            outputs: [Item.of('byg:purple_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('byg:blue_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('byg:blue_sand', 4)
+            outputs: [Item.of('byg:blue_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('byg:white_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('byg:white_sand', 4)
+            outputs: [Item.of('byg:white_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('byg:black_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('byg:black_sand', 4)
+            outputs: [Item.of('byg:black_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('atmospheric:arid_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('atmospheric:arid_sand', 4)
+            outputs: [Item.of('atmospheric:arid_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('atmospheric:red_arid_sandstone', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('atmospheric:red_arid_sand', 4)
+            outputs: [Item.of('atmospheric:red_arid_sand', 4)],
+            energy: 2400
         },
         {
             inputs: [Item.of('betterendforge:dense_snow', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('minecraft:snow_block', 9)
+            outputs: [Item.of('minecraft:snow_block', 9)],
+            energy: 2400
         },
         {
             inputs: [Item.of('minecraft:snow_block', 9), Ingredient.of('#thermal:crafting/dies/packing_3x3')],
-            output: Item.of('betterendforge:dense_snow', 1)
+            outputs: [Item.of('betterendforge:dense_snow', 1)],
+            energy: 2400
         },
         {
             inputs: [Ingredient.of('#integrateddynamics:menril_logs', 1)],
-            output: [
+            outputs: [
                 Item.of('integrateddynamics:crystalized_menril_chunk', 4),
                 Fluid.of('integrateddynamics:menril_resin', 1000)
-            ]
+            ],
+            energy: 2400
         },
         {
             inputs: [Item.of('integrateddynamics:menril_planks', 1)],
-            output: [
+            outputs: [
                 Item.of('integrateddynamics:crystalized_menril_chunk', 1),
                 Fluid.of('integrateddynamics:menril_resin', 250)
-            ]
+            ],
+            energy: 2400
         },
         {
             inputs: [Item.of('minecraft:popped_chorus_fruit', 1)],
-            output: [
+            outputs: [
                 Item.of('integrateddynamics:crystalized_chorus_chunk', 4),
                 Fluid.of('integrateddynamics:liquid_chorus', 125)
-            ]
+            ],
+            energy: 2400
         },
         {
             inputs: [Item.of('integrateddynamics:proto_chorus', 1)],
-            output: [
+            outputs: [
                 Item.of('integrateddynamics:crystalized_chorus_chunk', 2),
                 Fluid.of('integrateddynamics:liquid_chorus', 125)
-            ]
+            ],
+            energy: 2400
         },
         {
             id: 'thermal:machine/press/packing2x2/press_honeycomb_packing',
             inputs: [Item.of('minecraft:honeycomb', 9), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('minecraft:honeycomb_block', 1)
+            outputs: [Item.of('minecraft:honeycomb_block', 1)],
+            energy: 2400
         },
         {
             id: 'thermal:machine/press/unpacking/press_honeycomb_unpacking',
             inputs: [Item.of('minecraft:honeycomb_block', 1), Ingredient.of('#thermal:crafting/dies/unpacking')],
-            output: Item.of('minecraft:honeycomb', 9)
+            outputs: [Item.of('minecraft:honeycomb', 9)],
+            energy: 2400
         },
         {
             inputs: [Item.of('mekanism:hdpe_pellet')],
-            output: [Item.of('mekanism:hdpe_sheet')]
+            outputs: [Item.of('mekanism:hdpe_sheet')],
+            energy: 2400
+        },
+        {
+            inputs: [Item.of('minecraft:vine')],
+            outputs: [Fluid.of('industrialforegoing:latex', 50)],
+            energy: 400,
+            id: 'thermal:machine/press/press_vine_to_latex'
+        },
+        {
+            inputs: [Item.of('minecraft:dandelion')],
+            outputs: [Fluid.of('industrialforegoing:latex', 50)],
+            energy: 400,
+            id: 'thermal:machine/press/press_dandelion_to_latex'
         }
     ];
 
@@ -106,7 +139,8 @@ events.listen('recipes', (event) => {
                 Item.of(`emendatusenigmatica:${metal}_ingot`, 9),
                 Ingredient.of('#thermal:crafting/dies/packing_3x3')
             ],
-            output: Item.of(`emendatusenigmatica:${metal}_block`)
+            outputs: [Item.of(`emendatusenigmatica:${metal}_block`)],
+            energy: 2400
         });
     });
 
@@ -117,21 +151,23 @@ events.listen('recipes', (event) => {
                     Item.of('resourcefulbees:' + variant + '_honeycomb', 9),
                     Ingredient.of('#thermal:crafting/dies/packing_3x3')
                 ],
-                output: Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1)
+                outputs: [Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1)],
+                energy: 2400
             },
             {
                 inputs: [
                     Item.of('resourcefulbees:' + variant + '_honeycomb_block', 1),
                     Ingredient.of('#thermal:crafting/dies/unpacking')
                 ],
-                output: Item.of('resourcefulbees:' + variant + '_honeycomb', 9)
+                outputs: [Item.of('resourcefulbees:' + variant + '_honeycomb', 9)],
+                energy: 2400
             }
         );
     });
 
     recipes.forEach((recipe) => {
         recipe.id
-            ? event.recipes.thermal.press(recipe.output, recipe.inputs).energy(2400).id(recipe.id)
-            : event.recipes.thermal.press(recipe.output, recipe.inputs).energy(2400);
+            ? event.recipes.thermal.press(recipe.outputs, recipe.inputs).energy(recipe.energy).id(recipe.id)
+            : event.recipes.thermal.press(recipe.outputs, recipe.inputs).energy(recipe.energy);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/refinery.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/refinery.js
@@ -12,6 +12,10 @@ events.listen('recipes', (event) => {
             {
                 outputs: [Item.of('minecraft:sugar', 2)],
                 input: fluid.of('thermal:syrup', 25)
+            },
+            {
+                outputs: [Item.of('industrialforegoing:dryrubber', 1)],
+                input: fluid.of('industrialforegoing:latex', 900)
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
@@ -58,7 +58,7 @@ const treeRegistry = [
                 leaf: 'byg:baobab_leaves',
                 fruit: 'byg:baobab_fruit',
                 substrate: 'dirt',
-                sap: 'thermal:latex',
+                sap: 'industrialforegoing:latex',
                 amount: 50
             },
             {
@@ -167,7 +167,7 @@ const treeRegistry = [
                 trunk: 'byg:mahogany_log',
                 leaf: 'byg:mahogany_leaves',
                 substrate: 'dirt',
-                sap: 'thermal:latex',
+                sap: 'industrialforegoing:latex',
                 amount: 50
             },
             {
@@ -245,7 +245,7 @@ const treeRegistry = [
                 trunk: 'byg:rainbow_eucalyptus_log',
                 leaf: 'byg:rainbow_eucalyptus_leaves',
                 substrate: 'dirt',
-                sap: 'thermal:latex',
+                sap: 'industrialforegoing:latex',
                 amount: 50
             },
             {
@@ -360,7 +360,7 @@ const treeRegistry = [
                 leaf: 'minecraft:jungle_leaves',
                 fruit: 'alexsmobs:banana',
                 substrate: 'dirt',
-                sap: 'thermal:latex',
+                sap: 'industrialforegoing:latex',
                 amount: 50
             },
             {


### PR DESCRIPTION
IF Latex is now the only latex available.
The Arboreal Extractor can extract it endlessly from certain living trees or the IF Fluid Extractor can be used to pull it out of cut logs as normal.

'Easy' recipes using a bucket and vines/dandelions now produce 3 tiny dry rubber.
Latex can still be pressed out of vines/dandelions with a multi-press at a rate of 50mb. So 18 of these items makes 1 dry rubber, as opposed to 24 with the bucket method.
Fractionating Still produces 1 Dry Rubber  from 900 mb of latex. In line with the IF Latex Processing Unit

Completes #1592