### PR TITLE
Botania utility[Expert] Redstring and Corporea rework

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -1,6 +1,10 @@
 onEvent('recipes', (event) => {
     const recipes = [
-        { replaceTarget: { id: 'entangled:block' }, toReplace: 'minecraft:chest', replaceWith: '#forge:chests/wooden' }
+        {
+            replaceTarget: { id: 'entangled:block' },
+            toReplace: 'minecraft:chest',
+            replaceWith: '#forge:chests/wooden'
+        }
     ];
     event.replaceInput({}, 'refinedstorage:silicon', '#forge:silicon');
     event.replaceInput({}, 'refinedstorage:crafter', '#refinedstorage:crafter');
@@ -200,226 +204,225 @@ onEvent('recipes', (event) => {
             '#forge:gravel'
         ]);
     });
-    var data = {
-        recipes: [
-            {
-                type: 'storage_blocks',
-                replace: 'iron',
-                replaceWith: 'aluminum',
-                items: [
-                    'bloodmagic:soulforge',
-                    'mininggadgets:upgrade_fortune_1',
-                    'resourcefulbees:centrifuge_casing',
-                    'xnet:antenna_base'
-                ]
-            },
-            {
-                type: 'storage_blocks',
-                replace: 'iron',
-                replaceWith: 'brass',
-                items: ['ars_nouveau:glyph_press']
-            },
-            {
-                type: 'storage_blocks',
-                replace: 'iron',
-                replaceWith: 'invar',
-                items: ['resourcefulbees:centrifuge_controller']
-            },
-            {
-                type: 'storage_blocks',
-                replace: 'iron',
-                replaceWith: 'lead',
-                items: ['travel_anchors:travel_anchor', 'thermal:machine_press', 'bloodmagic:alchemicalreactionchamber']
-            },
-            {
-                type: 'storage_blocks',
-                replace: 'iron',
-                replaceWith: 'tin',
-                items: ['aquaculture:tackle_box']
-            },
-            {
-                type: 'dusts',
-                replace: 'gold',
-                replaceWith: 'copper',
-                items: ['mekanism:upgrade_energy']
-            },
-            {
-                type: 'gears',
-                replace: 'gold',
-                replaceWith: 'bronze',
-                items: ['thermal:upgrade_augment_1']
-            },
-            {
-                type: 'gears',
-                replace: 'gold',
-                replaceWith: 'copper',
-                items: ['thermal:flux_drill', 'thermal:flux_saw']
-            },
-            {
-                type: 'gears',
-                replace: 'gold',
-                replaceWith: 'silver',
-                items: ['thermal:dynamo_lapidary']
-            },
-            {
-                type: 'ingots',
-                replace: 'gold',
-                replaceWith: 'brass',
-                items: [
-                    'ars_nouveau:arcane_core',
-                    'ars_nouveau:crystallizer',
-                    'ars_nouveau:volcanic_accumulator',
-                    'pneumaticcraft:gun_ammo',
-                    'ars_nouveau:marvelous_clay'
-                ]
-            },
-            {
-                type: 'ingots',
-                replace: 'gold',
-                replaceWith: 'bronze',
-                items: [
-                    'bloodmagic:alchemytable',
-                    'bloodmagic:altar',
-                    'bloodmagic:sacrificialdagger',
-                    'bloodmagic:experiencebook',
-                    'bloodmagic:soulforge',
-                    'pneumaticcraft:medium_tank',
-                    'pneumaticcraft:minigun',
-                    'pneumaticcraft:pressure_gauge',
-                    'thermal:diving_helmet',
-                    'thermal:diving_chestplate',
-                    'thermal:diving_leggings',
-                    'thermal:diving_boots',
-                    'minecraft:clock'
-                ]
-            },
-            {
-                type: 'ingots',
-                replace: 'gold',
-                replaceWith: 'copper',
-                items: [
-                    'mekanismgenerators:electromagnetic_coil',
-                    'mekanism:energy_tablet',
-                    'mininggadgets:upgrade_magnet',
-                    'xnet:controller',
-                    'thermal:rf_coil_xfer_augment',
-                    'thermal:rf_coil_storage_augment',
-                    'thermal:rf_coil_augment',
-                    'thermal:rf_coil',
-                    'rftoolsstorage:storage_scanner',
-                    'rftoolsbuilder:shield_block1',
-                    'pneumaticcraft:vortex_tube',
-                    'pneumaticcraft:heat_sink',
-                    'modularrouters:speed_upgrade',
-                    'xnet:connector_blue',
-                    'xnet:connector_red',
-                    'xnet:connector_green'
-                ]
-            },
-            {
-                type: 'ingots',
-                replace: 'gold',
-                replaceWith: 'silver',
-                items: ['torchmaster:feral_flare_lantern', 'mekanism:teleportation_core', 'botania:mana_spreader']
-            },
-            {
-                type: 'ingots',
-                replace: 'gold',
-                replaceWith: 'tin',
-                items: ['pneumaticcraft:memory_stick']
-            },
-            {
-                type: 'ingots',
-                replace: 'iron',
-                replaceWith: 'aluminum',
-                items: [
-                    'immersiveengineering:conveyor_splitter',
-                    'immersiveengineering:conveyor_vertical',
-                    'immersiveengineering:conveyor_basic',
-                    'immersiveengineering:current_transformer',
-                    'immersiveengineering:transformer_hv',
-                    'immersiveengineering:transformer',
-                    'immersiveengineering:dynamo',
-                    'immersiveengineering:furnace_heater',
-                    'immersiveengineering:toolupgrade_drill_lube',
-                    'endermail:locker',
-                    'endermail:package_controller',
-                    'cookingforblockheads:preservation_chamber',
-                    'buildersaddition:arcade',
-                    'minecraft:compass',
-                    'minecraft:piston',
-                    'xnet:antenna_dish',
-                    'xnet:antenna_base',
-                    'xnet:antenna',
-                    'transport:fluid_loader',
-                    'resourcefulbees:centrifuge_casing',
-                    'engineersdecor:metal_bar'
-                ]
-            },
-            {
-                type: 'ingots',
-                replace: 'iron',
-                replaceWith: 'brass',
-                items: ['ars_nouveau:mana_condenser', 'ars_nouveau:enchanting_apparatus']
-            },
-            {
-                type: 'ingots',
-                replace: 'iron',
-                replaceWith: 'copper',
-                items: [
-                    'shrink:shrinking_device',
-                    'immersiveengineering:charging_station',
-                    'cookingforblockheads:heating_unit',
-                    'aquaculture:tackle_box'
-                ]
-            },
-            {
-                type: 'ingots',
-                replace: 'iron',
-                replaceWith: 'lead',
-                items: ['travel_anchors:travel_anchor', 'travel_anchors:travel_staff']
-            },
-            {
-                type: 'ingots',
-                replace: 'iron',
-                replaceWith: 'tin',
-                items: ['bloodmagic:soulsnare', 'modularrouters:bulk_item_filter']
-            },
-            {
-                type: 'nuggets',
-                replace: 'gold',
-                replaceWith: 'bronze',
-                items: ['rftoolsstorage:storage_module0']
-            },
-            {
-                type: 'nuggets',
-                replace: 'gold',
-                replaceWith: 'copper',
-                items: [
-                    'xnet:connector_routing',
-                    'xnet:netcable_routing',
-                    'xnet:netcable_yellow',
-                    'xnet:netcable_blue',
-                    'xnet:netcable_green',
-                    'xnet:netcable_red',
-                    'rftoolsbase:machine_base',
-                    'rftoolsbase:machine_frame',
-                    'rftoolscontrol:card_base',
-                    'modularrouters:speed_upgrade',
-                    'modularrouters:blank_upgrade',
-                    'modularrouters:blank_module'
-                ]
-            },
-            {
-                type: 'nuggets',
-                replace: 'gold',
-                replaceWith: 'silver',
-                items: ['botania:spark']
-            }
-        ]
-    };
 
