### PR TITLE
[Performance] Set alwaysSetupTerrainOffThread to true

### DIFF
--- a/config/forge-client.toml
+++ b/config/forge-client.toml
@@ -8,7 +8,7 @@
 	#Enable Forge to queue all chunk updates to the Chunk Update thread.
 	#May increase FPS significantly, but may also cause weird rendering lag.
 	#Not recommended for computers without a significant number of cores available.
-	alwaysSetupTerrainOffThread = false
+	alwaysSetupTerrainOffThread = true
 	#EXPERIMENTAL: Enable the Forge block rendering pipeline - fixes the lighting of custom models.
 	experimentalForgeLightPipelineEnabled = true
 	#Enable the Forge block rendering pipeline - fixes the lighting of custom models.


### PR DESCRIPTION
Repeat PR because I messed up the first one.

Back in 1.12 foamfix would set this to true for you, but the pack doesn't have this on.

This actually helps my (low end, dual core) computer to cope with terrain loading, and doesn't seem to make anything behave oddly; just like the old times. It's always worked.