### PR TITLE
Add Tinkers Bees

### DIFF
--- a/config/resourcefulbees/bees/material/Enderslime.json
+++ b/config/resourcefulbees/bees/material/Enderslime.json
@@ -1,0 +1,60 @@
+{
+    "flower": "ALL",
+    "maxTimeInHive": 4800,
+    "sizeModifier": 1,
+    "hasHoneycomb": true,
+    "traits": ["slimy", "can_swim"],
+    "ColorData": {
+        "honeycombColor": "#C75EFF",
+        "primaryColor": "#C75EFF",
+        "secondaryColor": "#4D277A",
+        "isBeeColored": true,
+        "modelType": "GELATINOUS"
+    },
+    "CombatData": {
+        "isPassive": false,
+        "removeStingerOnAttack": false,
+        "inflictsPoison": true,
+        "attackDamage": 2
+    },
+    "MutationData": {
+        "hasMutation": true,
+        "mutations": [
+            {
+                "type": "BLOCK",
+                "inputID": "minecraft:honey_block",
+                "outputs": [{ "outputID": "tconstruct:ender_slime", "weight": 10 }]
+            }
+        ]
+    },
+    "CentrifugeData": {
+        "hasCentrifugeOutput": true,
+
+        "mainOutput": "tconstruct:ender_slime_ball",
+        "mainOutputWeight": 0.6,
+        "mainOutputCount": 4,
+
+        "secondaryOutput": "refinedstorage:processor_binding",
+        "secondaryOutputWeight": 0.02,
+        "secondaryOutputCount": 1,
+
+        "bottleOutput": "minecraft:honey_bottle",
+        "bottleOutputWeight": 0.25,
+        "bottleOutputCount": 1,
+
+        "mainInputCount": 1
+    },
+    "SpawnData": {
+        "canSpawnInWorld": false
+    },
+    "BreedData": {
+        "isBreedable": true,
+        "feedItem": "tag:forge:slime_block",
+        "feedAmount": 1,
+        "childGrowthDelay": -24000,
+        "breedDelay": 6000
+    },
+    "TraitData": {
+        "hasTraits": true
+    }
+}

--- a/config/resourcefulbees/bees/material/Ichor.json
+++ b/config/resourcefulbees/bees/material/Ichor.json
@@ -1,0 +1,60 @@
+{
+    "flower": "ALL",
+    "maxTimeInHive": 4800,
+    "sizeModifier": 1,
+    "hasHoneycomb": true,
+    "traits": ["slimy", "can_swim"],
+    "ColorData": {
+        "honeycombColor": "#FDAB69",
+        "primaryColor": "#FDAB69",
+        "secondaryColor": "#2B6C62",
+        "isBeeColored": true,
+        "modelType": "GELATINOUS"
+    },
+    "CombatData": {
+        "isPassive": false,
+        "removeStingerOnAttack": false,
+        "inflictsPoison": true,
+        "attackDamage": 2
+    },
+    "MutationData": {
+        "hasMutation": true,
+        "mutations": [
+            {
+                "type": "BLOCK",
+                "inputID": "minecraft:honey_block",
+                "outputs": [{ "outputID": "tconstruct:ichor_slime", "weight": 10 }]
+            }
+        ]
+    },
+    "CentrifugeData": {
+        "hasCentrifugeOutput": true,
+
+        "mainOutput": "tconstruct:ichor_slime_ball",
+        "mainOutputWeight": 0.6,
+        "mainOutputCount": 4,
+
+        "secondaryOutput": "refinedstorage:processor_binding",
+        "secondaryOutputWeight": 0.02,
+        "secondaryOutputCount": 1,
+
+        "bottleOutput": "minecraft:honey_bottle",
+        "bottleOutputWeight": 0.25,
+        "bottleOutputCount": 1,
+
+        "mainInputCount": 1
+    },
+    "SpawnData": {
+        "canSpawnInWorld": false
+    },
+    "BreedData": {
+        "isBreedable": true,
+        "feedItem": "tag:forge:slime_block",
+        "feedAmount": 1,
+        "childGrowthDelay": -24000,
+        "breedDelay": 6000
+    },
+    "TraitData": {
+        "hasTraits": true
+    }
+}

