### PR TITLE
Set up tags for Occultism Books to allow automation via RS

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/occultism/book_of_binding.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/occultism/book_of_binding.js
@@ -1,0 +1,8 @@
+onEvent('item.tags', (event) => {
+    event.get('occultism:book_of_binding_bound').add([/book_of_binding_bound/]);
+
+    event.get('occultism:book_of_binding_bound/foliot').add('occultism:book_of_binding_bound_foliot');
+    event.get('occultism:book_of_binding_bound/djinni').add('occultism:book_of_binding_bound_djinni');
+    event.get('occultism:book_of_binding_bound/afrit').add('occultism:book_of_binding_bound_afrit');
+    event.get('occultism:book_of_binding_bound/marid').add('occultism:book_of_binding_bound_marid');
+});


### PR DESCRIPTION
Since these books all end up with different nbt, RS gets confused. Tags simply create a way for RS to recognize what are identical items with differing flavor text.