### PR TITLE
Update Tinker's Anvil description and allowed blocks

### DIFF
--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -34,7 +34,7 @@ onEvent('item.tooltip', (event) => {
         },
         {
             items: ['tconstruct:scorched_anvil', 'tconstruct:tinkers_anvil'],
-            text: [Text.of('Craftable with almost any metal block.').gold()]
+            text: [Text.of('Craftable with any alloy blocks.').gold()]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
@@ -21,7 +21,9 @@ onEvent('item.tags', (event) => {
         'betterendforge:ender_block',
         'betterendforge:aurora_crystal',
         'betterendforge:amber_block',
-        'betterendforge:thallasium_block'
+        'betterendforge:thallasium_block',
+        'powah:energized_steel_block',
+        'mythicbotany:alfsteel_block'
     ]);
 
     event.get(storageBlocks + '/glowstone').add('minecraft:glowstone');
@@ -39,4 +41,6 @@ onEvent('item.tags', (event) => {
 
     event.add(storageBlocks + '/sunmetal', ['architects_palette:sunmetal_block']);
     event.add(storageBlocks + '/tinkers_bronze', ['tconstruct:tinkers_bronze_block']);
+    event.add(storageBlocks + '/energized_steel', ['powah:energized_steel_block']);
+    event.add(storageBlocks + '/alfsteel', ['mythicbotany:alfsteel_block']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/tconstruct/anvil_metal.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/tconstruct/anvil_metal.js
@@ -1,0 +1,16 @@
+onEvent('item.tags', (event) => {
+    let anvil_blocks = [
+        '#forge:storage_blocks/refined_obsidian',
+        '#forge:storage_blocks/refined_glowstone',
+        '#forge:storage_blocks/alfsteel',
+        '#forge:storage_blocks/energized_steel',
+        '#forge:storage_blocks/enderium',
+        '#forge:storage_blocks/lumium',
+        '#forge:storage_blocks/signalum',
+        '#forge:storage_blocks/arcane_gold',
+        '#forge:storage_blocks/terminite',
+        '#forge:storage_blocks/aeternium',
+        '#forge:storage_blocks/terrasteel'
+    ];
+    event.add('tconstruct:anvil_metal', anvil_blocks);
+});


### PR DESCRIPTION
Resolves #2521

Changes the tooltip to specify all alloy blocks may be used. Expands the `tconstruct:anvil_metal` tag to include all other alloys in the pack.