--- a/config/resourcefulbees/bees/material/Skyslime.json
+++ b/config/resourcefulbees/bees/material/Skyslime.json
@@ -1,0 +1,60 @@
+{
+    "flower": "ALL",
+    "maxTimeInHive": 4800,
+    "sizeModifier": 1,
+    "hasHoneycomb": true,
+    "traits": ["slimy", "can_swim"],
+    "ColorData": {
+        "honeycombColor": "#72CFCB",
+        "primaryColor": "#72CFCB",
+        "secondaryColor": "#2B6C62",
+        "isBeeColored": true,
+        "modelType": "GELATINOUS"
+    },
+    "CombatData": {
+        "isPassive": false,
+        "removeStingerOnAttack": false,
+        "inflictsPoison": true,
+        "attackDamage": 2
+    },
+    "MutationData": {
+        "hasMutation": true,
+        "mutations": [
+            {
+                "type": "BLOCK",
+                "inputID": "minecraft:honey_block",
+                "outputs": [{ "outputID": "tconstruct:sky_slime", "weight": 10 }]
+            }
+        ]
+    },
+    "CentrifugeData": {
+        "hasCentrifugeOutput": true,
+
+        "mainOutput": "tconstruct:sky_slime_ball",
+        "mainOutputWeight": 0.6,
+        "mainOutputCount": 4,
+
+        "secondaryOutput": "refinedstorage:processor_binding",
+        "secondaryOutputWeight": 0.02,
+        "secondaryOutputCount": 1,
+
+        "bottleOutput": "minecraft:honey_bottle",
+        "bottleOutputWeight": 0.25,
+        "bottleOutputCount": 1,
+
+        "mainInputCount": 1
+    },
+    "SpawnData": {
+        "canSpawnInWorld": false
+    },
+    "BreedData": {
+        "isBreedable": true,
+        "feedItem": "tag:forge:slime_block",
+        "feedAmount": 1,
+        "childGrowthDelay": -24000,
+        "breedDelay": 6000
+    },
+    "TraitData": {
+        "hasTraits": true
+    }
+}

--- a/config/resourcefulbees/bees/metal/Cobalt.json
+++ b/config/resourcefulbees/bees/metal/Cobalt.json
@@ -1,0 +1,60 @@
+{
+    "flower": "ALL",
+    "maxTimeInHive": 3600,
+    "sizeModifier": 1,
+    "hasHoneycomb": true,
+    "traits": ["can_swim"],
+    "ColorData": {
+        "honeycombColor": "#88CEFF",
+        "primaryColor": "#209EBD",
+        "secondaryColor": "#0C3E8A",
+        "isBeeColored": true,
+        "modelType": "ORE"
+    },
+    "CombatData": {
+        "isPassive": false,
+        "removeStingerOnAttack": false,
+        "inflictsPoison": true,
+        "attackDamage": 1
+    },
+    "MutationData": {
+        "hasMutation": true,
+        "mutations": [
+            {
+                "type": "BLOCK",
+                "inputID": "tag:forge:stone",
+                "outputs": [{ "outputID": "emendatusenigmatica:cobalt_ore", "weight": 10 }]
+            }
+        ]
+    },
+    "CentrifugeData": {
+        "hasCentrifugeOutput": true,
+
+        "mainOutput": "emendatusenigmatica:cobalt_chunk",
+        "mainOutputWeight": 0.5,
+        "mainOutputCount": 1,
+
+        "secondaryOutput": "minecraft:manyullyn_nugget",
+        "secondaryOutputWeight": 0.1,
+        "secondaryOutputCount": 3,
+
+        "bottleOutput": "minecraft:honey_bottle",
+        "bottleOutputWeight": 0.25,
+        "bottleOutputCount": 1,
+
+        "mainInputCount": 1
+    },
+    "SpawnData": {
+        "canSpawnInWorld": false
+    },
+    "BreedData": {
+        "isBreedable": true,
+        "feedItem": "tag:forge:storage_blocks/cobalt",
+        "feedAmount": 1,
+        "childGrowthDelay": -24000,
+        "breedDelay": 6000
+    },
+    "TraitData": {
+        "hasTraits": true
+    }
+}

--- a/config/resourcefulbees/bees/metal/Cobalt.json
+++ b/config/resourcefulbees/bees/metal/Cobalt.json
@@ -34,7 +34,7 @@
         "mainOutputWeight": 0.5,
         "mainOutputCount": 1,
 
