### PR TITLE
[Expert] Alternate recipes for Eidolon ingredients to facilitate automation

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -212,6 +212,32 @@ onEvent('recipes', (event) => {
                 ticks: 200,
                 orbLevel: 3,
                 id: 'bloodmagic:arc/weakbloodshard'
+            },
+            {
+                inputs: [
+                    ['minecraft:crimson_roots', 'undergarden:blisterberry'],
+                    '#forge:crops/nether_wart',
+                    '#forge:dusts/sulfur'
+                ],
+                output: 'eidolon:crimson_essence',
+                count: 2,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
+            },
+            {
+                inputs: [
+                    'eidolon:zombie_heart',
+                    'minecraft:rotten_flesh',
+                    '#forge:dusts/charcoal',
+                    'projectvibrantjourneys:charred_bones',
+                    'undergarden:ink_mushroom'
+                ],
+                output: 'eidolon:death_essence',
+                count: 4,
+                syphon: 200,
+                ticks: 200,
+                orbLevel: 1
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
@@ -112,6 +112,27 @@ onEvent('recipes', (event) => {
                 minimumDrain: 0.0,
                 drain: 0.0,
                 id: 'bloodmagic:soulforge/sentientscythe'
+            },
+            {
+                inputs: [
+                    'atum:nuit_godshard',
+                    'eidolon:soul_shard',
+                    'astralsorcery:nocturnal_powder',
+                    'eidolon:death_essence'
+                ],
+                output: Item.of('eidolon:shadow_gem'),
+                minimumDrain: 100.0,
+                drain: 32.0
+            },
+            {
+                inputs: [
+                    ['#forge:ingots/regalium', '#forge:ingots/nebu'],
+                    'eidolon:soul_shard',
+                    'eidolon:crimson_essence'
+                ],
+                output: Item.of('eidolon:arcane_gold_ingot'),
+                minimumDrain: 32.0,
+                drain: 16.0
             }
         ]
     };


### PR DESCRIPTION
Alternate Recipes for a few Eidolon Crucible Recipes. These are meant to assist in later automation as the Crucible is... very challenging to automate.

Shadow Gem:
![image](https://user-images.githubusercontent.com/9543430/123144822-1c184680-d42a-11eb-9f94-6a6d716cf07a.png)

Refined Crimson:
![image](https://user-images.githubusercontent.com/9543430/123144965-4964f480-d42a-11eb-9447-3ba3da580d76.png)

Essence of Death:
![image](https://user-images.githubusercontent.com/9543430/123145008-541f8980-d42a-11eb-9196-1ff9fe7e0640.png)

Arcane Gold:
![image](https://user-images.githubusercontent.com/9543430/123145043-60a3e200-d42a-11eb-98e9-8cae480801de.png)