### PR TITLE
Fixes Conflicting Glass Smelting from BYG

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -73,6 +73,7 @@ events.listen('recipes', (event) => {
         'buildersaddition:iron_rod',
 
         'byg:vermilion_sculk',
+        '/byg:\\w+_glass_from_sand/',
 
         'compactmachines:wall',
 


### PR DESCRIPTION
BYG Colored sands smelt down to colored glass, natively. However this conflicts with standard glass. Removed the colored sand to colored glass recipes.