### PR TITLE
[Worldgen] Spawn player at world center by default

### DIFF
--- a/config/terraforged/presets/Enigmatica.json
+++ b/config/terraforged/presets/Enigmatica.json
@@ -552,7 +552,7 @@
       "inland": 0.365
     },
     "properties": {
-      "spawnType": "CONTINENT_CENTER",
+      "spawnType": "WORLD_CENTER",
       "worldHeight": 256,
       "seaLevel": 58
     }


### PR DESCRIPTION
**Part of the worldgen changes patch series. Individual features are separate PRs to allow each one to be discussed separately.**

**What this do?**
Makes players spawn close to the world center on new worlds. This is actually less superficial than you might think.
Mostly because after generating a dozen worlds and spawning I started noticing that there wasn't a lot of terrain variation. As it turned out, it's just because of the whole center of continent thing. It makes it so when you spawn you are always going to see:
* River beds
* Inland terrain

By setting the spawn to world center we make sure that spawning on beaches and coastal areas, or transitions between are still possible. Oceans have been a big thing on the Minecraft scene for a while so it makes sense to not always have a new world be so deep inland, and increases variability betwen worlds.

**Questions you may ask**
"Wouldn't this cause ugly chunk borders?"
No, changing the preset file does not seem to affect existing worlds at all. Old worlds will not get these changes, but old worlds will still suffer biome border weirdness due to biome mod changes in 0.5.0.

"Wouldn't this cause players to spawn in the ocean sometimes?"
No, if the world center is submerged you will be spawned at the nearest beach, even if it is thousands of blocks away. This will be the world spawn.