### PR TITLE
Create Alchemy Table recipe for Cured Rubber

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
@@ -198,6 +198,14 @@ events.listen('recipes', (event) => {
                 orbLevel: 1
             },
             {
+                inputs: ['#forge:gems/sulfur', 'industrialforegoing:dryrubber', 'industrialforegoing:dryrubber'],
+                output: 'thermal:cured_rubber',
+                count: 2,
+                syphon: 400,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
                 inputs: ['minecraft:end_stone', 'minecraft:bone_meal', '#forge:mushrooms'],
                 output: 'betterendforge:end_mycelium',
                 count: 1,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
@@ -76,7 +76,7 @@ events.listen('recipes', (event) => {
             {
                 inputs: [Item.of('industrialforegoing:dryrubber', 2), '#forge:gems/sulfur'],
                 outputs: [Item.of('thermal:cured_rubber', 2)],
-                id: 'thermal:machine/smelter/smeler_cured_rubber'
+                id: 'thermal:machine/smelter/smelter_cured_rubber'
             }
         ]
     };


### PR DESCRIPTION
Fix typo in Thermal Smelter ID causing new recipe to not override old one.

Add new recipe to Alchemy Table to let more magically inclined folks access cured rubber through less tech oriented paths.