-        "secondaryOutput": "minecraft:manyullyn_nugget",
+        "secondaryOutput": "tconstruct:manyullyn_nugget",
         "secondaryOutputWeight": 0.1,
         "secondaryOutputCount": 3,
 

--- a/config/resourcefulbees/bees/metal/Cobalt.json
+++ b/config/resourcefulbees/bees/metal/Cobalt.json
@@ -22,7 +22,7 @@
         "mutations": [
             {
                 "type": "BLOCK",
-                "inputID": "tag:forge:stone",
+                "inputID": "tag:forge:netherrack",
                 "outputs": [{ "outputID": "emendatusenigmatica:cobalt_ore", "weight": 10 }]
             }
         ]

--- a/config/resourcefulbees/resources/assets/resourcefulbees/lang/en_us.json
+++ b/config/resourcefulbees/resources/assets/resourcefulbees/lang/en_us.json
@@ -357,5 +357,25 @@
    "block.resourcefulbees.starry_honeycomb_block": "Starry Honeycomb Block",
    "item.resourcefulbees.starry_honeycomb": "Starry Honeycomb",
    "item.resourcefulbees.starry_bee_spawn_egg": "Starry Spawn Egg",
-   "entity.resourcefulbees.starry_bee": "Starry Bee"
+   "entity.resourcefulbees.starry_bee": "Starry Bee",
+   
+   "block.resourcefulbees.cobalt_honeycomb_block": "Cobalt Honeycomb Block",
+   "item.resourcefulbees.cobalt_honeycomb": "Cobalt Honeycomb",
+   "item.resourcefulbees.cobalt_bee_spawn_egg": "Cobalt Spawn Egg",
+   "entity.resourcefulbees.cobalt_bee": "Cobalt Bee",
+   
+   "block.resourcefulbees.skyslime_honeycomb_block": "Skyslime Honeycomb Block",
+   "item.resourcefulbees.skyslime_honeycomb": "Skyslime Honeycomb",
+   "item.resourcefulbees.skyslime_bee_spawn_egg": "Skyslime Spawn Egg",
+   "entity.resourcefulbees.skyslime_bee": "Skyslime Bee",
+   
+   "block.resourcefulbees.enderslime_honeycomb_block": "Enderslime Honeycomb Block",
+   "item.resourcefulbees.enderslime_honeycomb": "Enderslime Honeycomb",
+   "item.resourcefulbees.enderslime_bee_spawn_egg": "Enderslime Spawn Egg",
+   "entity.resourcefulbees.enderslime_bee": "Enderslime Bee",
+   
+   "block.resourcefulbees.ichor_honeycomb_block": "Ichor Honeycomb Block",
+   "item.resourcefulbees.ichor_honeycomb": "Ichor Honeycomb",
+   "item.resourcefulbees.ichor_bee_spawn_egg": "Ichor Spawn Egg",
+   "entity.resourcefulbees.ichor_bee": "Ichor Bee"
 }

--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -48,5 +48,20 @@
 
     "fluid.bloodmagic.life_essence_fluid": "Life Essence",
 
