### PR TITLE
Fix entangled-common.toml

### DIFF
--- a/config/entangled-common.toml
+++ b/config/entangled-common.toml
@@ -5,29 +5,13 @@
 	#Allowed Values: true, false  Default: true
 	renderBlockHighlight = true
 
-	[Client.Client]
-		#When looking at an Entangled Block, should its bound block be highlighted?
-		#Requires a world reload
-		#Allowed Values: true, false  Default: true
-		renderBlockHighlight = true
-
-	[Client.General]
-		#Can entangled blocks be bound between different dimensions? Previously bound entangled blocks won't be affected.
-		#Requires a world reload
-		#Allowed Values: true, false  Default: true
-		allowDimensional = false
-		#What is the max range in which entangled blocks can be bound? Only affects blocks in the same dimension. -1 for infinite range. Previously bound entangled blocks won't be affected.
-		#Requires a world reload
-		#Allowed Range: -1 ~ 2147483647  Default: -1
-		maxDistance = 1000
-
 [General]
 	#Can entangled blocks be bound between different dimensions? Previously bound entangled blocks won't be affected.
 	#Requires a world reload
 	#Allowed Values: true, false  Default: true
-	allowDimensional = true
+	allowDimensional = false
 	#What is the max range in which entangled blocks can be bound? Only affects blocks in the same dimension. -1 for infinite range. Previously bound entangled blocks won't be affected.
 	#Requires a world reload
 	#Allowed Range: -1 ~ 2147483647  Default: -1
-	maxDistance = -1
+	maxDistance = 1000
 


### PR DESCRIPTION
Seems the format for this config may have changed, and our adjusted settings (no interdimensional linking, 1000 block limit) is being overridden by extra entries added for the new format. Deleted the config, let it regenerate, and adjusted appropriately.