### PR TITLE
Pretty Fluid Pipes Recipe Thermalization

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -13,6 +13,7 @@ events.listen('recipes', (event) => {
     event.remove({ type: 'minecraft:blasting', input: '#farmersdelight:tools/knives' });
 
     event.remove({ mod: 'prettypipes' });
+    event.remove({ mod: 'ppfluids' });
     event.remove({ mod: 'ironjetpacks' });
     event.remove({ mod: 'theoneprobe' });
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -1127,10 +1127,11 @@ events.listen('recipes', (event) => {
             C: 'minecraft:iron_bars'
         }),
 
-        shapedRecipe(Item.of('ppfluids:low_fluid_filter_module', 1), [' A ', ' B ', ' C '], {
+        shapedRecipe(Item.of('ppfluids:low_fluid_filter_module', 1), [' A ', 'DBD', ' C '], {
             A: 'thermal:diving_fabric',
             B: 'prettypipes:blank_module',
-            C: 'thermal:redstone_servo'
+            C: 'thermal:redstone_servo',
+            D: 'thermal:cured_rubber'
         }),
         shapedRecipe(Item.of('ppfluids:medium_fluid_filter_module', 1), [' C ', 'ABA', ' C '], {
             A: '#forge:nuggets/aluminum',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -1095,6 +1095,22 @@ events.listen('recipes', (event) => {
             B: 'prettypipes:medium_extraction_module',
             C: '#forge:ingots/electrum'
         }),
+        shapedRecipe(Item.of('ppfluids:low_fluid_extraction_module', 1), [' A ', 'DBD', ' C '], {
+            A: '#forge:dusts/redstone',
+            B: 'prettypipes:blank_module',
+            C: 'thermal:redstone_servo',
+            D: 'thermal:cured_rubber'
+        }),
+        shapedRecipe(Item.of('ppfluids:medium_fluid_extraction_module', 1), [' C ', 'ABA', ' A '], {
+            A: '#forge:nuggets/aluminum',
+            B: 'ppfluids:low_fluid_extraction_module',
+            C: '#forge:ingots/aluminum'
+        }),
+        shapedRecipe(Item.of('ppfluids:high_fluid_extraction_module', 1), [' C ', 'ABA', ' A '], {
+            A: '#forge:nuggets/bronze',
+            B: 'ppfluids:medium_fluid_extraction_module',
+            C: '#forge:ingots/bronze'
+        }),
         shapedRecipe(Item.of('prettypipes:low_filter_module', 1), [' A ', ' B ', ' C '], {
             A: '#forge:paper',
             B: 'prettypipes:blank_module',
@@ -1110,6 +1126,23 @@ events.listen('recipes', (event) => {
             B: 'prettypipes:medium_filter_module',
             C: 'minecraft:iron_bars'
         }),
+
+        shapedRecipe(Item.of('ppfluids:low_fluid_filter_module', 1), [' A ', ' B ', ' C '], {
+            A: 'thermal:diving_fabric',
+            B: 'prettypipes:blank_module',
+            C: 'thermal:redstone_servo'
+        }),
+        shapedRecipe(Item.of('ppfluids:medium_fluid_filter_module', 1), [' C ', 'ABA', ' C '], {
+            A: '#forge:nuggets/aluminum',
+            B: 'ppfluids:low_fluid_filter_module',
+            C: 'minecraft:iron_bars'
+        }),
+        shapedRecipe(Item.of('ppfluids:high_fluid_filter_module', 1), [' C ', 'ABA', ' C '], {
+            A: '#forge:nuggets/bronze',
+            B: 'ppfluids:medium_fluid_filter_module',
+            C: 'minecraft:iron_bars'
+        }),
+
         shapedRecipe(Item.of('prettypipes:low_speed_module', 1), [' A ', ' B ', ' C '], {
             A: 'minecraft:sugar',
             B: 'prettypipes:blank_module',
@@ -1170,6 +1203,24 @@ events.listen('recipes', (event) => {
             B: 'prettypipes:medium_retrieval_module',
             C: '#forge:ingots/electrum'
         }),
+
+        shapedRecipe(Item.of('ppfluids:low_fluid_retrieval_module', 1), [' A ', 'DBD', ' C '], {
+            A: 'minecraft:observer',
+            B: 'prettypipes:blank_module',
+            C: 'thermal:redstone_servo',
+            D: 'thermal:cured_rubber'
+        }),
+        shapedRecipe(Item.of('ppfluids:medium_fluid_retrieval_module', 1), [' A ', 'ABA', ' C '], {
+            A: '#forge:nuggets/aluminum',
+            B: 'ppfluids:low_fluid_retrieval_module',
+            C: '#forge:ingots/aluminum'
+        }),
+        shapedRecipe(Item.of('ppfluids:high_fluid_retrieval_module', 1), [' A ', 'ABA', ' C '], {
+            A: '#forge:nuggets/bronze',
+            B: 'ppfluids:medium_fluid_retrieval_module',
+            C: '#forge:ingots/bronze'
+        }),
+
         shapedRecipe(Item.of('prettypipes:stack_size_module', 1), [' A ', ' B ', ' C '], {
             A: 'minecraft:comparator',
             B: 'prettypipes:blank_module',
@@ -1223,6 +1274,11 @@ events.listen('recipes', (event) => {
         shapedRecipe(Item.of('prettypipes:pipe', 12), ['   ', 'ABA', '   '], {
             A: '#forge:ingots/tin',
             B: '#forge:glass/colorless'
+        }),
+        shapedRecipe(Item.of('ppfluids:fluid_pipe', 12), [' C ', 'ABA', ' C '], {
+            A: '#forge:ingots/tin',
+            B: '#forge:glass/colorless',
+            C: 'thermal:cured_rubber'
         }),
         shapedRecipe(Item.of('prettypipes:item_terminal', 1), [' B ', 'CAD', 'EFE'], {
             A: 'thermal:machine_frame',


### PR DESCRIPTION
#2334

Rubber factors into base recipes.
Upgrades follow a similar pattern to their Item counterparts, but use Aluminum for Medium tier and Bronze for High tier as opposed to Invar and Electrum

Pipes:
![image](https://user-images.githubusercontent.com/9543430/120503694-84c35480-c391-11eb-87bb-a34ad0fd9645.png)

Low Fluid Extraction:
![image](https://user-images.githubusercontent.com/9543430/120503761-90af1680-c391-11eb-862d-f555ed5d7336.png)

Medium Fluid Extraction:
![image](https://user-images.githubusercontent.com/9543430/120503837-a02e5f80-c391-11eb-9120-50fee9bf05e8.png)

High Fluid Extraction:
![image](https://user-images.githubusercontent.com/9543430/120503885-aa505e00-c391-11eb-86e0-dce8b44d672b.png)

Filter uses Marine Fabric instead of paper
![image](https://user-images.githubusercontent.com/9543430/120506597-116f1200-c394-11eb-9b1c-62bad15fa2ff.png)

Low Fluid Retrieval:
![image](https://user-images.githubusercontent.com/9543430/120506716-2fd50d80-c394-11eb-84d6-d3a1e5eebedd.png)

