### PR TITLE
[Worldgen] Bigger Beaches

### DIFF
--- a/config/terraforged/presets/Enigmatica.json
+++ b/config/terraforged/presets/Enigmatica.json
@@ -548,8 +548,8 @@
       "deepOcean": 0.056,
       "shallowOcean": 0.115,
       "beach": 0.246,
-      "coast": 0.328,
-      "inland": 0.365
+      "coast": 0.435,
+      "inland": 0.474
     },
     "properties": {
       "spawnType": "CONTINENT_CENTER",

--- a/config/terraforged/presets/Enigmatica.json
+++ b/config/terraforged/presets/Enigmatica.json
@@ -547,7 +547,7 @@
     "controlPoints": {
       "deepOcean": 0.056,
       "shallowOcean": 0.115,
-      "beach": 0.246,
+      "beach": 0.300,
       "coast": 0.435,
       "inland": 0.474
     },


### PR DESCRIPTION
**Part of the worldgen changes patch series. Individual features are separate PRs to allow each one to be discussed separately.**

**What this do?**
Make more big beach on average. You get less of this on the coast (they still exist):
![2021-06-25_11 12 31](https://user-images.githubusercontent.com/57966308/123439513-34ae6b00-d5a8-11eb-80b9-6dd96cf2c2ad.png)
And more of this:
![2021-06-25_11 23 27](https://user-images.githubusercontent.com/57966308/123440864-a0dd9e80-d5a9-11eb-9455-0d311f87d2f3.png)
Looks like there's even sunlight rays from above. But that was just an astral sorcery flare.

This increases coastal terrain % and beach terrain %. The bigger beaches and coastal terrain may make new scenarios (eg. not inland terrain) more accessible for building.

**Questions you may ask**
"Wouldn't this cause ugly chunk borders?"
No, changing the preset file does not seem to affect existing worlds at all. Old worlds will not get these changes, but old worlds will still suffer biome border weirdness due to biome mod changes in 0.5.0.