### PR TITLE
Increase base height of PNC Elevators

### DIFF
--- a/config/pneumaticcraft-common.toml
+++ b/config/pneumaticcraft-common.toml
@@ -58,7 +58,7 @@
 	electrostatic_lightning_chance = 100000
 	#The max height of an elevator per stacked Elevator Base block.
 	#Range: 1 ~ 256
-	elevator_base_blocks_per_base = 4
+	elevator_base_blocks_per_base = 8
 	#The amount of air produced by using 100 FE (Forge Energy) in the flux compressor
 	#Range: > 0
 	flux_compressor_efficiency = 40


### PR DESCRIPTION
Base range was updated in the mod some time ago from 4 to 6. This gives it a tiny boost over that, at 8 blocks. These can be stacked to increase the total height of the elevator, so this just reduces the number of stacked elevators that are needed by a bit.