### PR TITLE
Repair BYG Biome Removals in Bees

### DIFF
--- a/config/resourcefulbees/bees/natural/Glowstone.json
+++ b/config/resourcefulbees/bees/natural/Glowstone.json
@@ -57,7 +57,7 @@
     "SpawnData": {
         "canSpawnInWorld": true,
         "spawnWeight": 10,
-        "biomeWhitelist": "byg:glowstone_gardens, byg:wailing_garth, byg:crimson_gardens",
+        "biomeWhitelist": "tag:NETHER",
         "biomeBlacklist": "tag:OVERWORLD,END",
         "minGroupSize": 2,
         "maxGroupSize": 3,

--- a/config/resourcefulbees/biome_dictionary/nether.json
+++ b/config/resourcefulbees/biome_dictionary/nether.json
@@ -4,17 +4,6 @@
         "minecraft:soul_sand_valley",
         "minecraft:crimson_forest",
         "minecraft:warped_forest",
-        "minecraft:basalt_deltas",
-        "byg:brimstone_caverns",
-        "byg:crimson_gardens",
-        "byg:embur_bog",
-        "byg:glowstone_gardens",
-        "byg:magma_wastes",
-        "byg:quartz_desert",
-        "byg:subzero_hypogeal",
-        "byg:sythian_torrids",
-        "byg:warped_desert",
-        "byg:weeping_mire",
-        "byg:withering_woods"
+        "minecraft:basalt_deltas"
     ]
 }


### PR DESCRIPTION
Change Glowstone Bee to spawn in Nether rather than specific biomes. Removed BYG biomes from nether.json. Resolves #2451.