### PR TITLE
Restore #forge:netherbricks tag to nether bricks

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/netherbricks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/netherbricks.js
@@ -1,3 +1,3 @@
 onEvent('item.tags', (event) => {
-    event.add('forge:netherbricks', ['byg:blue_nether_bricks', 'byg:yellow_nether_bricks']);
+    event.add('forge:netherbricks', ['minecraft:nether_bricks', 'byg:blue_nether_bricks', 'byg:yellow_nether_bricks']);
 });


### PR DESCRIPTION
This may not be the right way to fix this as somewhere else it has lost its native tag but this looks good, is easy to find again and it works too.
Fixes #2432