### PR TITLE
Fix Skeleton.json

### DIFF
--- a/config/resourcefulbees/bees/natural/Skeleton.json
+++ b/config/resourcefulbees/bees/natural/Skeleton.json
@@ -58,7 +58,7 @@
     },
     "BreedData": {
         "isBreedable": true,
-        "feedItem": "tag:forge:bone_block",
+        "feedItem": "minecraft:bone_block",
         "feedAmount": 1,
         "childGrowthDelay": -24000,
         "breedDelay": 6000


### PR DESCRIPTION
Someone removes one tag and suddenly things stop working. Changed breeding material from "tag:forge:bone_block" to "minecraft:bone_block". Confirmed this actually works...

Fixes #2500.