### PR TITLE
Corrections to Ars Nouveau quests

### DIFF
--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -34,8 +34,8 @@
 			}]
 		}
 		{
-			x: 12.0d
-			y: -5.5d
+			x: 8.0d
+			y: -5.0d
 			subtitle: "T-U-R-R-E-T, Turret"
 			description: [
 				"The Spell Turret is an enhanced apparatus used to cast spells on demand with a redstone pulse. "
@@ -489,8 +489,8 @@
 			}]
 		}
 		{
-			x: 9.5d
-			y: -4.0d
+			x: 3.5d
+			y: -3.5d
 			subtitle: "Boop the Snoot"
 			description: [
 				"An amicable being that's deeply attuned with mana, Whelps may be summoned to perform more complicated tasks by casting a prepared Spell Scroll in the area around their Summoning Stone."
@@ -514,8 +514,8 @@
 			}]
 		}
 		{
-			x: 10.5d
-			y: -5.0d
+			x: 6.5d
+			y: -4.5d
 			subtitle: "In Search of the Golden Acorn"
 			description: [
 				"Carbuncles are curious forest critters with a love for all things shiny. Gold, in particular. They may be befriended by tossing them a small amount of gold. Once befriended, they will assist by collecting items and moving them to inventories. "
@@ -549,8 +549,8 @@
 			]
 		}
 		{
-			x: 8.5d
-			y: -3.5d
+			x: 2.5d
+			y: -3.0d
 			subtitle: "Whispering Winds"
 			description: [
 				"Sylphs are the care-takers of the forest, helping new growth to flourish. They will come with you willingly if you honor them by planting a tree in their stead. Once befriended, a Sylph will tend to a small area and gift you with their bounty. Plant down trees, crops, flowers, and other natural items and over time the Sylph will grow more of these and offer them to you."
@@ -599,8 +599,8 @@
 			]
 		}
 		{
-			x: 9.0d
-			y: -5.5d
+			x: 3.0d
+			y: -5.0d
 			subtitle: "Shh! Shh! You'll break the spell."
 			description: [
 				"Not all tasks lend themselves to completion by simple automatons like a turret or a rune. There exist certain magical creatures in this world that will help an aspiring practitioner quite willingly. Before seeking them out, create a Summoning Crystal to act as a focus for the magics to come."
@@ -649,8 +649,8 @@
 		{
 			title: "Auto-magically"
 			icon: "ars_nouveau:glyph_self"
-			x: 10.5d
-			y: -6.5d
+			x: 5.5d
+			y: -6.0d
 			description: ["What good is magic if it cannot be made to work for us without constant intervention?"]
 			dependencies: ["00000000000003AC"]
 			id: "00000000000009ED"
@@ -670,8 +670,8 @@
 		{
 			title: "Turret Practice: Micro Farms"
 			icon: "ars_nouveau:glyph_harvest"
-			x: 12.5d
-			y: -3.5d
+			x: 8.5d
+			y: -3.0d
 			description: [
 				"A simple and compact crop farm can be made with a spell turret with the following spell:"
 				""
@@ -710,8 +710,8 @@
 		}
 		{
 			title: "Turret Practice: Redstone Clock"
-			x: 11.5d
-			y: -4.0d
+			x: 7.5d
+			y: -3.5d
 			description: [
 				"Considering the Turret needs a redstone signal to work, some form of clock is in order. There are many designs that will work, but perhaps something more thematic is in order?"
 				""
@@ -864,8 +864,8 @@
 		}
 		{
 			icon: "ars_nouveau:wixie_charm"
-			x: 10.5d
-			y: -3.5d
+			x: 5.5d
+			y: -3.0d
 			subtitle: "Wyrd Sisters"
 			description: [
 				"Wouldn't it be helpful to have a hand around the Crafting Table? Someone to pass you this, or fetch you that? Or perhaps they could just do the job for you while you further your studies of the arcane?"
@@ -898,8 +898,8 @@
 			}]
 		}
 		{
-			x: 10.5d
-			y: -2.5d
+			x: 5.5d
+			y: -2.0d
 			subtitle: "Nanny Ogg's Cookbook"
 			description: [
 				"Simple item crafting isn’t the only thing these crafty ladies have hidden up their sleeves. They’re quite the adept in a brewery as well, making potions of all types. "
@@ -929,8 +929,8 @@
 		}
 		{
 			icon: "ars_nouveau:potion_melder"
-			x: 9.5d
-			y: -1.5d
+			x: 4.5d
+			y: -1.0d
 			subtitle: "Subtle Infusions"
 			description: [
 				"The clever arcanist finds ways to save themselves time, and nothing wastes time like drinking five different potions in preparation for a fight. Why not mix them and drink them all at once? "
@@ -982,8 +982,8 @@
 			]
 		}
 		{
-			x: 11.5d
-			y: -1.5d
+			x: 6.5d
+			y: -1.0d
 			subtitle: "Why Limit Happy Hour?"
 			description: ["Multiple doses all bottled up and ready to go in an eco-friendly re-usable package. Each Flask can hold up to eight doses of potion and may even be enchanted to increase the potency or duration of the potions within. "]
 			dependencies: ["4DC7DC466B1F2D0B"]
@@ -1024,8 +1024,8 @@
 			}]
 		}
 		{
-			x: 5.5d
-			y: -6.0d
+			x: 10.5d
+			y: -6.5d
 			subtitle: "I Love the Smell of Napalm in the Morning"
 			description: [
 				"Nothing quite says “Magic” like burning reagents on a pyre!"
@@ -1049,8 +1049,8 @@
 		}
 		{
 			icon: "ars_nouveau:ritual_disintegration"
-			x: 4.5d
-			y: -5.0d
+			x: 11.5d
+			y: -4.0d
 			subtitle: "XP = MC Squared "
 			description: [
 				"Killing monsters can be a … messy affair. Why not skip the trouble and simply distill them down into their very essence? "
@@ -1081,7 +1081,7 @@
 			}]
 		}
 		{
-			x: 6.5d
+			x: 9.5d
 			y: -4.0d
 			subtitle: "Here Comes the Rain Again, Falling On My Head Like a Memory"
 			description: [
@@ -1104,8 +1104,8 @@
 		}
 		{
 			title: "Celestial Manipulation"
-			x: 6.5d
-			y: -5.0d
+			x: 9.0d
+			y: -5.5d
 			subtitle: "Ain't nobody got time for that!"
 			description: [
 				"Are your days too short? Not enough time for your nocturnal pursuits? "
@@ -1138,8 +1138,8 @@
 			}]
 		}
 		{
-			x: 4.5d
-			y: -4.0d
+			x: 10.5d
+			y: -4.5d
 			subtitle: "Hear Ye, Hear Ye"
 			description: [
 				"All you Lowly Pillagers, Ravaging Vindicators, and Summoners of Questionable Merit are here-by formally summoned to participate in the coming tournaments! "
@@ -1161,8 +1161,8 @@
 		}
 		{
 			title: "Fertility and Growth"
-			x: 5.5d
-			y: -3.5d
+			x: 12.0d
+			y: -5.5d
 			subtitle: "Magically Sustained Gestation"
 			description: [
 				"If you sad in life – use MSG. If you happy in life – use MSG. Put MSG in everything, it’ll turn out better. You just get baby? Put MSG on baby, make smarter."
@@ -1274,7 +1274,7 @@
 			}]
 		}
 		{
-			x: 8.0d
+			x: 4.5d
 			y: -4.5d
 			subtitle: "Very A-moose-ing."
 			description: [
@@ -1284,7 +1284,7 @@
 				""
 				"The number of wild Drygmies has dwindled in recent times. If none can be found, consider summoning them with the Altar of Birthing."
 			]
-			dependencies: ["00000000000003F7"]
+			dependencies: ["00000000000009ED"]
 			id: "4599C1B5F2048691"
 			tasks: [{
 				id: "2DE5518E628456D5"
@@ -1309,6 +1309,15 @@
 					player_command: false
 				}
 			]
+		}
+		{
+			x: 10.5d
+			y: -7.0d
+			id: "2C0C81740B9EDF18"
+			tasks: [{
+				id: "31C99F6DF0CAAB74"
+				type: "item"
+			}]
 		}
 	]
 }


### PR DESCRIPTION
Drygmies don't require a summoning crystal. moved nodes around a bit in consequence.