### PR TITLE
Increase shapeless crafting yield of Pewter to 2 for 2 dusts input.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shapeless.js
@@ -542,7 +542,7 @@ onEvent('recipes', (event) => {
             id: 'mythicbotany:wither_aconite_floating'
         },
         {
-            output: 'eidolon:pewter_blend',
+            output: Item.of('eidolon:pewter_blend', 2),
             inputs: ['#forge:dusts/lead', '#forge:dusts/iron'],
             id: 'eidolon:pewter_blend'
         },


### PR DESCRIPTION
Alloy crafting gives 2 ingots for 1 lead and 1 iron. Shapeless dust crafting was only giving 1 pewter dust. Increased to 2 to match.