+    "fluid.kubejs.molten_cobalt_bee": "Molten Cobalt Bee",
+    "fluid.kubejs.molten_aluminum_bee": "Molten Aluminum Bee",
+    "fluid.kubejs.liquid_slimy_bee": "Liquid Slimy Bee",
+    "fluid.kubejs.liquid_skyslime_bee": "Liquid Skyslime Bee",
+    "fluid.kubejs.liquid_ichor_bee": "Liquid Ichor Bee",
+    "fluid.kubejs.liquid_enderslime_bee": "Liquid Enderslime Bee",
+
+    "item.kubejs.molten_cobalt_bee_bucket": "Molten Cobalt Bee Bucket",
+    "item.kubejs.molten_aluminum_bee_bucket": "Molten Aluminum Bee Bucket",
+    "item.kubejs.liquid_slimy_bee_bucket": "Liquid Slimy Bee Bucket",
+    "item.kubejs.liquid_skyslime_bee_bucket": "Liquid Skyslime Bee Bucket",
+    "item.kubejs.liquid_ichor_bee_bucket": "Liquid Ichor Bee Bucket",
+    "item.kubejs.liquid_enderslime_bee_bucket": "Liquid Enderslime Bee Bucket",
+
+
     "": ""
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/alloy.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/alloy.js
@@ -1,0 +1,84 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        {
+            inputs: [
+                {
+                    name: "kubejs:molten_aluminum_bee",
+                    amount: 500
+                },
+                {
+                    name: "resourcefulbees:lapis_honey",
+                    amount: 500
+                }
+            ],
+            result: {
+                fluid: "kubejs:molten_cobalt_bee",
+                amount: 500
+            },
+            temperature: 1400
+        },
+        {
+            inputs: [
+                {
+                    name: "kubejs:liquid_slimy_bee",
+                    amount: 500
+                },
+                {
+                    name: "tconstruct:sky_slime",
+                    amount: 500
+                }
+            ],
+            result: {
+                fluid: "kubejs:liquid_skyslime_bee",
+                amount: 500
+            },
+            temperature: 500
+        },
+        {
+            inputs: [
+                {
+                    name: "kubejs:liquid_slimy_bee",
+                    amount: 500
+                },
+                {
+                    name: "tconstruct:blood",
+                    amount: 500
+                }
+            ],
+            result: {
+                fluid: "kubejs:liquid_ichor_bee",
+                amount: 500
+            },
+            temperature: 500
+        },
+        {
+            inputs: [
+                {
+                    name: "kubejs:liquid_slimy_bee",
+                    amount: 500
+                },
+                {
+                    name: "tconstruct:ender_slime",
+                    amount: 500
+                }
+            ],
+            result: {
+                fluid: "kubejs:liquid_enderslime_bee",
+                amount: 500
+            },
+            temperature: 500
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'tconstruct:alloy',
+            inputs: recipe.inputs,
+            result: recipe.result,
+            temperature: recipe.temperature
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/casting_table.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/casting_table.js
@@ -1,0 +1,78 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        /*{
+            cast: {
+                tag: 'tconstruct:casts/single_use/gem'
+            },
+            cast_consumed: true,
+            fluid: {
+                name: 'kubejs:molten_cobalt_bee',
+                amount: 500
+            },
+            result: 'resourcefulbees:cobalt_bee_spawn_egg',
+            cooling_time: 600
+        }*/
+        {
+            cast: {
+                item: 'resourcefulbees:bee_jar'
+            },
+            cast_consumed: true,
+            fluid: {
+                name: 'kubejs:molten_cobalt_bee',
+                amount: 500
+            },
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:cobalt_bee", BeeType: "cobalt", Color: "#209EBD"}).toJson(),
+            cooling_time: 200
+        },
+        {
+            cast: {
+                item: 'resourcefulbees:bee_jar'
+            },
+            cast_consumed: true,
+            fluid: {
+                name: 'kubejs:liquid_skyslime_bee',
+                amount: 500
+            },
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:skyslime_bee", BeeType: "skyslime", Color: "#72CFCB"}).toJson(),
+            cooling_time: 100
+        },
+        {
+            cast: {
+                item: 'resourcefulbees:bee_jar'
+            },
+            cast_consumed: true,
+            fluid: {
+                name: 'kubejs:liquid_ichor_bee',
+                amount: 500
+            },
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:ichor_bee", BeeType: "ichor", Color: "#FDAB69"}).toJson(),
+            cooling_time: 100
+        },
+        {
+            cast: {
+                item: 'resourcefulbees:bee_jar'
+            },
+            cast_consumed: true,
+            fluid: {
+                name: 'kubejs:liquid_enderslime_bee',
+                amount: 500
+            },
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:enderslime_bee", BeeType: "enderslime", Color: "#C75EFF"}).toJson(),
+            cooling_time: 100
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'tconstruct:casting_table',
+            cast: recipe.cast,
+            cast_consumed: recipe.cast_consumed,
+            fluid: recipe.fluid,
+            result: recipe.result,
+            cooling_time: recipe.cooling_time
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/entity_melting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/entity_melting.js
@@ -1,0 +1,40 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        {
+            entity: {
+                types: [
+                    'resourcefulbees:aluminum_bee'
+                ]
+            },
+            result: {
+                fluid: 'kubejs:molten_aluminum_bee',
+                amount: 100
+            },
+            damage: 2
+        },
+        {
+            entity: {
+                types: [
+                    'resourcefulbees:slimy_bee'
+                ]
+            },
+            result: {
+                fluid: 'kubejs:liquid_slimy_bee',
+                amount: 100
+            },
+            damage: 2
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'tconstruct:entity_melting',
+            entity: recipe.entity,
+            result: recipe.result,
+            damage: recipe.damage
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/melting_fuel.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/melting_fuel.js
@@ -1,0 +1,24 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        {
+            fluid: {
+                name: "resourcefulbees:blaze_honey",
+                amount: 50
+            },
+            duration: 150,
+            temperature: 1500
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'tconstruct:melting_fuel',
+            fluid: recipe.fluid,
+            duration: recipe.duration,
+            temperature: recipe.temperature
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/startup_scripts/fluid_registry.js
+++ b/kubejs/startup_scripts/fluid_registry.js
@@ -1,0 +1,52 @@
+onEvent('fluid.registry', (event) => {
+    const generalFluids = [
+        {
+            type: 'thick',
+            id: 'molten_cobalt_bee',
+            texture: '0x209EBD',
+            display: 'Molten Cobalt Bee'
+        },
+        {
+            type: 'thick',
+            id: 'molten_aluminum_bee',
+            texture: '0xdce6f7',
+            display: 'Molten Aluminum Bee'
+        },
+        {
+            type: 'thin',
+            id: 'liquid_slimy_bee',
+            texture: '0x73c262',
+            display: 'Liquid Slimy Bee'
+        },
+        {
+            type: 'thin',
+            id: 'liquid_skyslime_bee',
+            texture: '0x72CFCB',
+            display: 'Liquid Skyslime Bee'
+        },
+        {
+            type: 'thin',
+            id: 'liquid_ichor_bee',
+            texture: '0xFDAB69',
+            display: 'Liquid Ichor Bee'
+        },
+        {
+            type: 'thin',
+            id: 'liquid_enderslime_bee',
+            texture: '0xC75EFF',
+            display: 'Liquid Enderslime Bee'
+        }
+    ];
+
+    generalFluids.forEach((fluid) => {
+        if (fluid.type == 'thick') {
+            event.create(fluid.id).textureThick(fluid.texture).bucketColor(fluid.texture); //.displayName(fluid.display);
+        }
+        else if (fluid.type == 'thin') {
+            event.create(fluid.id).textureThin(fluid.texture).bucketColor(fluid.texture); //.displayName(fluid.display);
+        }/*
+        else if (fluid.type == 'custom') {
+            event.create(fluid.id).displayName(fluid.display).textureStill(fluid.still).textureFlowing(fluid.flowing).bucketColor(fluid.color)
+        }*/
+    });
+});


### PR DESCRIPTION
Adds Blaze Honey as a valid smeltery fuel, equivalent to Molten Blaze.

<img width="509" alt="image" src="https://user-images.githubusercontent.com/13169307/121720973-b931c180-cab1-11eb-816f-7918bd3b6aec.png">

Adds Tinkers base material bees & related infrastructure. Use for bee combs is via standard centrifuge recipes. Crafting the bees is slightly more complicated - will start with melting a base bee, either Aluminum or Slimy, to a liquid:

<img width="565" alt="image" src="https://user-images.githubusercontent.com/13169307/121718957-c8fcd600-cab0-11eb-9a2b-69748a1fe0ca.png">

Relevant fluids are added to a new Fluid Registry file. These fluids are then alloyed with various things (Lapis Honey, Liquid Skyslime/Enderslime/Blood) to make a liquid for the downstream bee:

<img width="580" alt="image" src="https://user-images.githubusercontent.com/13169307/121719991-02354600-cab1-11eb-9a95-ad641bec6880.png">

This is then poured into a bee jar in the crafting table, resulting in a filled bee jar after cooling:

<img width="637" alt="image" src="https://user-images.githubusercontent.com/13169307/121720462-255ff580-cab1-11eb-9a97-f7fb96d48c8f.png">

There are a few bits of commented-out code here; one is an example in the casting_table.js file of what an actual craft using a cast would look like (this being a one-use sand cast). The second is in the fluid registry file - in theory we should be able to use .displayName() to set the in-game naming for the new fluids, but for whatever reason it doesn't seem to be working. I'm troubleshooting it with @MaxNeedsSnacks, but in the meantime using the en_us.json lang file is getting the job done so I've commented it out. Lastly, there is capacity to use custom textures (rather than a color) with the fluid registry system, so I've included that as a commented-out option we can enable later if we need to.