### PR TITLE
[Performance/Balance] Tweak ultimine config

### DIFF
--- a/config/ftbultimine.json5
+++ b/config/ftbultimine.json5
@@ -2,11 +2,11 @@
 	/* Max amount of blocks that can be ultimined at once
 	   Range: 1 - 32768
 	*/
-	"maxBlocks": 128,
+	"maxBlocks": 32,
 	/* Hunger multiplied for each block mined with ultimine
 	   Range: 0 - 10000
 	*/
-	"exhaustionPerBlock": 25.0,
+	"exhaustionPerBlock": 50.0,
 	// Groups stone types together so you can mine all of them at once
 	"mergeStone": false,
 	// Disable warnings for potentially laggy config settings


### PR DESCRIPTION
Changes ultimine to have a maximum of 32 blocks per operation. Why? Because moving the mouse around (or mining) with ultimine makes me lag badly, erm, as soon as it maps anything that isn't a vein. Reducing to 32 makes the stuttering disappear, and digging with it makes you look like you are creating a natural cave! 32 is more than enough for excavating, mining veins and felling non-massive trees.

As for the balance part, it simply makes it a little more expensive. I'd make it even more, but that would probably not appease everyone very much. I simply enjoy how the food expensive-fied veinminer on MC Eternal makes you ponder whether it is worth it to quick mine your veins or slow mine them depending on your food shortage conditions- here on E6 it's not even something that ever goes through my head. Whether to change the cost further is up to you, but the base increase in cost will remain in this PR.
