### PR TITLE
Mekanism Fusion Fuel Production Buff

### DIFF
--- a/config/Mekanism/general.toml
+++ b/config/Mekanism/general.toml
@@ -36,7 +36,7 @@
 		#Heat capacity of Thermal Evaporation Tower layers (increases amount of energy needed to increase temperature).
 		heatCapacity = 100.0
 		#Temperature to amount produced ratio for Thermal Evaporation Tower.
-		tempMultiplier = 0.4
+		tempMultiplier = 0.8
 		#Thermal Evaporation Tower heat loss per tick.
 		heatDissipation = 0.02
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/chemical_infusing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/chemical_infusing.js
@@ -1,0 +1,22 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        {
+            output: ['mekanismgenerators:fusion_fuel', 2],
+            leftInput: ['mekanismgenerators:deuterium', 1],
+            rightInput: ['mekanismgenerators:tritium', 1],
+            id: 'mekanismgenerators:chemical_infusing/fusion_fuel'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'mekanism:chemical_infusing',
+            leftInput: { amount: recipe.leftInput[1], gas: recipe.leftInput[0] },
+            rightInput: { amount: recipe.rightInput[1], gas: recipe.rightInput[0] },
+            output: { gas: recipe.output[0], amount: recipe.output[1] }
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});


### PR DESCRIPTION
Increase D-T Fuel to 2mb for every 1mb of Deuterium and 1mb of Tritium
Increase production rate for Evap towers.

With these changes, max fusion now only requires 3 Evap towers, which should be significant for servers. Two for Brine and one for Lithium.

Looked into potentially increasing the processing speed of pumps, but couldn't find any way of tweaking those.

Resolves #2525