### PR TITLE
Fix server_files/start-server.sh

### DIFF
--- a/server_files/start-server.sh
+++ b/server_files/start-server.sh
@@ -26,7 +26,7 @@ if command -v wget >>/dev/null; then
 else
     if command -v curl >>/dev/null; then
         echo "DEBUG: (curl) Downloading ${URL}"
-        curl -o serverstarter-2.0.1.jar "${URL}"
+        curl -L -o serverstarter-2.0.1.jar "${URL}"
     else
         echo "Neither wget or curl were found on your system. Please install one and try again"
     fi

--- a/server_files/start-server.sh
+++ b/server_files/start-server.sh
@@ -7,30 +7,30 @@ if [[ $(cat server-setup-config.yaml | grep 'ramDisk:' | awk 'BEGIN {FS=":"}{pri
     sudo mount -t tmpfs -o size=2G tmpfs "$SAVE_DIR"
     DO_RAMDISK=1
 fi
-	if [ -f serverstarter-2.0.1.jar ]; then
-			echo "Skipping download. Using existing serverstarter-2.0.1.jar"
-         java -jar serverstarter-2.0.1.jar
-               if [[ $DO_RAMDISK -eq 1 ]]; then
-               sudo umount "$SAVE_DIR"
-               rm -rf "$SAVE_DIR"
-               mv "${SAVE_DIR}_backup" "$SAVE_DIR"
-               fi
-               exit 0
-	else
-			export URL="https://github.com/Yoosk/ServerStarter/releases/download/v2.0.1/serverstarter-2.0.1.jar"
-	fi
-		echo $URL
-		if ! command - v wget >> /dev/null; then
-			echo "DEBUG: (wget) Downloading ${URL}"
-			wget -O serverstarter-2.0.1.jar "${URL}"
-   else
-			if ! command - v curl >> /dev/null; then
-				echo "DEBUG: (curl) Downloading ${URL}"
-				curl -o serverstarter-2.0.1.jar "${URL}"
-			else
-				echo "Neither wget or curl were found on your system. Please install one and try again"
-         fi
-      fi
+if [ -f serverstarter-2.0.1.jar ]; then
+    echo "Skipping download. Using existing serverstarter-2.0.1.jar"
+    java -jar serverstarter-2.0.1.jar
+    if [[ $DO_RAMDISK -eq 1 ]]; then
+        sudo umount "$SAVE_DIR"
+        rm -rf "$SAVE_DIR"
+        mv "${SAVE_DIR}_backup" "$SAVE_DIR"
+    fi
+    exit 0
+else
+    export URL="https://github.com/Yoosk/ServerStarter/releases/download/v2.0.1/serverstarter-2.0.1.jar"
+fi
+echo $URL
+if ! command - v wget >> /dev/null; then
+    echo "DEBUG: (wget) Downloading ${URL}"
+    wget -O serverstarter-2.0.1.jar "${URL}"
+else
+    if ! command - v curl >> /dev/null; then
+        echo "DEBUG: (curl) Downloading ${URL}"
+        curl -o serverstarter-2.0.1.jar "${URL}"
+    else
+        echo "Neither wget or curl were found on your system. Please install one and try again"
+    fi
+fi
 java -jar serverstarter-2.0.1.jar
 if [[ $DO_RAMDISK -eq 1 ]]; then
     sudo umount "$SAVE_DIR"

--- a/server_files/start-server.sh
+++ b/server_files/start-server.sh
@@ -20,11 +20,11 @@ else
     export URL="https://github.com/Yoosk/ServerStarter/releases/download/v2.0.1/serverstarter-2.0.1.jar"
 fi
 echo $URL
-if ! command - v wget >> /dev/null; then
+if command -v wget >>/dev/null; then
     echo "DEBUG: (wget) Downloading ${URL}"
     wget -O serverstarter-2.0.1.jar "${URL}"
 else
-    if ! command - v curl >> /dev/null; then
+    if command -v curl >>/dev/null; then
         echo "DEBUG: (curl) Downloading ${URL}"
         curl -o serverstarter-2.0.1.jar "${URL}"
     else


### PR DESCRIPTION
I tried to run the server in a docker container that has `curl` but no `wget`, and it failed horribly.  This PR fixes it.

1. The script is unreadable due to random indentation.  Fix that.
2. The script attempts to detect the presence of `wget` and `curl`, using the bash `command` builtin, but does so incorrectly.
3. The script runs `curl` on a URL that returns a 302 redirect response, without the flag to follow redirects.

I kept each of these changes in separate commits for ease of review; feel free to squash-merge.

In bash, `command - v` (with an extra space) is not a thing.  Running it like that would always fail with a syntax error.  The `if !` treated that failure as expected, and the script would proceed to try using wget, regardless of whether wget is installed on the system.

Here's what it looks like when you run it directly:
```
$ command - v curl
bash: -: command not found
$ command -v curl
/usr/bin/curl
```

Here are the docs for the bash `command` builtin: https://www.gnu.org/software/bash/manual/bash.html#index-command

And here are the docs for curl's `-L` parameter to follow redirects: https://curl.se/docs/manpage.html#-L


There are other weird things about this script, like trying to append (unnecessarily) to `/dev/null`, and emitting an error message if neither `wget` nor `curl` are available, but then continuing anyway and possibly returning 0 (success).  But this PR is enough to get it working for me.

I also noticed the same problems in the `Create Together` modpack.  Should I submit a similar PR over there?