### PR TITLE
Fix Soupy Bee

### DIFF
--- a/config/resourcefulbees/bees/special/Soup.json
+++ b/config/resourcefulbees/bees/special/Soup.json
@@ -1,5 +1,5 @@
 {
-    "flower": "forge:mushrooms",
+    "flower": "tag:forge:mushrooms",
     "maxTimeInHive": 6000,
     "sizeModifier": 1,
     "hasHoneycomb": true,


### PR DESCRIPTION
I done goofed - "forge:mushrooms" is a tag, and needs to be labeled as such to function as their flower.