### PR TITLE
Remove book o enchanting trinket from random pool

### DIFF
--- a/config/losttrinkets/general_common.toml
+++ b/config/losttrinkets/general_common.toml
@@ -8,7 +8,7 @@ blackList = ["losttrinkets:tha_ghost"]
 unlockCooldown = 36000
 #List of trinkets that can't be unlocked randomly eg: ["losttrinkets:piggy", "losttrinkets:magical_feathers"]
 #The trinkets listed in here will not be removed from players that already unlocked them.
-nonRandom = ["losttrinkets:rock_candy", "losttrinkets:tha_cloud", "losttrinkets:turtle_shell", "losttrinkets:blaze_heart", "losttrinkets:tha_bat", "losttrinkets:tea_leaf", "losttrinkets:octopick", "losttrinkets:magical_herbs", "losttrinkets:magical_feathers", "losttrinkets:mad_aura"]
+nonRandom = ["losttrinkets:rock_candy", "losttrinkets:tha_cloud", "losttrinkets:turtle_shell", "losttrinkets:blaze_heart", "losttrinkets:tha_bat", "losttrinkets:tea_leaf", "losttrinkets:octopick", "losttrinkets:magical_herbs", "losttrinkets:magical_feathers", "losttrinkets:mad_aura", "losttrinkets:book_o_enchanting"]
 
 [Trinket_Slots]
 	#Amount of Xp levels added to the next unlocking cost.


### PR DESCRIPTION
this trinket is supposed to make it so you don't need bookshelves to enchant at higher levels but does not work with apotheosis' enchanting overhaul. No reason to exist.

Fixes #2326 