### PR TITLE
Make Post Box craftable earlier

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -994,6 +994,15 @@ onEvent('recipes', (event) => {
                 A: '#forge:sawdust'
             },
             id: 'thermal:storage/sawdust_block'
+        },
+        {
+            output: 'cfm:post_box',
+            pattern: ['AAA', 'ABA', 'A A'],
+            key: {
+                A: '#forge:ingots/iron_aluminum',
+                B: '#forge:chests'
+            },
+            id: 'cfm:post_box'
         }
     ];
 


### PR DESCRIPTION
This thing is just for sending mail to server mates, yet costs shulker boxes. Kinda uncool. Changed to any chest. Alternatively uses iron or aluminum.