### PR TITLE
[Expert] Make Hovering Hourglass available earlier in progression

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
@@ -63,6 +63,17 @@ onEvent('recipes', (event) => {
                 C: 'botania:corporea_block'
             },
             id: 'botania:corporea_crystal_cube'
+        },
+        {
+            output: 'botania:hourglass',
+            pattern: ['ABA', 'CDC', 'ABA'],
+            key: {
+                A: '#forge:nuggets/nebu',
+                B: 'atum:crystal_glass',
+                C: '#forge:dusts/redstone',
+                D: '#forge:gems/mana'
+            },
+            id: 'botania:hourglass'
         }
     ];
 


### PR DESCRIPTION
Makes Botania's Hovering Hourglass available earlier for early automation.

![image](https://user-images.githubusercontent.com/9543430/125555788-63209b27-2f32-4740-989b-65d7552a5e3f.png)