### PR TITLE
Blacklist tinker's construct from supplementaries wall lantern support

### DIFF
--- a/config/ftbquests/quests/chapters/immersive_engineering.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering.snbt
@@ -479,8 +479,8 @@
 		{
 			title: "Arc Furnace"
 			icon: "immersiveengineering:storage_steel"
-			x: -7.0d
-			y: -0.5d
+			x: -6.5d
+			y: 0.0d
 			description: [
 				"The Arc Furnace is a large, power-intensive machine that can smelt ores into ingots at a 1:2 ratio, but can also be used to quickly make alloys."
 				""
@@ -854,8 +854,8 @@
 		{
 			title: "Excavator"
 			icon: "minecraft:gold_ore"
-			x: -7.0d
-			y: 0.5d
+			x: -6.5d
+			y: 1.0d
 			description: [
 				"Once you've determined an appropriate spot to excavate, you can build this machine there. Be warned that the Excavator requires a rather hefty amount of energy to run."
 				""
@@ -927,7 +927,11 @@
 			icon: "immersiveengineering:sample_drill"
 			x: -5.5d
 			y: 0.5d
-			description: ["As described in the \"Minerals\" section of the manual, certain IE machines can detect and mine massive veins of otherwise unobtainable ore. The first step toward this is to use Survey Tools and a Core Sample Drill to find what veins are in a chunk."]
+			description: [
+				"As described in the \"Minerals\" section of the manual, certain IE machines can detect and mine massive veins of otherwise unobtainable ore. The first step toward this is to use Survey Tools and a Core Sample Drill to find what veins are in a chunk."
+				""
+				"A number of custom mineral nodes have been added for Enigmatica 6. Be sure to check them out as they can be quite lucrative!"
+			]
 			dependencies: ["0000000000000012"]
 			id: "0000000000000061"
 			tasks: [{
@@ -1304,8 +1308,8 @@
 		{
 			title: "Sulfur Recovery Unit"
 			icon: "immersivepetroleum:diesel_bucket"
-			x: -5.5d
-			y: 2.5d
+			x: -3.5d
+			y: 1.0d
 			description: [
 				"The Sulfurized Diesel produced in the Distillation Tower contains some minor impurities that can be filtered out. By passing the fuel through a Sulfur Recovery Unit, the Sulfur may be collected and put to use elsewhere. Both Diesel and Sulfurized Diesel burn equally well."
 				""
@@ -1314,6 +1318,7 @@
 				"Note: Building Gadgets Patterns and Create Schematics are available in your Enigmatica 6 instance folder to assist with this multiblock."
 			]
 			dependencies: ["7A3633A43D7AB0F2"]
+			optional: true
 			id: "083FA0F4798DB004"
 			tasks: [
 				{

--- a/config/supplementaries-common.toml
+++ b/config/supplementaries-common.toml
@@ -201,7 +201,7 @@
 		#allow wall lanterns placement
 		enabled = true
 		#mod ids of mods that have lantern block that extend the base lantern class but don't look like one
-		mod_blacklist = ["extlights", "betterendforge"]
+		mod_blacklist = ["extlights", "betterendforge", "tconstruct"]
 
 	[tweaks.bells_tweaks]
 		#ring a bell by clicking on a chain that's connected to it


### PR DESCRIPTION
Blacklist tinker's construct from supplementaries wall lantern support. Resolves: #2584

Couple more minor tweaks to IE quest layout and a note about custom mineral nodes.