### PR TITLE
Tinkers Metal Unification pass

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -146,6 +146,7 @@ onEvent('recipes', (event) => {
         'simplefarming:apple_pie',
         'simplefarming:blueberry_pie',
 
+        'thermal:compat/tconstruct/chiller_tconstruct_molten_debris_ingot',
         'thermal:machine/smelter/smelter_alloy_netherite',
         'thermal:machine/press/packing2x2/press_honeycomb_packing',
         'thermal:machine/refinery/refinery_crude_oil',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/chiller.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/chiller.js
@@ -1,18 +1,49 @@
 onEvent('recipes', (event) => {
-    const recipes = [
+    let recipes = [
         {
-            input: Fluid.of('integrateddynamics:menril_resin', 1000),
+            inputs: [Fluid.of('integrateddynamics:menril_resin', 1000)],
             output: Item.of('integrateddynamics:crystalized_menril_block', 1)
         },
         {
-            input: Fluid.of('integrateddynamics:liquid_chorus', 1000),
+            inputs: [Fluid.of('integrateddynamics:liquid_chorus', 1000)],
             output: Item.of('integrateddynamics:crystalized_chorus_block', 1)
+        },
+        {
+            inputs: [Fluid.of('tconstruct:molten_clay', 144), 'tconstruct:ingot_cast'],
+            output: Item.of('minecraft:brick', 1),
+            energy: 5000,
+            id: 'thermal:compat/tconstruct/chiller_tconstruct_clay_ingot'
+        },
+        {
+            inputs: [Fluid.of('tconstruct:molten_netherite', 144), 'tconstruct:ingot_cast'],
+            output: Item.of('minecraft:netherite_ingot', 1),
+            energy: 5000,
+            id: 'thermal:compat/tconstruct/chiller_tconstruct_netherite_ingot'
+        },
+        {
+            inputs: [Fluid.of('tconstruct:molten_debris', 144), 'tconstruct:ingot_cast'],
+            output: Item.of('minecraft:netherite_scrap', 1),
+            energy: 5000,
+            id: 'thermal:compat/tconstruct/chiller_tconstruct_molten_debris'
+        },
+        {
+            inputs: [Fluid.of('tconstruct:molten_netherite', 16), 'tconstruct:nugget_cast'],
+            output: Item.of('tconstruct:netherite_nugget', 1),
+            energy: 555,
+            id: 'thermal:compat/tconstruct/chiller_tconstruct_netherite_nugget'
+        },
+        {
+            inputs: [Fluid.of('tconstruct:molten_debris', 16), 'tconstruct:nugget_cast'],
+            output: Item.of('tconstruct:debris_nugget', 1),
+            energy: 555,
+            id: 'thermal:compat/tconstruct/chiller_tconstruct_debris_nugget'
         }
     ];
+
     honeyVarieties.forEach((honeyVariety) => {
         let honey = honeyVariety.split(':')[1];
         recipes.push({
-            input: Fluid.of(honeyVariety, 1000),
+            inputs: [Fluid.of(honeyVariety, 1000)],
             output: Item.of(
                 honeyVariety == 'resourcefulbees:honey' ? 'minecraft:honey_block' : `${honeyVariety}_block`
             ),
@@ -21,7 +52,10 @@ onEvent('recipes', (event) => {
     });
 
     recipes.forEach((recipe) => {
-        const re = event.recipes.thermal.chiller(recipe.output, recipe.input);
+        const re = event.recipes.thermal.chiller(recipe.output, recipe.inputs);
+        if (recipe.energy) {
+            re.energy(recipe.energy);
+        }
         if (recipe.id) {
             re.id(recipe.id);
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ingots.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ingots.js
@@ -46,4 +46,5 @@ onEvent('item.tags', (event) => {
     event.add('forge:ingots/sunmetal', ['architects_palette:sunmetal_brick']);
 
     event.add('forge:ingots/nether_brick', ['byg:blue_nether_brick', 'byg:yellow_nether_brick']);
+    event.get('forge:ingots/tinkers_bronze').add('tconstruct:tinkers_bronze_ingot');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/nuggets.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/nuggets.js
@@ -14,4 +14,5 @@ onEvent('item.tags', (event) => {
 
     event.get('forge:nuggets/thallasium').add('betterendforge:thallasium_nugget');
     event.get('forge:nuggets/terminite').add('betterendforge:terminite_nugget');
+    event.get('forge:nuggets/tinkers_bronze').add('tconstruct:tinkers_bronze_nugget');
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/ores.js
@@ -18,7 +18,7 @@ onEvent('item.tags', (event) => {
     ]);
 
     event.get('forge:ores/nether/gold').add('minecraft:nether_gold_ore');
-    event.get('forge:ores/netherite_scrap').remove('minecraft:ancient_debris');
+    //event.get('forge:ores/netherite_scrap').remove('minecraft:ancient_debris');
     event.get('forge:ores/netherite').add('minecraft:ancient_debris');
 
     event.add('forge:ores/ender', 'betterendforge:ender_ore');

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
@@ -38,4 +38,5 @@ onEvent('item.tags', (event) => {
     event.add(storageBlocks + '/amber', ['betterendforge:amber_block']);
 
     event.add(storageBlocks + '/sunmetal', ['architects_palette:sunmetal_block']);
+    event.add(storageBlocks + '/tinkers_bronze', ['tconstruct:tinkers_bronze_block']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/thermal/dies.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/thermal/dies.js
@@ -14,4 +14,5 @@ onEvent('item.tags', (event) => {
         event.add('thermal:crafting/dies', [`#thermal:crafting/dies/${dieName}`]);
         event.add(`thermal:crafting/dies/${dieName}`, [`immersiveengineering:mold_${dieName}`]);
     });
+    event.add('thermal:crafting/casts', ['#tconstruct:casts/multi_use']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -2,13 +2,20 @@
 onEvent('recipes', (event) => {
     materialsToUnify.forEach((material) => {
         var ore = getPreferredItemInTag(Ingredient.of('#forge:ores/' + material)).id;
+        var block = getPreferredItemInTag(Ingredient.of('#forge:storage_blocks/' + material)).id;
         var ingot = getPreferredItemInTag(Ingredient.of('#forge:ingots/' + material)).id;
+        var nugget = getPreferredItemInTag(Ingredient.of('#forge:nuggets/' + material)).id;
+
         var gem = getPreferredItemInTag(Ingredient.of('#forge:gems/' + material)).id;
         var chunk = getPreferredItemInTag(Ingredient.of('#forge:chunks/' + material)).id;
 
         var crushedOre = getPreferredItemInTag(Ingredient.of('#create:crushed_ores/' + material)).id;
         var dust = getPreferredItemInTag(Ingredient.of('#forge:dusts/' + material)).id;
         var shard = getPreferredItemInTag(Ingredient.of('#forge:shards/' + material)).id;
+
+        var gear = getPreferredItemInTag(Ingredient.of('#forge:gears/' + material)).id;
+        var rod = getPreferredItemInTag(Ingredient.of('#forge:rods/' + material)).id;
+        var plate = getPreferredItemInTag(Ingredient.of('#forge:plates/' + material)).id;
 
         astralsorcery_ore_processing_infuser(event, material, ore, ingot, gem, shard);
 
@@ -45,6 +52,11 @@ onEvent('recipes', (event) => {
         pedestals_ingot_gem_crushing(event, material, ingot, dust, gem);
 
         thermal_ore_pulverizing(event, material, ore, dust, gem, shard);
+        thermal_metal_casting(event, material, ingot, nugget, gear, rod, plate);
+        thermal_gem_casting(event, material, gem, gear, rod, plate);
+
+        tconstruct_metal_casting(event, material, block, ingot, nugget, gear, rod, plate);
+        tconstruct_gem_casting(event, material, block, gem, gear, rod, plate);
     });
 
     function astralsorcery_ore_processing_infuser(event, material, ore, ingot, gem, shard) {
@@ -1180,5 +1192,180 @@ onEvent('recipes', (event) => {
             type: 'thermal:pulverizer'
         });
         event.recipes.thermal.pulverizer(outputs, input).experience(experience);
+    }
+
+    function thermal_metal_casting(event, material, ingot, nugget, gear, rod, plate) {
+        if (!Fluid.exists(`tconstruct:molten_${material}`) || ingot == air) {
+            return;
+        }
+
+        let recipes = [{ type: 'ingot', amount: 144, output: ingot, energy: 5000 }];
+        if (nugget != air) {
+            recipes.push({ type: 'nugget', amount: 16, output: nugget, energy: 555 });
+        }
+        if (gear != air) {
+            recipes.push({ type: 'gear', amount: 576, output: gear, energy: 20000 });
+        }
+        if (rod != air) {
+            recipes.push({ type: 'rod', amount: 72, output: rod, energy: 2500 });
+        }
+        if (plate != air) {
+            recipes.push({ type: 'plate', amount: 144, output: plate, energy: 5000 });
+        }
+
+        recipes.forEach((recipe) => {
+            event.recipes.thermal
+                .chiller(recipe.output, [
+                    Fluid.of(`tconstruct:molten_${material}`, recipe.amount),
+                    `tconstruct:${recipe.type}_cast`
+                ])
+                .energy(recipe.energy)
+                .id(`thermal:compat/tconstruct/chiller_tconstruct_${material}_${recipe.type}`);
+        });
+    }
+
+    function thermal_gem_casting(event, material, gem, gear, rod, plate) {
+        if (!Fluid.exists(`tconstruct:molten_${material}`) || gem == air) {
+            return;
+        }
+
+        blacklistedMaterials = ['ender'];
+        for (var i = 0; i < blacklistedMaterials.length; i++) {
+            if (blacklistedMaterials[i] == material) {
+                return;
+            }
+        }
+
+        let recipes = [{ type: 'gem', amount: 144, output: gem, energy: 5000 }];
+
+        if (gear != air) {
+            recipes.push({ type: 'gear', amount: 576, output: gear, energy: 20000 });
+        }
+        if (rod != air) {
+            recipes.push({ type: 'rod', amount: 72, output: rod, energy: 2500 });
+        }
+        if (plate != air) {
+            recipes.push({ type: 'plate', amount: 144, output: plate, energy: 5000 });
+        }
+
+        recipes.forEach((recipe) => {
+            event.recipes.thermal
+                .chiller(recipe.output, [
+                    Fluid.of(`tconstruct:molten_${material}`, recipe.amount),
+                    `tconstruct:${recipe.type}_cast`
+                ])
+                .energy(recipe.energy)
+                .id(`thermal:compat/tconstruct/chiller_tconstruct_${material}_${recipe.type}`);
+        });
+    }
+
+    function tconstruct_metal_casting(event, material, block, ingot, nugget, gear, rod, plate) {
+        if (!Fluid.exists(`tconstruct:molten_${material}`) || ingot == air) {
+            return;
+        }
+
+        let recipes = [{ type: 'ingot', amount: 144, cooling: 57, output: ingot }];
+
+        if (nugget != air) {
+            recipes.push({ type: 'nugget', amount: 16, cooling: 19, output: nugget });
+        }
+        if (gear != air) {
+            recipes.push({ type: 'gear', amount: 576, cooling: 114, output: gear });
+        }
+        if (rod != air) {
+            recipes.push({ type: 'rod', amount: 72, cooling: 40, output: rod });
+        }
+        if (plate != air) {
+            recipes.push({ type: 'plate', amount: 144, cooling: 57, output: plate });
+        }
+
+        let casts = ['gold', 'sand'];
+        casts.forEach((cast) => {
+            recipes.forEach((recipe) => {
+                event
+                    .custom({
+                        type: 'tconstruct:casting_table',
+                        cast: {
+                            tag: `tconstruct:casts/${cast == 'sand' ? 'single_use' : 'multi_use'}/${recipe.type}`
+                        },
+                        cast_consumed: cast == 'sand' ? true : false,
+                        fluid: {
+                            name: `tconstruct:molten_${material}`,
+                            amount: recipe.amount
+                        },
+                        result: recipe.output,
+                        cooling_time: recipe.cooling
+                    })
+                    .id(`tconstruct:smeltery/casting/metal/${material}/${recipe.type}_${cast}_cast`);
+            });
+        });
+        event
+            .custom({
+                type: 'tconstruct:casting_basin',
+                fluid: {
+                    name: `tconstruct:molten_${material}`,
+                    amount: 1296
+                },
+                result: block,
+                cooling_time: 171
+            })
+            .id(`tconstruct:smeltery/casting/metal/${material}/block`);
+    }
+
+    function tconstruct_gem_casting(event, material, block, gem, gear, rod, plate) {
+        if (!Fluid.exists(`tconstruct:molten_${material}`) || gem == air) {
+            return;
+        }
+
+        blacklistedMaterials = ['ender'];
+        for (var i = 0; i < blacklistedMaterials.length; i++) {
+            if (blacklistedMaterials[i] == material) {
+                return;
+            }
+        }
+
+        let recipes = [{ type: 'gem', amount: 144, cooling: 64, output: gem }];
+
+        if (gear != air) {
+            recipes.push({ type: 'gear', amount: 576, cooling: 256, output: gear });
+        }
+        if (rod != air) {
+            recipes.push({ type: 'rod', amount: 72, cooling: 32, output: rod });
+        }
+        if (plate != air) {
+            recipes.push({ type: 'plate', amount: 144, cooling: 64, output: plate });
+        }
+
+        let casts = ['gold', 'sand'];
+        casts.forEach((cast) => {
+            recipes.forEach((recipe) => {
+                event
+                    .custom({
+                        type: 'tconstruct:casting_table',
+                        cast: {
+                            tag: `tconstruct:casts/${cast == 'sand' ? 'single_use' : 'multi_use'}/${recipe.type}`
+                        },
+                        cast_consumed: cast == 'sand' ? true : false,
+                        fluid: {
+                            name: `tconstruct:molten_${material}`,
+                            amount: recipe.amount
+                        },
+                        result: recipe.output,
+                        cooling_time: recipe.cooling
+                    })
+                    .id(`tconstruct:smeltery/casting/${material}/${recipe.type}_${cast}_cast`);
+            });
+        });
+        event
+            .custom({
+                type: 'tconstruct:casting_basin',
+                fluid: {
+                    name: `tconstruct:molten_${material}`,
+                    amount: 1296
+                },
+                result: block,
+                cooling_time: 193
+            })
+            .id(`tconstruct:smeltery/casting/${material}/block`);
     }
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/materials.js
@@ -56,7 +56,15 @@ const materialsToUnify = [
     'coal_coke',
     'starmetal',
     'amber',
-    'cobalt'
+    'cobalt',
+    'queens_slime',
+    'rose_gold',
+    'tinkers_bronze',
+    'knightslime',
+    'slimesteel',
+    'manyullyn',
+    'soulsteel',
+    'hepatizon'
 ];
 
 // Used to determine which material types to unify


### PR DESCRIPTION
re-add default forge tag to ancient debris. Not sure why this was removed, but it's breaking a lot of recipes now with it off. Ancient Debris processing probably needs a clean pass once Jaopca goes.

Add tinker's fluid handling to Unify script. Both for casting/basin as well as for Thermal Blast Chiller

Couple odd blast chiller recipes added as well to cover a few of the other materials. Would like to add some more here for things like ender pearls and slime. Low priority. maybe tomorrow