### PR TITLE
Cleanup curios inventory

### DIFF
--- a/defaultconfigs/curios-server.toml
+++ b/defaultconfigs/curios-server.toml
@@ -54,3 +54,13 @@
   identifier = "feet"
   override = false
   hasCosmetic = true
+
+[[curiosSettings]]
+  identifier = "bracelet"
+  override = true
+  size = 0
+
+[[curiosSettings]]
+  identifier = "glasses"
+  override = true
+  size = 0

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/bracelet.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/bracelet.js
@@ -1,0 +1,10 @@
+onEvent('item.tags', (event) => {
+    event.remove('curios:bracelet', [
+        'atum:relic_silver_bracelet',
+        'atum:relic_gold_bracelet',
+        'atum:relic_sapphire_bracelet',
+        'atum:relic_ruby_bracelet',
+        'atum:relic_emerald_bracelet',
+        'atum:relic_diamond_bracelet'
+    ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/glasses.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/glasses.js
@@ -1,0 +1,5 @@
+onEvent('item.tags', (event) => {
+    event.remove('curios:glasses', [
+        'advancedperipherals:ar_goggles'
+    ]);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/goggles.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/goggles.js
@@ -2,6 +2,7 @@ onEvent('item.tags', (event) => {
     event.add('curios:createplus.goggle_slot', [
         'artifacts:night_vision_goggles',
         'botania:cosmetic_engineer_goggles',
-        'botania:monocle'
+        'botania:monocle',
+        'advancedperipherals:ar_goggles'
     ]);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/hands.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/curios/hands.js
@@ -1,0 +1,5 @@
+onEvent('item.tags', (event) => {
+    event.add('curios:hands', [
+        '#atum:relic_non_dirty/bracelet'
+    ]);
+});


### PR DESCRIPTION
This PR removes the glasses & bracelet slots from the curios menu:
* The AR glasses from Advanced Peripherals now use the goggles slot instead
* The bracelets from Atum now use the hands slot (they're tagged as vanity but they don't even show up on the player model, so these definitely don't need their own slot)