### PR TITLE
Updates to Sawing and Crushing - Expanding Occultism, Create, and Immersive Engineering capabilities

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/crushing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/crushing.js
@@ -18,13 +18,25 @@ onEvent('recipes', (event) => {
             input: { tag: 'forge:grain' },
             output: 'create:wheat_flour',
             count: 1,
-            time: 400
+            time: 50
         },
         {
             input: { item: 'minecraft:sugar_cane' },
             output: 'minecraft:sugar',
             count: 2,
+            time: 50
+        },
+        {
+            input: { tag: 'forge:ores/netherite' },
+            output: 'minecraft:netherite_scrap',
+            count: 1,
             time: 400
+        },
+        {
+            input: { tag: 'minecraft:logs' },
+            output: 'emendatusenigmatica:wood_dust',
+            count: 4,
+            time: 100
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_dyes.js
@@ -10,6 +10,7 @@ onEvent('recipes', (event) => {
         thermal_dye_centrifuge(event, recipe);
         atum_quern_milling(event, recipe);
         shapeless_dye_crafting(event, recipe);
+        occultism_dye_crushing(event, recipe);
     });
 });
 
@@ -194,4 +195,26 @@ function shapeless_dye_crafting(event, recipe) {
         inputs = [recipe.input];
 
     event.shapeless(output, inputs);
+}
+function occultism_dye_crushing(event, recipe) {
+    if (recipe.input == 'minecraft:bone') {
+        return;
+    }
+
+    var baseCount = 2,
+        multiplier = 1;
+    if (recipe.type == 'large') {
+        multiplier = 2;
+    }
+
+    var count = baseCount * multiplier,
+        output = recipe.primary,
+        input = recipe.input;
+
+    event.custom({
+        type: 'occultism:crushing',
+        ingredient: { item: input },
+        result: { item: output, count: count },
+        crushing_time: 50
+    });
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_sawables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_sawables.js
@@ -1,17 +1,18 @@
 //priority: 900
 onEvent('recipes', (event) => {
     buildWoodVariants.forEach((variant) => {
-        var sawDust = 'emendatusenigmatica:wood_dust';
+        var sawDust = 'emendatusenigmatica:wood_dust',
+            treeBark = 'farmersdelight:tree_bark';
 
-        create_cutting(event, variant);
-        immersiveengineering_sawing(event, variant, sawDust);
+        create_cutting(event, variant, sawDust, treeBark);
+        immersiveengineering_sawing(event, variant, sawDust, treeBark);
         mekanism_sawing(event, variant, sawDust);
         pedestal_sawing(event, variant);
         thermal_sawing(event, variant, sawDust);
     });
 });
 
-function create_cutting(event, variant) {
+function create_cutting(event, variant, sawDust, treeBark) {
     var modID = variant.logBlock.split(':')[0];
 
     // mod blacklist
@@ -29,25 +30,29 @@ function create_cutting(event, variant) {
             {
                 input: variant.logBlock,
                 output: variant.logBlockStripped,
+                secondaryOutput: treeBark,
                 count: 1,
                 time: 50
             },
             {
                 input: variant.woodBlock,
                 output: variant.woodBlockStripped,
+                secondaryOutput: treeBark,
                 count: 1,
                 time: 50
             },
             {
                 input: variant.logBlockStripped,
                 output: variant.plankBlock,
-                count: 5,
+                secondaryOutput: sawDust,
+                count: 6,
                 time: 100
             },
             {
                 input: variant.woodBlockStripped,
                 output: variant.plankBlock,
-                count: 5,
+                secondaryOutput: sawDust,
+                count: 6,
                 time: 100
             }
         ]
@@ -65,6 +70,10 @@ function create_cutting(event, variant) {
                 {
                     item: recipe.output,
                     count: recipe.count
+                },
+                {
+                    item: recipe.secondaryOutput,
+                    count: 1
                 }
             ],
             processingTime: recipe.time
@@ -72,7 +81,7 @@ function create_cutting(event, variant) {
     });
 }
 
-function immersiveengineering_sawing(event, variant, sawDust) {
+function immersiveengineering_sawing(event, variant, sawDust, treeBark) {
     // mod blacklist
     if (variant.modId == 'minecraft') {
         return;
@@ -94,7 +103,7 @@ function immersiveengineering_sawing(event, variant, sawDust) {
             [
                 {
                     stripping: true,
-                    output: sawDust
+                    output: treeBark
                 },
                 {
                     stripping: false,


### PR DESCRIPTION
Adds dye crushing to Occultism crusher. Starts at 2x, goes up to 6x output with the top tier spirit.

Adds Ancient Debris crushing to Occultism. Starts at 1x, goes up to 3x with top tier spirit.

Reduced time for crushing wheat and sugar. They were as slow as obsidian :D

Adds a way to get saw dust from the crusher, pulverizing logs.

Increase plank output from Create saw from 5 to 6 to be in line with other sawing methods. Added sawdust as a secondary output.

Adds tree bark as an output from IE and Create sawing of non stripped logs.