### PR TITLE
Fix Create Recipe Conflict for Crushed End Stone

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -78,6 +78,7 @@ onEvent('recipes', (event) => {
 
         'byg:vermilion_sculk',
         '/byg:\\w+_glass_from_sand/',
+        'byg:compat/create/end_sand_from_crushing',
 
         'compactmachines:wall',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/stonecutter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/stonecutter.js
@@ -92,6 +92,8 @@ onEvent('recipes', (event) => {
     event.stonecutting('masonry:andesitepolishedwall', 'minecraft:polished_andesite');
     event.stonecutting('masonry:darkprismarinepanelswall', 'minecraft:dark_prismarine');
     event.stonecutting('masonry:prismarinepaverswall', 'minecraft:prismarine_bricks');
+    event.stonecutting('betterendforge:endstone_dust', 'byg:end_sand');
+    event.stonecutting('byg:end_sand', 'betterendforge:endstone_dust');
 
     var masonryTiledStoneTypes = masonryStoneTypes.concat(['endstone', 'netherrack', 'obsidian']);
     masonryTiledStoneTypes.forEach((stoneType) => {


### PR DESCRIPTION
All the other crushing recipes are making the occultism dust. Removed the end sand crushing recipe and added a stonecutter recipe to swap between byg/betterend endstone sands.

Resolves #2677