### PR TITLE
[Expert] Switch to Quark as base candle

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -12,7 +12,6 @@ onEvent('recipes', (event) => {
             },
             id: 'botanypots:crafting/botany_pot'
         },
-
         {
             output: 'ironjetpacks:hardened_jetpack',
             pattern: ['ABA', 'ECE', 'D D'],
@@ -990,6 +989,15 @@ onEvent('recipes', (event) => {
                 A: '#forge:dusts/wood'
             },
             id: 'mekanism:paper'
+        },
+        {
+            output: 'supplementaries:candle_holder',
+            pattern: ['A', 'B'],
+            key: {
+                A: '#quark:candles',
+                B: '#forge:nuggets/pewter'
+            },
+            id: 'supplementaries:candle_holder'
         }
     ];
 
@@ -1384,18 +1392,6 @@ onEvent('recipes', (event) => {
                 F: 'morphtool:tool'
             }
         ),
-        shapedRecipe(Item.of('occultism:candle_white'), [' B ', 'AAA', 'AAA'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
-        shapedRecipe(Item.of('eidolon:candle', 4), ['B', 'A'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
-        shapedRecipe(Item.of('quark:white_candle', 2), ['B', 'A', 'A'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
         shapedRecipe(Item.of('byg:embur_hyphae', 3), ['AA', 'AA'], {
             A: 'byg:embur_pedu'
         }),

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/candle_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/candle_materials.js
@@ -1,0 +1,7 @@
+onEvent('item.tags', (event) => {
+    event
+        .get('enigmatica:candle_materials')
+        .add('minecraft:honeycomb')
+        .add('resourcefulbees:wax')
+        .add('occultism:tallow');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -114,14 +114,14 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle'
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle'
                 ],
                 reagent: 'bloodmagic:holy_water_anointment',
                 output: 'eidolon:candle',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
@@ -4,46 +4,12 @@ onEvent('recipes', (event) => {
     }
 
     var data = {
-        recipes: [
-            {
-                inputs: ['#forge:wax', '#forge:string'],
-                output: 'buildersaddition:large_candle',
-                count: 1,
-                cookingTime: 100,
-                id: 'buildersaddition:large_candle'
-            },
-            {
-                inputs: ['#forge:tallow', '#forge:string'],
-                output: 'buildersaddition:large_candle',
-                count: 1,
-                cookingTime: 100
-            },
-            {
-                inputs: ['minecraft:honeycomb', '#forge:string'],
-                output: 'buildersaddition:large_candle',
-                count: 1,
-                cookingTime: 100
-            },
-            {
-                inputs: ['minecraft:soul_sand', 'buildersaddition:large_candle'],
-                output: 'buildersaddition:large_soul_candle',
-                count: 1,
-                cookingTime: 100,
-                id: 'buildersaddition:large_soul_candle_soul_sand'
-            },
-            {
-                inputs: ['minecraft:soul_soil', 'buildersaddition:large_candle'],
-                output: 'buildersaddition:large_soul_candle',
-                count: 1,
-                cookingTime: 100,
-                id: 'buildersaddition:large_soul_candle_soul_soil'
-            }
-        ]
+        recipes: []
     };
 
     colors.forEach((color) => {
         data.recipes.push({
-            inputs: [`#forge:dyes/${color}`, 'buildersaddition:large_candle'],
+            inputs: [`#forge:dyes/${color}`, '#enigmatica:candle_materials', '#forge:string'],
             output: `quark:${color}_candle`,
             count: 1,
             cookingTime: 100,


### PR DESCRIPTION
Remove dependency on builders addition candles as the 'base' candle. Quark candles are now the base, crafted in the cooking pot.

New tag introduced for candle materials. This intentionally excludes resourceful bees combs since it kind of cluttered the recipe (hard to see it accepts tallow and wax) and people would need to be crazy to waste resource combs on a silly candle.

Consecrated candles only use white (pure) candles intentionally.

Minor change to supplementaries Candle Holder to use Pewter instead of Iron. This affects all gamemodes