### PR TITLE
Fix Bloody Bee Mutation

### DIFF
--- a/config/resourcefulbees/bees/magic/Bloody.json
+++ b/config/resourcefulbees/bees/magic/Bloody.json
@@ -20,8 +20,9 @@
         "mutations": [
             {
                 "type": "BLOCK",
+                "chance": 0.2,
                 "inputID": "minecraft:water",
-                "outputs": [{ "outputID": "bloodmagic:life_essence_fluid", "weight": 10 }]
+                "outputs": [{ "outputID": "bloodmagic:life_essence_block", "weight": 10 }]
             }
         ]
     },


### PR DESCRIPTION
Mutations work best when you actually use the block ID for the target instead of the fluid ID. Also reduced the mutation chance to 20% - average of 2 buckets per pollination seems more reasonable than 10 for-sure buckets.