### PR TITLE
Implement mekanism_ingot_gem_crushing(),

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/crushing.js
@@ -1,10 +1,6 @@
 onEvent('recipes', (event) => {
     const recipes = [
         {
-            input: '#forge:gems/ender',
-            output: Item.of('emendatusenigmatica:ender_dust')
-        },
-        {
             input: 'byg:pink_sandstone',
             output: Item.of('byg:pink_sand', 2)
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -48,6 +48,7 @@ onEvent('recipes', (event) => {
         immersiveengineering_hammer_crushing(event, material, ore, dust);
         immersiveengineering_gem_crushing(event, material, dust, gem);
 
+        mekanism_ingot_gem_crushing(event, material, ingot, dust, gem);
         mekanism_metal_ore_processing(
             event,
             material,
@@ -625,6 +626,34 @@ onEvent('recipes', (event) => {
         event.recipes.immersiveengineering
             .crusher(primaryOutput, input, [Item.of(secondaryOutput).chance(secondaryChance)])
             .id(`immersiveengineering:crusher/ore_${material}`);
+    }
+
+    function mekanism_ingot_gem_crushing(event, material, ingot, dust, gem) {
+        if (dust == air) {
+            return;
+        }
+      
+        var input,
+            output = Item.of(dust, 1);
+        if (ingot != air) {
+            type = 'ingot';
+            input = `#forge:ingots/${material}`;
+        } else if (gem != air) {
+            input = `#forge:gems/${material}`;
+            type = 'gem';
+        } else {
+            return;
+        }
+
+        event.remove({
+            input: input,
+            mod: 'mekanism',
+            type: 'mekanism:crushing'
+        });
+
+        event.recipes.mekanism
+            .crushing(output, input)
+            .id(`mekanism:processing/${material}/to_dust`);
     }
 
     function mekanism_metal_ore_processing(

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_materials.js
@@ -243,7 +243,7 @@ onEvent('recipes', (event) => {
         }
 
         var input,
-            output = Item.of(dust, 1);
+            output = dust;
         if (ingot != air) {
             type = 'ingot';
             input = `#forge:ingots/${material}`;
@@ -634,7 +634,7 @@ onEvent('recipes', (event) => {
         }
       
         var input,
-            output = Item.of(dust, 1);
+            output = dust;
         if (ingot != air) {
             type = 'ingot';
             input = `#forge:ingots/${material}`;
@@ -1092,7 +1092,7 @@ onEvent('recipes', (event) => {
         }
 
         var input,
-            output = Item.of(dust, 1);
+            output = dust;
         if (ingot != air) {
             type = 'ingot';
             input = `#forge:ingots/${material}`;


### PR DESCRIPTION
- Implement mekanism_ingot_gem_crushing() to add missing Crusher recipes
- Standardizes mekanism crusher ingot/gem -> dust recipe id's as /to_dust
- Removes redundant ender dust recipe in [crushing.js](https://github.com/NillerMedDild/Enigmatica6/blob/develop/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/crushing.js) as a result of these changes