### PR TITLE
Increase mana cost for Drygmy and Sylph production

### DIFF
--- a/config/ars_nouveau-common.toml
+++ b/config/ars_nouveau-common.toml
@@ -41,6 +41,15 @@
 	#How often Drygmys spawn
 	#Range: 0 ~ 100
 	drygmyWeight = 3
+	#How much mana drygmys consume per generation
+	#Range: 0 ~ 10000
+	drygmyManaCost = 8000
+	#How much mana sylphs consume per generation
+	#Range: 0 ~ 10000
+	sylphManaCost = 2000
+	#How many channels must occur before a drygmy produces loot
+	#Range: 0 ~ 300
+	drygmyMaxProgress = 15
 
 #Mana
 [mana]


### PR DESCRIPTION
Greatly slows down the production rate if people use only passive mana gens. A single volcanic accumulator can no longer support multiples of each creature without tossing it blazing archwood.