### PR TITLE
[Expert] Outlining progression via temp(ish) quests and more changes to progression

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -13,5 +13,548 @@
 	}
 	always_invisible: true
 	default_quest_shape: ""
-	quests: [ ]
+	quests: [
+		{
+			x: -0.5d
+			y: -5.0d
+			id: "72D589CE18202510"
+			tasks: [{
+				id: "46003D18E8B6E35F"
+				type: "item"
+				title: "Lightning"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "powah:charged_snowball"
+								Count: 1b
+							}
+							{
+								id: "thermal:lightning_charge"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+		}
+		{
+			x: -2.5d
+			y: -4.5d
+			dependencies: ["72D589CE18202510"]
+			id: "55B791C2720332C5"
+			tasks: [{
+				id: "606F700B17783FF9"
+				type: "item"
+				item: "minecraft:heart_of_the_sea"
+			}]
+		}
+		{
+			x: -0.5d
+			y: -3.5d
+			dependencies: ["55B791C2720332C5"]
+			id: "2A5E2A21BFECF76C"
+			tasks: [{
+				id: "0887A21EA010D9D6"
+				type: "item"
+				item: "minecraft:conduit"
+			}]
+		}
+		{
+			x: -2.5d
+			y: 0.0d
+			dependencies: ["0516126B238879F4"]
+			id: "1C17C09DD9AB58BD"
+			tasks: [{
+				id: "164A56C8CA322F09"
+				type: "item"
+				item: "eidolon:crucible"
+			}]
+		}
+		{
+			x: -0.5d
+			y: 0.5d
+			dependencies: [
+				"159492DF6B36BD22"
+				"2A5E2A21BFECF76C"
+			]
+			id: "0CA3D2BAD8F2B868"
+			tasks: [
+				{
+					id: "1BB8ED560E74D300"
+					type: "item"
+					item: "eidolon:worktable"
+				}
+				{
+					id: "1AA92C12098BE568"
+					type: "item"
+					item: "eidolon:unholy_symbol"
+				}
+			]
+		}
+		{
+			x: -0.5d
+			y: -0.75d
+			dependencies: [
+				"5AA38E6753FF4210"
+				"1C17C09DD9AB58BD"
+			]
+			id: "159492DF6B36BD22"
+			tasks: [
+				{
+					id: "44074CDF69D0BCA4"
+					type: "item"
+					item: "atum:scarab"
+				}
+				{
+					id: "708850EA380231C4"
+					type: "item"
+					item: "undergarden:catalyst"
+				}
+			]
+		}
+		{
+			x: -4.0d
+			y: 0.0d
+			id: "0516126B238879F4"
+			tasks: [{
+				id: "5DF04EAD9E35FFCE"
+				type: "item"
+				item: "eidolon:brazier"
+			}]
+		}
+		{
+			x: -2.5d
+			y: -1.5d
+			dependencies: ["4642C99F4B51005B"]
+			id: "5AA38E6753FF4210"
+			tasks: [
+				{
+					id: "638694418DEBB47D"
+					type: "item"
+					item: "betterendforge:silk_moth_nest"
+				}
+				{
+					id: "21E47A96FD36B37B"
+					type: "item"
+					item: "naturesaura:gold_fiber"
+				}
+			]
+		}
+		{
+			x: -2.5d
+			y: -3.0d
+			dependencies: ["2A5E2A21BFECF76C"]
+			id: "4642C99F4B51005B"
+			tasks: [
+				{
+					id: "6D272FF41C244D34"
+					type: "item"
+					item: "ars_nouveau:enchanting_apparatus"
+				}
+				{
+					id: "67FDDC3CABAFF8F2"
+					type: "item"
+					item: "ars_nouveau:arcane_pedestal"
+				}
+			]
+		}
+		{
+			x: 1.5d
+			y: 1.5d
+			dependencies: ["0CA3D2BAD8F2B868"]
+			id: "102775CD7F9CD338"
+			tasks: [{
+				id: "0F780C3F50CF951D"
+				type: "item"
+				item: "astralsorcery:altar_discovery"
+			}]
+		}
+		{
+			x: -0.5d
+			y: 3.0d
+			dependencies: [
+				"0CA3D2BAD8F2B868"
+				"06A20E7EA36392CB"
+			]
+			id: "331A6D1459DFCD86"
+			tasks: [{
+				id: "61705BD23EA4F985"
+				type: "item"
+				item: "bloodmagic:alchemytable"
+			}]
+		}
+		{
+			x: -2.5d
+			y: 1.5d
+			dependencies: [
+				"1C17C09DD9AB58BD"
+				"0CA3D2BAD8F2B868"
+			]
+			id: "06A20E7EA36392CB"
+			tasks: [
+				{
+					id: "6DBA42D76D507F3F"
+					type: "item"
+					item: "bloodmagic:altar"
+				}
+				{
+					id: "00FAE80C413DF107"
+					type: "item"
+					item: "bloodmagic:daggerofsacrifice"
+				}
+			]
+		}
+		{
+			x: -2.5d
+			y: 7.0d
+			dependencies: [
+				"635E552B5928C2B3"
+				"4280183EE48A8F1E"
+				"2E079C386DCED957"
+			]
+			id: "2ECA82ED72DA6D61"
+			tasks: [{
+				id: "63C152D3BAEB82B5"
+				type: "item"
+				item: "bloodmagic:soulforge"
+			}]
+		}
+		{
+			x: -1.5d
+			y: 4.5d
+			dependencies: ["331A6D1459DFCD86"]
+			id: "635E552B5928C2B3"
+			tasks: [{
+				id: "6D74AA77CE879BF9"
+				type: "item"
+				item: "occultism:chalk_white_impure"
+			}]
+		}
+		{
+			x: -0.5d
+			y: 4.5d
+			dependencies: ["331A6D1459DFCD86"]
+			id: "4280183EE48A8F1E"
+			tasks: [{
+				id: "1F25BF76B1B146A3"
+				type: "item"
+				item: "occultism:chalk_gold_impure"
+			}]
+		}
+		{
+			x: 0.5d
+			y: 4.5d
+			dependencies: ["331A6D1459DFCD86"]
+			id: "464450BE4AAE26B0"
+			tasks: [{
+				id: "309EF98B691BAC31"
+				type: "item"
+				item: "occultism:chalk_purple_impure"
+			}]
+		}
+		{
+			x: 1.5d
+			y: 4.5d
+			dependencies: ["331A6D1459DFCD86"]
+			id: "3DC9E0412A63646C"
+			tasks: [{
+				id: "1E2D0FDDE29B281D"
+				type: "item"
+				item: "occultism:chalk_red_impure"
+			}]
+		}
+		{
+			x: -2.5d
+			y: 4.5d
+			dependencies: ["1C17C09DD9AB58BD"]
+			id: "2E079C386DCED957"
+			tasks: [
+				{
+					id: "427776AD91737C88"
+					type: "item"
+					item: "occultism:golden_sacrificial_bowl"
+				}
+				{
+					id: "43A94D0505685C1B"
+					type: "item"
+					item: "occultism:spirit_attuned_crystal"
+				}
+			]
+		}
+		{
+			x: -4.0d
+			y: 2.5d
+			dependencies: ["06A20E7EA36392CB"]
+			id: "5BC50DE75421CAAA"
+			tasks: [
+				{
+					id: "7549201E699C5AE0"
+					type: "item"
+					item: "bloodmagic:blankrune"
+				}
+				{
+					id: "3832859FD741B2D0"
+					type: "item"
+					item: "bloodmagic:soulsnare"
+				}
+			]
+		}
+		{
+			x: -6.0d
+			y: 4.5d
+			dependencies: [
+				"2ECA82ED72DA6D61"
+				"5BC50DE75421CAAA"
+				"2422557696EB83F3"
+			]
+			id: "46221D2561D076D1"
+			tasks: [{
+				id: "1C77457254C258CC"
+				type: "item"
+				item: {
+					id: "bloodmagic:soulgempetty"
+					Count: 1b
+					tag: {
+						souls: 64.0d
+					}
+				}
+			}]
+		}
+		{
+			x: -6.0d
+			y: -0.5d
+			dependencies: ["598A3BD34A7DD40B"]
+			id: "2422557696EB83F3"
+			tasks: [{
+				id: "21F3F09A493EE8D1"
+				type: "item"
+				item: "naturesaura:nature_altar"
+			}]
+		}
+		{
+			x: -4.0d
+			y: -1.5d
+			dependencies: [
+				"5AA38E6753FF4210"
+				"566824DF05761A43"
+			]
+			id: "598A3BD34A7DD40B"
+			tasks: [{
+				id: "64DA833E05EAACEC"
+				type: "item"
+				item: "naturesaura:wood_stand"
+			}]
+		}
+		{
+			x: -6.0d
+			y: -3.0d
+			dependencies: ["4642C99F4B51005B"]
+			id: "295B7A0FB81D44DB"
+			tasks: [{
+				id: "3281C71438B7C50A"
+				type: "item"
+				item: "botania:apothecary_default"
+			}]
+		}
+		{
+			x: -6.0d
+			y: -2.0d
+			dependencies: ["295B7A0FB81D44DB"]
+			id: "566824DF05761A43"
+			tasks: [{
+				id: "7F1D294618FECED9"
+				type: "item"
+				item: "botania:pure_daisy"
+			}]
+		}
+		{
+			x: -6.0d
+			y: 8.5d
+			dependencies: ["2ECA82ED72DA6D61"]
+			id: "269C18852281A11E"
+			tasks: [{
+				id: "1721226282B4C95E"
+				type: "item"
+				item: {
+					id: "bloodmagic:soulgemcommon"
+					Count: 1b
+					tag: {
+						souls: 1024.0d
+					}
+				}
+			}]
+		}
+		{
+			x: -6.0d
+			y: 7.0d
+			dependencies: [
+				"2ECA82ED72DA6D61"
+				"2422557696EB83F3"
+			]
+			id: "6EECDEC09A67787E"
+			tasks: [{
+				id: "45448C65EE7C90B8"
+				type: "item"
+				item: {
+					id: "bloodmagic:soulgemlesser"
+					Count: 1b
+					tag: {
+						souls: 256.0d
+					}
+				}
+			}]
+		}
+		{
+			x: -6.0d
+			y: 10.0d
+			dependencies: ["2ECA82ED72DA6D61"]
+			id: "4C38CF2CADE34234"
+			tasks: [{
+				id: "70D6FF41B54F2CE2"
+				type: "item"
+				item: {
+					id: "bloodmagic:soulgemgreater"
+					Count: 1b
+					tag: {
+						souls: 4096.0d
+					}
+				}
+			}]
+		}
+		{
+			x: 1.0d
+			y: 8.5d
+			dependencies: ["7E400A70D25984AC"]
+			id: "3A27E020822D9C81"
+			tasks: [{
+				id: "5EFC72CCA95F4D0E"
+				type: "item"
+				item: {
+					id: "bloodmagic:soulsword"
+					Count: 1b
+					tag: {
+						Damage: 0
+					}
+				}
+			}]
+		}
+		{
+			x: 1.5d
+			y: 7.0d
+			dependencies: [
+				"635E552B5928C2B3"
+				"4280183EE48A8F1E"
+				"464450BE4AAE26B0"
+			]
+			id: "7E400A70D25984AC"
+			tasks: [{
+				id: "21343EEBBC66D220"
+				type: "item"
+				item: {
+					id: "occultism:infused_pickaxe"
+					Count: 1b
+					tag: {
+						spiritName: "Jarcraure"
+						Damage: 0
+					}
+				}
+			}]
+		}
+		{
+			x: -4.0d
+			y: 12.0d
+			dependencies: ["56015C7ABFB5BF44"]
+			id: "7F8A19BA987B1F85"
+			tasks: [{
+				id: "5880B6C8ACCBB841"
+				type: "item"
+				item: {
+					id: "occultism:iesnium_pickaxe"
+					Count: 1b
+					tag: {
+						Damage: 0
+					}
+				}
+			}]
+		}
+		{
+			x: 2.0d
+			y: 8.5d
+			dependencies: ["7E400A70D25984AC"]
+			id: "05D48014A63BEC6E"
+			tasks: [{
+				id: "04DF701DD4B0AECB"
+				type: "item"
+				item: {
+					id: "bloodmagic:soulpickaxe"
+					Count: 1b
+					tag: {
+						Damage: 0
+					}
+				}
+			}]
+		}
+		{
+			x: -8.0d
+			y: -1.5d
+			dependencies: [
+				"2422557696EB83F3"
+				"566824DF05761A43"
+			]
+			id: "181E9A83AED8515E"
+			tasks: [{
+				id: "1C14B299858B774A"
+				type: "item"
+				item: "botania:mana_pool"
+			}]
+		}
+		{
+			x: -8.0d
+			y: 0.5d
+			dependencies: [
+				"181E9A83AED8515E"
+				"2422557696EB83F3"
+			]
+			id: "7789F115E799ECBF"
+			tasks: [{
+				id: "34B74E5F079F3570"
+				type: "item"
+				item: "botania:manasteel_ingot"
+			}]
+		}
+		{
+			x: -5.0d
+			y: 11.0d
+			dependencies: ["4C38CF2CADE34234"]
+			id: "56015C7ABFB5BF44"
+			tasks: [{
+				id: "3A9BB6800431957B"
+				type: "item"
+				item: "bloodmagic:rawdemoncrystal"
+			}]
+		}
+		{
+			x: -0.5d
+			y: 7.0d
+			dependencies: [
+				"635E552B5928C2B3"
+				"4280183EE48A8F1E"
+			]
+			id: "120A5E18716B7033"
+			tasks: [{
+				id: "6A9B3739841C01EF"
+				type: "item"
+				item: {
+					id: "occultism:otherworld_goggles"
+					Count: 1b
+					tag: {
+						Damage: 0
+					}
+				}
+			}]
+		}
+	]
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
@@ -25,11 +25,6 @@ onEvent('recipes', (event) => {
             replaceWith: Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:nether' })
         },
         {
-            filter: { id: 'occultism:crafting/iesnium_pickaxe' },
-            toReplace: '#forge:rods/wooden',
-            replaceWith: 'betterendforge:leather_wrapped_stick'
-        },
-        {
             filter: { id: 'atum:scarab_from_crunchy_scarab' },
             toReplace: '#forge:ingots/gold',
             replaceWith: '#forge:nuggets/nebu'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -713,6 +713,15 @@ onEvent('recipes', (event) => {
                 C: '#forge:gems/mana'
             },
             id: 'eidolon:basic_belt'
+        },
+        {
+            output: 'eidolon:crucible',
+            pattern: ['A A', 'ABA', 'AAA'],
+            key: {
+                A: '#forge:ingots/pewter',
+                B: 'minecraft:conduit'
+            },
+            id: 'eidolon:crucible'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/array.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/array.js
@@ -26,6 +26,12 @@ onEvent('recipes', (event) => {
                 output: 'bloodmagic:arcaneashes',
                 texture: 'sunarray',
                 id: 'bloodmagic:array/day'
+            },
+            {
+                inputs: ['ars_nouveau:ritual_scrying', 'bloodmagic:blankslate'],
+                output: 'bloodmagic:divinationsigil',
+                texture: 'divinationsigil',
+                id: 'bloodmagic:array/divinationsigil'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
@@ -133,6 +133,13 @@ onEvent('recipes', (event) => {
                 output: Item.of('eidolon:arcane_gold_ingot'),
                 minimumDrain: 32.0,
                 drain: 16.0
+            },
+            {
+                inputs: ['bloodmagic:rawdemoncrystal', 'bloodmagic:soulpickaxe', '#forge:storage_blocks/iesnium'],
+                output: Item.of('occultism:iesnium_pickaxe'),
+                minimumDrain: 4000.0,
+                drain: 2048.0,
+                id: 'occultism:crafting/iesnium_pickaxe'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -10,7 +10,7 @@ onEvent('recipes', (event) => {
                 { tag: 'botania:petals/white' },
                 { tag: 'botania:petals/white' },
                 { tag: 'botania:petals/white' },
-                { tag: 'forge:dusts/fluorite' },
+                { item: 'minecraft:conduit' },
                 { item: 'thermal:phytogro' }
             ],
             output: { item: 'botania:pure_daisy' },
@@ -22,7 +22,8 @@ onEvent('recipes', (event) => {
                 { tag: 'botania:petals/brown' },
                 { tag: 'botania:petals/red' },
                 { tag: 'botania:petals/light_gray' },
-                { item: 'naturesaura:crimson_aura_mushroom' },
+                { tag: 'botania:runes/fire' },
+                { tag: 'botania:runes/air' },
                 { item: 'thermal:phytogro' }
             ],
             output: { item: 'botania:endoflame' },
@@ -85,6 +86,19 @@ onEvent('recipes', (event) => {
             ],
             output: { item: 'mythicbotany:aquapanthus' },
             id: 'mythicbotany:petal_apothecary/aquapanthus'
+        },
+        {
+            inputs: [
+                { tag: 'botania:petals/light_gray' },
+                { tag: 'botania:petals/light_gray' },
+                { tag: 'botania:petals/yellow' },
+                { tag: 'botania:petals/yellow' },
+                { tag: 'botania:petals/red' },
+                { item: 'undergarden:masticator_scales' },
+                { item: 'thermal:phytogro' }
+            ],
+            output: { item: 'botania:gourmaryllis' },
+            id: 'botania:petal_apothecary/gourmaryllis'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
@@ -53,6 +53,12 @@ onEvent('recipes', (event) => {
                 entity: 'ars_nouveau:wilden_stalker',
                 aura: 150000,
                 time: 120
+            },
+            {
+                inputs: ['naturesaura:token_anger', 'eidolon:shadow_gem', '#forge:ingots/forgotten_metal'],
+                entity: 'undergarden:masticator',
+                aura: 500000,
+                time: 200
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/animal_spawner.js
@@ -6,64 +6,102 @@ onEvent('recipes', (event) => {
     var data = {
         recipes: [
             {
-                inputs: ['quark:bottled_cloud', 'resourcefulbees:sand_honeycomb', 'minecraft:sand'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    'quark:bottled_cloud',
+                    'resourcefulbees:sand_honeycomb',
+                    'minecraft:sand'
+                ],
                 entity: 'alexsmobs:guster',
                 aura: 150000,
                 time: 120
             },
             {
-                inputs: ['#forge:dusts/fluorite', 'resourcefulbees:electrum_honeycomb', 'powah:charged_snowball'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    '#forge:dusts/fluorite',
+                    'resourcefulbees:electrum_honeycomb',
+                    'powah:charged_snowball'
+                ],
                 entity: 'thermal:blitz',
                 aura: 150000,
                 time: 120
             },
             {
-                inputs: ['#forge:dusts/lapis', 'resourcefulbees:icy_honeycomb', 'minecraft:blue_ice'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    '#forge:dusts/lapis',
+                    'resourcefulbees:icy_honeycomb',
+                    'minecraft:blue_ice'
+                ],
                 entity: 'thermal:blizz',
                 aura: 150000,
                 time: 120
             },
             {
-                inputs: ['#forge:dusts/apatite', 'resourcefulbees:rocky_honeycomb', 'minecraft:basalt'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    '#forge:dusts/apatite',
+                    'resourcefulbees:rocky_honeycomb',
+                    'minecraft:basalt'
+                ],
                 entity: 'thermal:basalz',
                 aura: 150000,
                 time: 120
             },
             {
-                inputs: ['#forge:dusts/sulfur', 'resourcefulbees:coal_honeycomb', 'minecraft:nether_bricks'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    '#forge:dusts/sulfur',
+                    'resourcefulbees:coal_honeycomb',
+                    'minecraft:nether_bricks'
+                ],
                 entity: 'minecraft:blaze',
                 aura: 150000,
                 time: 120,
                 id: 'naturesaura:animal_spawner/blaze'
             },
             {
-                inputs: ['resourcefulbees:bloody_honeycomb', 'minecraft:blue_ice'],
+                inputs: ['naturesaura:birth_spirit', 'resourcefulbees:bloody_honeycomb', 'minecraft:blue_ice'],
                 entity: 'ars_nouveau:wilden_guardian',
                 aura: 250000,
                 time: 120
             },
             {
-                inputs: ['resourcefulbees:bloody_honeycomb', 'valhelsia_structures:bone_pile'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    'resourcefulbees:bloody_honeycomb',
+                    'valhelsia_structures:bone_pile'
+                ],
                 entity: 'ars_nouveau:wilden_hunter',
                 aura: 150000,
                 time: 120
             },
             {
-                inputs: ['resourcefulbees:bloody_honeycomb', 'astralsorcery:nocturnal_powder'],
+                inputs: [
+                    'naturesaura:birth_spirit',
+                    'resourcefulbees:bloody_honeycomb',
+                    'astralsorcery:nocturnal_powder'
+                ],
                 entity: 'ars_nouveau:wilden_stalker',
                 aura: 150000,
                 time: 120
             },
             {
-                inputs: ['naturesaura:token_anger', 'eidolon:shadow_gem', '#forge:ingots/forgotten_metal'],
+                inputs: [
+                    'farmersdelight:honey_glazed_ham_block',
+                    'naturesaura:token_anger',
+                    'eidolon:shadow_gem',
+                    '#forge:ingots/forgotten_metal'
+                ],
                 entity: 'undergarden:masticator',
-                aura: 500000,
+                aura: 5000000,
                 time: 200
             }
         ]
     };
     data.recipes.forEach((recipe) => {
-        let ingredients = [Ingredient.of('naturesaura:birth_spirit').toJson()];
+        let ingredients = [];
 
         recipe.inputs.forEach((input) => {
             ingredients.push(Ingredient.of(input).toJson());


### PR DESCRIPTION
Change flower progression for Botania:

First flower likely to be gourmaryllis, requiring materials from Undergarden. Could technically make a hydroangea if the player is truly hard pressed to find masticator scales. Starting off with a good generator is going to be relevant considering the increased cost of runes, however. This cost trend may apply to other mana crafts too...
![image](https://user-images.githubusercontent.com/9543430/123193284-7a691780-d472-11eb-96cd-62d6de758d79.png)

Endoflames now require runes to make:
![image](https://user-images.githubusercontent.com/9543430/123193359-a84e5c00-d472-11eb-9235-287cc526e868.png)

Small change to pure daisy, now uses conduit as most starting magic crafting methods do.
![image](https://user-images.githubusercontent.com/9543430/123193389-b8663b80-d472-11eb-9d53-3511de128375.png)

Same for the Crucible:
![image](https://user-images.githubusercontent.com/9543430/123196630-40027900-d478-11eb-85bf-6852ba790195.png)

Divination Sigil:
![image](https://user-images.githubusercontent.com/9543430/123195660-8e167d00-d476-11eb-9102-b706e313ec17.png)

Iesnium Pickaxe changed again, bearing in mind that the sentient pick also mines iesnium and is available earlier.
![image](https://user-images.githubusercontent.com/9543430/123195693-9a023f00-d476-11eb-98cc-ba637bb79e64.png)

Rough outline of progression created in hidden quest chapter.  Does not cover the entire progression yet, but it gives a good basis to start from. Will work on expanding this as a reference for further progression work and testing. Ultimately it will be pruned down to just a high level 'guide' for the player.