### PR TITLE
Fix Curing Rubber take sulfur gems when most recipes produce sulfur dust

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -64,7 +64,10 @@ onEvent('recipes', (event) => {
 
         'astralsorcery:infuser/gold_ore',
 
+        'betterendforge:gunpowder_from_sulphur',
+
         'bloodmagic:smelting/ingot_netherite_scrap',
+        'bloodmagic:alchemytable/gunpowder',
 
         'botania:fertilizer_dye',
 
@@ -174,6 +177,8 @@ onEvent('recipes', (event) => {
         'thermal:signalum_dust_4',
         'thermal:rubber_3',
         'thermal:smelting/cured_rubber_from_smelting',
+        'thermal:storage/sulfur_block',
+        'thermal:gunpowder_4',
 
         'powah:crafting/energy_cell_basic_2',
         'powah:crafting/cable_basic',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -14,7 +14,7 @@ onEvent('recipes', (event) => {
     event.replaceInput({}, 'mythicbotany:elementium_ore', '#forge:ores/elementium');
     event.replaceInput({}, 'thermal:rubber', 'industrialforegoing:dryrubber');
     event.replaceInput({}, 'thermal:cinnabar', '#forge:gems/cinnabar');
-    event.replaceInput({}, 'thermal:sulfur', '#forge:gems/sulfur');
+    event.replaceInput({}, 'thermal:sulfur', '#forge:dust/sulfur');
     event.replaceInput({}, 'thermal:apatite', '#forge:gems/apatite');
     event.replaceInput({}, 'thermal:niter', '#forge:gems/niter');
     event.replaceInput({}, 'thermal:bitumen', '#forge:gems/bitumen', true);

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -14,7 +14,7 @@ onEvent('recipes', (event) => {
     event.replaceInput({}, 'mythicbotany:elementium_ore', '#forge:ores/elementium');
     event.replaceInput({}, 'thermal:rubber', 'industrialforegoing:dryrubber');
     event.replaceInput({}, 'thermal:cinnabar', '#forge:gems/cinnabar');
-    event.replaceInput({}, 'thermal:sulfur', '#forge:dust/sulfur');
+    event.replaceInput({}, 'thermal:sulfur', '#forge:gems/sulfur');
     event.replaceInput({}, 'thermal:apatite', '#forge:gems/apatite');
     event.replaceInput({}, 'thermal:niter', '#forge:gems/niter');
     event.replaceInput({}, 'thermal:bitumen', '#forge:gems/bitumen', true);

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
@@ -198,7 +198,7 @@ onEvent('recipes', (event) => {
                 orbLevel: 1
             },
             {
-                inputs: ['#forge:gems/sulfur', 'industrialforegoing:dryrubber', 'industrialforegoing:dryrubber'],
+                inputs: ['#forge:dusts/sulfur', 'industrialforegoing:dryrubber', 'industrialforegoing:dryrubber'],
                 output: 'thermal:cured_rubber',
                 count: 2,
                 syphon: 400,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/induction_smelter.js
@@ -78,7 +78,7 @@ onEvent('recipes', (event) => {
                 outputs: [Item.of('minecraft:quartz'), Item.of('thermal:slag')]
             },
             {
-                inputs: [Item.of('industrialforegoing:dryrubber', 2), '#forge:gems/sulfur'],
+                inputs: [Item.of('industrialforegoing:dryrubber', 2), '#forge:dusts/sulfur'],
                 outputs: [Item.of('thermal:cured_rubber', 2)],
                 id: 'thermal:machine/smelter/smelter_cured_rubber'
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/thermal/machine/pulverizer.js
@@ -125,7 +125,17 @@ onEvent('recipes', (event) => {
                 input: 'minecraft:sugar_cane',
                 outputs: [Item.of('minecraft:sugar', 2), Item.of('minecraft:sugar').chance(0.1)],
                 experience: 0.1
-            }
+            },
+            {
+                input: '#forge:rods/blaze',
+                outputs: [
+                  Item.of('minecraft:blaze_powder', 3),
+                  Item.of('emendatusenigmatica:sulfur_dust').chance(0.25)
+                ],
+                id: 'thermal:machine/pulverizer/pulverizer_blaze_rod',
+                experience: 0.2
+            },
+
         ]
     };
 


### PR DESCRIPTION
Most recipes for pulverizers create sulfur dust as a secondary output (except blaze rods) but curing requires sulfur gem.

Therefore this PR change curing to use sulfur dust (both in induction smelter and blood altar).

This PR also makes it so the only recipes that create sulfur gems are the ore processings or Sulfur Gems (secondary outputs being dust) (and 2 recipes from the induction smelter using slag, but induction smelter creating dust doesn't fit for me?)
