### PR TITLE
Buff Create Paper recipe

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/compacting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/compacting.js
@@ -18,9 +18,10 @@ events.listen('recipes', (event) => {
                     '#forge:dusts/wood',
                     '#forge:dusts/wood',
                     '#forge:dusts/wood',
+                    '#forge:dusts/wood',
                     { fluidTag: 'minecraft:water', amount: 250 }
                 ],
-                output: Item.of('minecraft:paper', 2)
+                output: Item.of('minecraft:paper', 6)
             },
             {
                 inputs: [Fluid.of('immersiveengineering:concrete', 500)],


### PR DESCRIPTION
brings it in line with the other paper rebalance. 1.5x paper per wood dust. More efficient on water.
#2347