### PR TITLE
Add Bee Recipes to MythBot Mana Infuser

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mythicbotany_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/mythicbotany_infusion.js
@@ -1,23 +1,10 @@
+//todo remove in 0.6.0
+//moved to expert/recipetypes/mythicbotany/infusion.js
 onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
-    const recipes = [
-        {
-            inputs: ['resourcefulbees:mana_bee_spawn_egg'],
-            output: 'resourcefulbees:terrestrial_bee_spawn_egg',
-            mana: 2000000,
-            fromColor: 16711821,
-            toColor: 16750080
-        },
-        {
-            inputs: ['resourcefulbees:terrestrial_honeycomb', 'botania:mana_pearl', 'botania:mana_diamond'],
-            output: 'botania:terrasteel_ingot',
-            mana: 300000,
-            fromColor: 255,
-            toColor: 65280
-        }
-    ];
+    const recipes = [];
 
     recipes.forEach((recipe) => {
         const re = event.custom({

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
@@ -4,8 +4,21 @@ onEvent('recipes', (event) => {
     }
     const recipes = [
         {
-            inputs: ['resourcefulbees:terrestrial_honeycomb', 'botania:mana_pearl', 'botania:mana_diamond'],
-            output: 'botania:terrasteel_ingot',
+            inputs: [{ item: 'resourcefulbees:mana_bee_spawn_egg' }],
+            output: {
+                item: 'resourcefulbees:terrestrial_bee_spawn_egg'
+            },
+            mana: 2000000
+        },
+        {
+            inputs: [
+                { item: 'resourcefulbees:terrestrial_honeycomb' },
+                { item: 'botania:mana_pearl' },
+                { item: 'botania:mana_diamond' }
+            ],
+            output: {
+                item: 'botania:terrasteel_ingot'
+            },
             mana: 300000
         }
     ];

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -1,0 +1,59 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    const recipes = [
+        {
+            inputs: [
+                { item: 'resourcefulbees:mana_bee_spawn_egg' }
+            ],
+            output: {
+                item: 'resourcefulbees:terrestrial_bee_spawn_egg'
+            },
+            mana: 2000000,
+            fromColor: 255,
+            toColor: 65280
+        },
+        {
+            inputs: [
+                { item: 'resourcefulbees:terrestrial_honeycomb' },
+                { item: 'botania:mana_pearl' },
+                { item: 'botania:mana_diamond' }
+            ],
+            output: {
+                item: 'botania:terrasteel_ingot'
+            },
+            mana: 300000,
+            fromColor: 255,
+            toColor: 65280
+        },
+        {
+            inputs: [
+                { item: 'resourcefulbees:elven_honeycomb' },
+                { tag: 'forge:gems/dragonstone' },
+                { item: 'botania:pixie_dust' }
+            ],
+            output: {
+                item: 'mythicbotany:alfsteel_ingot'
+            },
+            mana: 1500000,
+            fromColor: 16711821,
+            toColor: 16750080
+        }
+];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'mythicbotany:infusion',
+            group: 'infuser',
+            ingredients: recipe.inputs,
+            output: recipe.output,
+            mana: recipe.mana,
+            fromColor: recipe.fromColor,
+            toColor: recipe.toColor
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
@@ -1,0 +1,59 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+    const recipes = [
+        {
+            inputs: [
+                { item: 'resourcefulbees:mana_bee_spawn_egg' }
+            ],
+            output: {
+                item: 'resourcefulbees:terrestrial_bee_spawn_egg'
+            },
+            mana: 2000000,
+            fromColor: 255,
+            toColor: 65280
+        },
+        {
+            inputs: [
+                { item: 'resourcefulbees:terrestrial_honeycomb' },
+                { item: 'botania:mana_pearl' },
+                { item: 'botania:mana_diamond' }
+            ],
+            output: {
+                item: 'botania:terrasteel_ingot'
+            },
+            mana: 300000,
+            fromColor: 255,
+            toColor: 65280
+        },
+        {
+            inputs: [
+                { item: 'resourcefulbees:elven_honeycomb' },
+                { tag: 'forge:gems/dragonstone' },
+                { item: 'botania:pixie_dust' }
+            ],
+            output: {
+                item: 'mythicbotany:alfsteel_ingot'
+            },
+            mana: 1500000,
+            fromColor: 16711821,
+            toColor: 16750080
+        }
+];
+
+    recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'mythicbotany:infusion',
+            group: 'infuser',
+            ingredients: recipe.inputs,
+            output: recipe.output,
+            mana: recipe.mana,
+            fromColor: recipe.fromColor,
+            toColor: recipe.toColor
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});


### PR DESCRIPTION
Recipes for Terrestrial spawn eggs and using Terrestrial combs were missing from the Mana Infuser - added them. Also restructured things a bit - there are separate folders for Normal/Expert, with MythBot in its own folder rather than with Botania. Left file in expert/recipetypes/botania for removal in 0.6.0. Fixes #2595.