### PR TITLE
Set up Create Infinite Fluid blacklist

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/create/no_infinite_draining.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/fluids/create/no_infinite_draining.js
@@ -1,0 +1,33 @@
+onEvent('fluid.tags', (event) => {
+    event
+        .get('create:no_infinite_draining')
+        .add([
+            /tconstruct/,
+            /mekanism/,
+            /jaopca/,
+            /chorus/,
+            /essence/,
+            /meat/,
+            /slime/,
+            /bio/,
+            /diesel/,
+            /ethanol/,
+            /gasoline/,
+            /kerosene/,
+            /lpg/,
+            /lubricant/,
+            /plastic/,
+            /napalm/,
+            /potion/,
+            /creosote/,
+            /honey/,
+            /syrup/,
+            /tree_oil/,
+            /light_oil/,
+            /heavy_oil/,
+            /fuel/,
+            /plantoil/,
+            /vegetable_oil/,
+            /yeast/
+        ]);
+});


### PR DESCRIPTION
The goal here is to remove some of the more insane infinite fluids from the Create Hose Pump.

Things that remain:
Tree products that are already infinite such as menril, latex, resin, and sap.
Ether Gas because... well if you can make 10k buckets of that I guess you win.
Crude oil, but none of it's byproducts.
Sludge and sewage
LP (on the fence on this one, but pumping it has it's own issues to solve)

So this largely gets rid of all metals, and everything Mekanism related fluids, plus any other processed outputs.