### PR TITLE
Refactor shaped.js - Normal

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/shaped.js
@@ -1,3 +1,4 @@
+//todo remove in 0.6.0
 /*onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipes/shaped.js
@@ -1,4 +1,5 @@
-onEvent('recipes', (event) => {
+//todo remove in 0.6.0
+/* onEvent('recipes', (event) => {
     if (global.isNormalMode == false) {
         return;
     }
@@ -130,3 +131,4 @@ onEvent('recipes', (event) => {
         }
     });
 });
+*/

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/shaped.js
@@ -1,0 +1,26 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: 'botania:gaia_pylon',
+            pattern: [' D ', 'EPE', ' D '],
+            key: {
+                P: 'botania:mana_pylon',
+                D: 'botania:pixie_dust',
+                E: '#forge:ingots/elementium'
+            },
+            id: 'mythicbotany:modified_gaia_pylon_with_alfsteel'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/compactcrafting/shaped.js
@@ -1,0 +1,38 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('compactmachines:tunnel', { definition: { id: 'compactmachines:item' } }),
+            pattern: ['ABA', 'BCB', 'DBD'],
+            key: {
+                A: 'minecraft:hopper',
+                B: '#forge:gems/dimensional',
+                C: 'occultism:wormhole_frame',
+                D: '#forge:chests'
+            },
+            id: 'compactmachines:tunnel/item'
+        },
+        {
+            output: Item.of('compactmachines:tunnel', { definition: { id: 'compactmachines:redstone_in' } }),
+            pattern: ['ABA', 'BCB', 'DBD'],
+            key: {
+                A: 'glassential:glass_redstone',
+                B: '#forge:gems/dimensional',
+                C: 'occultism:wormhole_frame',
+                D: 'minecraft:redstone_torch'
+            },
+            id: 'compactmachines:tunnel/redstone'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/eidolon/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/eidolon/shaped.js
@@ -1,0 +1,24 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('eidolon:candle', 4),
+            pattern: ['B', 'A'],
+            key: {
+                A: '#forge:wax',
+                B: '#forge:string'
+            }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/minecraft/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/minecraft/shaped.js
@@ -1,0 +1,30 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: 'minecraft:furnace',
+            pattern: ['LLL', 'L L', 'LLL'],
+            key: {
+                L: '#forge:stone'
+            }
+        },
+        {
+            output: Item.of('minecraft:stick', 16),
+            pattern: ['A', 'A'],
+            key: {
+                A: '#minecraft:logs'
+            }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/shaped.js
@@ -1,0 +1,26 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: 'mythicbotany:alfsteel_pylon',
+            pattern: [' n ', 'npn', ' g '],
+            key: {
+                n: 'mythicbotany:alfsteel_nugget',
+                g: 'minecraft:ghast_tear',
+                p: 'botania:gaia_pylon'
+            },
+            id: 'mythicbotany:alfsteel_pylon'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/shaped.js
@@ -1,0 +1,24 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('occultism:candle_white'),
+            pattern: [' B ', 'AAA', 'AAA'],
+            key: {
+                A: '#forge:wax',
+                B: '#forge:string'
+            }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/prettypipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/prettypipes/shaped.js
@@ -1,0 +1,33 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('prettypipes:pipe', 12),
+            pattern: ['ABA'],
+            key: {
+                A: '#forge:ingots/tin',
+                B: '#forge:glass/colorless'
+            }
+        },
+        {
+            output: Item.of('ppfluids:fluid_pipe', 12),
+            pattern: [' C ', 'ABA', ' C '],
+            key: {
+                A: '#forge:ingots/tin',
+                B: '#forge:glass/colorless',
+                C: 'thermal:cured_rubber'
+            }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/quark/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/quark/shaped.js
@@ -1,0 +1,24 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('quark:white_candle', 2),
+            pattern: ['B', 'A', 'A'],
+            key: {
+                A: '#forge:wax',
+                B: '#forge:string'
+            }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});


### PR DESCRIPTION
Move all shaped.js recipes to mod-specific files in their normal/recipetypes folders.

Leaving a commented-out shaped.js in normal/recipes both to prevent pack upgrade issues & in case I somehow missed a recipe.

Added "//todo remove in 0.6.0" to the top of both expert & normal recipes/shaped.js.