### PR TITLE
Placed Dragon Head On Portal Frame After Dragon Death

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/entity/ender_dragon.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/entity/ender_dragon.js
@@ -1,0 +1,5 @@
+onEvent('entity.death', event => { 
+    if (event.entity.type == 'minecraft:ender_dragon'){
+      event.server.scheduleInTicks(700, event.server, function (callback) { 
+      callback.server.runCommandSilent('execute in minecraft:the_end run setblock 0 64 -1 minecraft:dragon_head replace')})}
+})


### PR DESCRIPTION
places dragon head on the top of the portal frame north side 700 ticks after dragon death, this gives plenty of time for the dragon to float down and die before the portal opens. The head gets yeeted if placed before the portal opens.