-    data.recipes.forEach((recipe) => {
+    const alt_material_tag_replacements = [
+        {
+            type: 'storage_blocks',
+            replace: 'iron',
+            replaceWith: 'aluminum',
+            items: [
+                'bloodmagic:soulforge',
+                'mininggadgets:upgrade_fortune_1',
+                'resourcefulbees:centrifuge_casing',
+                'xnet:antenna_base'
+            ]
+        },
+        {
+            type: 'storage_blocks',
+            replace: 'iron',
+            replaceWith: 'brass',
+            items: ['ars_nouveau:glyph_press']
+        },
+        {
+            type: 'storage_blocks',
+            replace: 'iron',
+            replaceWith: 'invar',
+            items: ['resourcefulbees:centrifuge_controller']
+        },
+        {
+            type: 'storage_blocks',
+            replace: 'iron',
+            replaceWith: 'lead',
+            items: ['travel_anchors:travel_anchor', 'thermal:machine_press', 'bloodmagic:alchemicalreactionchamber']
+        },
+        {
+            type: 'storage_blocks',
+            replace: 'iron',
+            replaceWith: 'tin',
+            items: ['aquaculture:tackle_box']
+        },
+        {
+            type: 'dusts',
+            replace: 'gold',
+            replaceWith: 'copper',
+            items: ['mekanism:upgrade_energy']
+        },
+        {
+            type: 'gears',
+            replace: 'gold',
+            replaceWith: 'bronze',
+            items: ['thermal:upgrade_augment_1']
+        },
+        {
+            type: 'gears',
+            replace: 'gold',
+            replaceWith: 'copper',
+            items: ['thermal:flux_drill', 'thermal:flux_saw']
+        },
+        {
+            type: 'gears',
+            replace: 'gold',
+            replaceWith: 'silver',
+            items: ['thermal:dynamo_lapidary']
+        },
+        {
+            type: 'ingots',
+            replace: 'gold',
+            replaceWith: 'brass',
+            items: [
+                'ars_nouveau:arcane_core',
+                'ars_nouveau:crystallizer',
+                'ars_nouveau:volcanic_accumulator',
+                'pneumaticcraft:gun_ammo',
+                'ars_nouveau:marvelous_clay'
+            ]
+        },
+        {
+            type: 'ingots',
+            replace: 'gold',
+            replaceWith: 'bronze',
+            items: [
+                'bloodmagic:alchemytable',
+                'bloodmagic:altar',
+                'bloodmagic:sacrificialdagger',
+                'bloodmagic:experiencebook',
+                'bloodmagic:soulforge',
+                'pneumaticcraft:medium_tank',
+                'pneumaticcraft:minigun',
+                'pneumaticcraft:pressure_gauge',
+                'thermal:diving_helmet',
+                'thermal:diving_chestplate',
+                'thermal:diving_leggings',
+                'thermal:diving_boots',
+                'minecraft:clock'
+            ]
+        },
+        {
+            type: 'ingots',
+            replace: 'gold',
+            replaceWith: 'copper',
+            items: [
+                'mekanismgenerators:electromagnetic_coil',
+                'mekanism:energy_tablet',
+                'mininggadgets:upgrade_magnet',
+                'xnet:controller',
+                'thermal:rf_coil_xfer_augment',
+                'thermal:rf_coil_storage_augment',
+                'thermal:rf_coil_augment',
+                'thermal:rf_coil',
+                'rftoolsstorage:storage_scanner',
+                'rftoolsbuilder:shield_block1',
+                'pneumaticcraft:vortex_tube',
+                'pneumaticcraft:heat_sink',
+                'modularrouters:speed_upgrade',
+                'xnet:connector_blue',
+                'xnet:connector_red',
+                'xnet:connector_green'
+            ]
+        },
+        {
+            type: 'ingots',
+            replace: 'gold',
+            replaceWith: 'silver',
+            items: ['torchmaster:feral_flare_lantern', 'mekanism:teleportation_core', 'botania:mana_spreader']
+        },
+        {
+            type: 'ingots',
+            replace: 'gold',
+            replaceWith: 'tin',
+            items: ['pneumaticcraft:memory_stick']
+        },
+        {
+            type: 'ingots',
+            replace: 'iron',
+            replaceWith: 'aluminum',
+            items: [
+                'immersiveengineering:conveyor_splitter',
+                'immersiveengineering:conveyor_vertical',
+                'immersiveengineering:conveyor_basic',
+                'immersiveengineering:current_transformer',
+                'immersiveengineering:transformer_hv',
+                'immersiveengineering:transformer',
+                'immersiveengineering:dynamo',
+                'immersiveengineering:furnace_heater',
+                'immersiveengineering:toolupgrade_drill_lube',
+                'endermail:locker',
+                'endermail:package_controller',
+                'cookingforblockheads:preservation_chamber',
+                'buildersaddition:arcade',
+                'minecraft:compass',
+                'minecraft:piston',
+                'xnet:antenna_dish',
+                'xnet:antenna_base',
+                'xnet:antenna',
+                'transport:fluid_loader',
+                'resourcefulbees:centrifuge_casing',
+                'engineersdecor:metal_bar'
+            ]
+        },
+        {
+            type: 'ingots',
+            replace: 'iron',
+            replaceWith: 'brass',
+            items: ['ars_nouveau:mana_condenser', 'ars_nouveau:enchanting_apparatus']
+        },
+        {
+            type: 'ingots',
+            replace: 'iron',
+            replaceWith: 'copper',
+            items: [
+                'shrink:shrinking_device',
+                'immersiveengineering:charging_station',
+                'cookingforblockheads:heating_unit',
+                'aquaculture:tackle_box'
+            ]
+        },
+        {
+            type: 'ingots',
+            replace: 'iron',
+            replaceWith: 'lead',
+            items: ['travel_anchors:travel_anchor', 'travel_anchors:travel_staff']
+        },
+        {
+            type: 'ingots',
+            replace: 'iron',
+            replaceWith: 'tin',
+            items: ['bloodmagic:soulsnare', 'modularrouters:bulk_item_filter']
+        },
+        {
+            type: 'nuggets',
+            replace: 'gold',
+            replaceWith: 'bronze',
+            items: ['rftoolsstorage:storage_module0']
+        },
+        {
+            type: 'nuggets',
+            replace: 'gold',
+            replaceWith: 'copper',
+            items: [
+                'xnet:connector_routing',
+                'xnet:netcable_routing',
+                'xnet:netcable_yellow',
+                'xnet:netcable_blue',
+                'xnet:netcable_green',
+                'xnet:netcable_red',
+                'rftoolsbase:machine_base',
+                'rftoolsbase:machine_frame',
+                'rftoolscontrol:card_base',
+                'modularrouters:speed_upgrade',
+                'modularrouters:blank_upgrade',
+                'modularrouters:blank_module'
+            ]
+        },
+        {
+            type: 'nuggets',
+            replace: 'gold',
+            replaceWith: 'silver',
+            items: ['botania:spark']
+        }
+    ];
+
+    alt_material_tag_replacements.forEach((recipe) => {
         recipe.items.forEach((item) => {
             event.replaceInput(
                 { output: item },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -12,7 +12,6 @@ onEvent('recipes', (event) => {
             },
             id: 'botanypots:crafting/botany_pot'
         },
-
         {
             output: 'ironjetpacks:hardened_jetpack',
             pattern: ['ABA', 'ECE', 'D D'],
@@ -990,6 +989,15 @@ onEvent('recipes', (event) => {
                 A: '#forge:dusts/wood'
             },
             id: 'mekanism:paper'
+        },
+        {
+            output: 'supplementaries:candle_holder',
+            pattern: ['A', 'B'],
+            key: {
+                A: '#quark:candles',
+                B: '#forge:nuggets/pewter'
+            },
+            id: 'supplementaries:candle_holder'
         }
     ];
 
@@ -1384,18 +1392,6 @@ onEvent('recipes', (event) => {
                 F: 'morphtool:tool'
             }
         ),
-        shapedRecipe(Item.of('occultism:candle_white'), [' B ', 'AAA', 'AAA'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
-        shapedRecipe(Item.of('eidolon:candle', 4), ['B', 'A'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
-        shapedRecipe(Item.of('quark:white_candle', 2), ['B', 'A', 'A'], {
-            A: '#forge:wax',
-            B: '#forge:string'
-        }),
         shapedRecipe(Item.of('byg:embur_hyphae', 3), ['AA', 'AA'], {
             A: 'byg:embur_pedu'
         }),

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/candle_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/enigmatica/candle_materials.js
@@ -1,0 +1,7 @@
+onEvent('item.tags', (event) => {
+    event
+        .get('enigmatica:candle_materials')
+        .add('minecraft:honeycomb')
+        .add('resourcefulbees:wax')
+        .add('occultism:tallow');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -20,7 +20,8 @@ onEvent('recipes', (event) => {
         { output: 'ars_nouveau:crystallizer', id: 'ars_nouveau:crystallizer' },
         { output: 'ars_nouveau:volcanic_accumulator', id: 'ars_nouveau:volcanic_accumulator' },
         { output: 'naturesaura:calling_spirit', id: 'naturesaura:calling_spirit' },
-        { output: 'naturesaura:animal_spawner', id: 'naturesaura:animal_spawner' }
+        { output: 'naturesaura:animal_spawner', id: 'naturesaura:animal_spawner' },
+        { output: 'botania:spark', id: 'botania:spark' }
     ];
 
     idRemovals.forEach((id) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -622,6 +622,27 @@ onEvent('recipes', (event) => {
                 D: 'alexsmobs:guster_eye'
             },
             id: 'astralsorcery:altar/grapple_wand'
+        },
+        {
+            output: 'botania:corporea_index',
+            pattern: ['ABA', 'BCB', 'DBD'],
+            key: {
+                A: 'atum:ectoplasm',
+                B: 'glassential:glass_ghostly',
+                C: 'botania:corporea_block',
+                D: 'occultism:spirit_attuned_gem'
+            },
+            id: 'botania:corporea_index'
+        },
+        {
+            output: 'botania:corporea_crystal_cube',
+            pattern: ['A', 'B', 'C'],
+            key: {
+                A: 'botania:corporea_spark',
+                B: 'glassential:glass_ghostly',
+                C: 'botania:corporea_block'
+            },
+            id: 'botania:corporea_crystal_cube'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shapeless.js
@@ -53,6 +53,30 @@ onEvent('recipes', (event) => {
                 'bloodmagic:weakbloodshard'
             ],
             id: 'bloodmagic:largebloodstonebrick'
+        },
+        {
+            output: Item.of('botania:red_string', 1),
+            inputs: ['minecraft:string', '#forge:storage_blocks/redstone', 'atum:ectoplasm'],
+            id: 'botania:red_string_alt'
+        },
+        {
+            output: Item.of('botania:corporea_spark', 1),
+            inputs: [
+                'botania:spark',
+                'atum:ectoplasm',
+                Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:nether' })
+            ],
+            id: 'botania:corporea_spark'
+        },
+        {
+            output: Item.of('botania:corporea_spark_master', 1),
+            inputs: ['botania:corporea_spark', '#atum:godshards'],
+            id: 'botania:corporea_spark_master'
+        },
+        {
+            output: Item.of('botania:corporea_block', 8),
+            inputs: ['naturesaura:infused_stone', 'botania:corporea_spark'],
+            id: 'botania:corporea_block'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -114,14 +114,14 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle',
-                    'buildersaddition:large_soul_candle'
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle',
+                    'quark:white_candle'
                 ],
                 reagent: 'bloodmagic:holy_water_anointment',
                 output: 'eidolon:candle',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/farmersdelight/cooking_pot.js
@@ -4,46 +4,12 @@ onEvent('recipes', (event) => {
     }
 
     var data = {
-        recipes: [
-            {
-                inputs: ['#forge:wax', '#forge:string'],
-                output: 'buildersaddition:large_candle',
-                count: 1,
-                cookingTime: 100,
-                id: 'buildersaddition:large_candle'
-            },
-            {
-                inputs: ['#forge:tallow', '#forge:string'],
-                output: 'buildersaddition:large_candle',
-                count: 1,
-                cookingTime: 100
-            },
-            {
-                inputs: ['minecraft:honeycomb', '#forge:string'],
-                output: 'buildersaddition:large_candle',
-                count: 1,
-                cookingTime: 100
-            },
-            {
-                inputs: ['minecraft:soul_sand', 'buildersaddition:large_candle'],
-                output: 'buildersaddition:large_soul_candle',
-                count: 1,
-                cookingTime: 100,
-                id: 'buildersaddition:large_soul_candle_soul_sand'
-            },
-            {
-                inputs: ['minecraft:soul_soil', 'buildersaddition:large_candle'],
-                output: 'buildersaddition:large_soul_candle',
-                count: 1,
-                cookingTime: 100,
-                id: 'buildersaddition:large_soul_candle_soul_soil'
-            }
-        ]
+        recipes: []
     };
 
     colors.forEach((color) => {
         data.recipes.push({
-            inputs: [`#forge:dyes/${color}`, 'buildersaddition:large_candle'],
+            inputs: [`#forge:dyes/${color}`, '#enigmatica:candle_materials', '#forge:string'],
             output: `quark:${color}_candle`,
             count: 1,
             cookingTime: 100,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -133,6 +133,18 @@ onEvent('recipes', (event) => {
                 empty_weight: 0,
                 rolls: 1
             }
+        },
+        {
+            inputs: [
+                { tag: 'botania:petals', count: 2 },
+                { item: 'botania:quartz_blaze', count: 2 },
+                { tag: 'forge:nuggets/nebu', count: 1 }
+            ],
+            output: {
+                entries: [{ result: { item: 'botania:spark', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            }
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/replace_input.js
@@ -3,9 +3,34 @@ onEvent('recipes', (event) => {
         return;
     }
 
-    event.replaceInput(
-        { id: 'compactmachines:personal_shrinking_device' },
-        'minecraft:book',
-        'shrink:shrinking_device'
-    );
+    const recipes = [
+        {
+            replaceTarget: { id: 'compactmachines:personal_shrinking_device' },
+            toReplace: 'minecraft:book',
+            replaceWith: 'shrink:shrinking_device'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.replaceInput(recipe.replaceTarget, recipe.toReplace, recipe.replaceWith);
+    });
+
+    const alt_material_tag_replacements = [
+        {
+            type: 'nuggets',
+            replace: 'gold',
+            replaceWith: 'silver',
+            items: ['botania:spark']
+        }
+    ];
+
+    alt_material_tag_replacements.forEach((recipe) => {
+        recipe.items.forEach((item) => {
+            event.replaceInput(
+                { output: item },
+                '#forge:' + recipe.type + '/' + recipe.replace,
+                '#forge:' + recipe.type + '/' + recipe.replace + '_' + recipe.replaceWith
+            );
+        });
+    });
 });


### PR DESCRIPTION

New Alternate Red String recipe. This makes redstring contraptions available a bit earlier than normal.

![image](https://user-images.githubusercontent.com/9543430/120949908-9dc26180-c713-11eb-9aa4-67dd731e73d7.png)

Livingrock still required for the blocks, so getting up to Nature's Aura to make will be the limiting factor.

Corporea is a very useful storage system early on (before things like RS beat it out) so I feel it's better to bring it up a bit considering how deep most Botania is. The following recipes bring it up to Nature's Aura level of magic as well as requiring some exploration of Atum

Revamp to Corporea recipes:
Base spark:
![image](https://user-images.githubusercontent.com/9543430/120952299-bbde9080-c718-11eb-8b1a-221d4bf00e5f.png)

Corporea Spark:
![image](https://user-images.githubusercontent.com/9543430/120952391-ec262f00-c718-11eb-87aa-7b10d456a8d1.png)

Master Corporea Spark requires a jaunt to Atum to get a god shard:
![image](https://user-images.githubusercontent.com/9543430/120952431-03fdb300-c719-11eb-9f01-d565082658f6.png)

Corporea Block makes use of Infused Rock, made through Nature's Aura.
![image](https://user-images.githubusercontent.com/9543430/120952697-930acb00-c719-11eb-9d3a-821d2fab5c42.png)

Corporea Index requires a bit of ectoplasm from Atum Wraiths
![image](https://user-images.githubusercontent.com/9543430/120952639-71a9df00-c719-11eb-9366-21b020a2b85f.png)

Corporea Crystal Cube:
![image](https://user-images.githubusercontent.com/9543430/120952799-bd5c8880-c719-11eb-9b7b-c58ea837e168.png)