### PR TITLE
[Expert] Initial RFTools Progression

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -99,5 +99,7 @@
     "item.kubejs.sliver_tin": "Crystalline Tin Sliver",
     "item.kubejs.sliver_uranium": "Crystalline Uranium Sliver",
     "item.kubejs.sliver_utherium": "Crystalline Utherium Sliver",
-    "item.kubejs.sliver_zinc": "Crystalline Zinc Sliver"
+    "item.kubejs.sliver_zinc": "Crystalline Zinc Sliver",
+
+    "item.kubejs.rftools_frame_parts": "RFTools Machine Frame Parts"
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -1,4 +1,4 @@
-onEvent('recipes', (event) => {
+/*onEvent('recipes', (event) => {
     var data = {
         recipes: [
             {
@@ -35,5 +35,82 @@ onEvent('recipes', (event) => {
     };
     data.recipes.forEach((recipe) => {
         event.custom(recipe);
+    });
+});
+*/
+
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+/*
+        {
+            inputs: [
+                '', // top left
+                '', // top 
+                '', // top right
+                '', // left
+                '', // right
+                '', // bottom left
+                '', // bottom
+                ''  // bottom right
+            ],
+            inputFluid: '', // optional
+            inputFluidAmount: 0, // leave at 0 for no fluid
+            processingTime: 50,
+            outputItemName: '',
+            outputItemCount: 1,
+            outputFluid: '', // optional
+            outputFluidAmount: 0, // leave at 0 for no fluid
+            id: ''
+        }
+*/
+        {
+            inputs: [
+                'minecraft:glass_pane'
+            ],
+            inputFluid: 'pneumaticcraft:memory_essence',
+            inputFluidAmount: 1000,
+            processingTime: 50,
+            outputItem: 'minecraft:glass_pane',
+            outputItemCount: 1,
+            outputFluid: 'industrialforegoing:essence',
+            outputFluidAmount: 1000
+        },
+        {
+            inputs: [
+                'minecraft:glass_pane'
+            ],
+            inputFluid: 'industrialforegoing:essence',
+            inputFluidAmount: 1000,
+            processingTime: 50,
+            outputItem: 'minecraft:glass_pane',
+            outputItemCount: 1,
+            outputFluid: 'pneumaticcraft:memory_essence',
+            outputFluidAmount: 1000
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        let ingredients = [];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input));
+        });
+
+        const re = event.custom({
+            type: 'industrialforegoing:dissolution_chamber',
+            input: ingredients,
+            inputFluid: `{FluidName:"${recipe.inputFluid}",Amount:${recipe.inputFluidAmount}}`,
+            processingTime: recipe.processingTime,
+            output: { item: recipe.outputItem, count: recipe.outputItemCount },
+            outputFluid: `{FluidName:"${recipe.outputFluid}",Amount:${recipe.outputFluidAmount}}`
+        });
+
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -1,44 +1,3 @@
-/*onEvent('recipes', (event) => {
-    var data = {
-        recipes: [
-            {
-                type: 'industrialforegoing:dissolution_chamber',
-                input: [
-                    {
-                        item: 'minecraft:glass_pane'
-                    }
-                ],
-                inputFluid: '{ FluidName: "pneumaticcraft:memory_essence", Amount: 1000 }',
-                processingTime: 50,
-                output: {
-                    item: 'minecraft:glass_pane',
-                    count: 1
-                },
-                outputFluid: '{ FluidName: "industrialforegoing:essence", Amount: 1000 }'
-            },
-            {
-                type: 'industrialforegoing:dissolution_chamber',
-                input: [
-                    {
-                        item: 'minecraft:glass_pane'
-                    }
-                ],
-                inputFluid: '{ FluidName: "industrialforegoing:essence", Amount: 1000 }',
-                processingTime: 50,
-                output: {
-                    item: 'minecraft:glass_pane',
-                    count: 1
-                },
-                outputFluid: '{ FluidName: "pneumaticcraft:memory_essence", Amount: 1000 }'
-            }
-        ]
-    };
-    data.recipes.forEach((recipe) => {
-        event.custom(recipe);
-    });
-});
-*/
-
 onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
@@ -60,8 +19,7 @@ onEvent('recipes', (event) => {
             inputFluid: '', // optional
             inputFluidAmount: 0, // leave at 0 for no fluid
             processingTime: 50,
-            outputItemName: '',
-            outputItemCount: 1,
+            outputItem: { item: '', count: 1 },
             outputFluid: '', // optional
             outputFluidAmount: 0, // leave at 0 for no fluid
             id: ''
@@ -74,8 +32,7 @@ onEvent('recipes', (event) => {
             inputFluid: 'pneumaticcraft:memory_essence',
             inputFluidAmount: 1000,
             processingTime: 50,
-            outputItem: 'minecraft:glass_pane',
-            outputItemCount: 1,
+            outputItem: { item: 'minecraft:glass_pane', count: 1 },
             outputFluid: 'industrialforegoing:essence',
             outputFluidAmount: 1000
         },
@@ -86,8 +43,7 @@ onEvent('recipes', (event) => {
             inputFluid: 'industrialforegoing:essence',
             inputFluidAmount: 1000,
             processingTime: 50,
-            outputItem: 'minecraft:glass_pane',
-            outputItemCount: 1,
+            outputItem: { item: 'minecraft:glass_pane', count: 1 },
             outputFluid: 'pneumaticcraft:memory_essence',
             outputFluidAmount: 1000
         }
@@ -105,7 +61,7 @@ onEvent('recipes', (event) => {
             input: ingredients,
             inputFluid: `{FluidName:"${recipe.inputFluid}",Amount:${recipe.inputFluidAmount}}`,
             processingTime: recipe.processingTime,
-            output: { item: recipe.outputItem, count: recipe.outputItemCount },
+            output: recipe.outputItem,
             outputFluid: `{FluidName:"${recipe.outputFluid}",Amount:${recipe.outputFluidAmount}}`
         });
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/assembly.js
@@ -3,15 +3,13 @@ onEvent('recipes', (event) => {
         {
             input: '#forge:ingots/compressed_iron',
             input_count: 4,
-            output: 'pneumaticcraft:elevator_frame',
-            output_count: 8,
+            output: { item: 'pneumaticcraft:elevator_frame', count: 8 },
             program: 'drill'
         },
         {
             input: 'pneumaticcraft:reinforced_brick_wall',
             input_count: 6,
-            output: 'pneumaticcraft:cannon_barrel',
-            output_count: 2,
+            output: { item: 'pneumaticcraft:cannon_barrel', count: 2 },
             program: 'drill'
         }
     ];
@@ -25,10 +23,7 @@ onEvent('recipes', (event) => {
         let re = event.custom({
             type: `pneumaticcraft:assembly_${recipe.program}`,
             input: constructed_input,
-            result: {
-                item: recipe.output,
-                count: recipe.output_count
-            },
+            result: recipe.output,
             program: recipe.program
         });
         if (recipe.id) {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/mechanical_crafting.js
@@ -57,6 +57,18 @@ onEvent('recipes', (event) => {
                 D: 'thermal:fire_tnt'
             },
             id: 'immersiveengineering:crafting/blastbrick'
+        },
+        {
+            output: 'rftoolsdim:dimension_builder',
+            pattern: ['  C  ', ' CDC ', 'CBEAC', ' CDC ', '  C  '],
+            key: {
+                A: 'rftoolsbase:machine_infuser',
+                B: 'rftoolsdim:enscriber',
+                C: 'mekanism:alloy_atomic',
+                D: 'mekanism:ultimate_control_circuit',
+                E: 'rftoolsbase:machine_frame'
+            },
+            id: 'rftoolsdim:dimension_builder'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -1,0 +1,71 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+/*
+        {
+            inputs: [
+                '', // top left
+                '', // top 
+                '', // top right
+                '', // left
+                '', // right
+                '', // bottom left
+                '', // bottom
+                ''  // bottom right
+            ],
+            inputFluid: '', // optional
+            inputFluidAmount: 0, // leave at 0 for no fluid
+            processingTime: 50,
+            outputItemName: '',
+            outputItemCount: 1,
+            outputFluid: '', // optional
+            outputFluidAmount: 0, // leave at 0 for no fluid
+            id: ''
+        }
+*/
+        {
+            inputs: [
+                'minecraft:redstone',
+                'rftoolsbase:machine_frame',
+                'minecraft:redstone',
+                'minecraft:redstone_torch',
+                'minecraft:redstone_torch',
+                '#forge:ingots/gold_copper',
+                '#forge:ingots/gold_copper',
+                '#forge:ingots/gold_copper'
+            ],
+            inputFluid: 'tconstruct:molten_obsidian',
+            inputFluidAmount: 1000,
+            processingTime: 50,
+            outputItem: 'rftoolsbuilder:shield_block1',
+            outputItemCount: 1,
+            outputFluid: '',
+            outputFluidAmount: 0,
+            id: 'rftoolsbuilder:shield_block1'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        let ingredients = [];
+
+        recipe.inputs.forEach((input) => {
+            ingredients.push(Ingredient.of(input));
+        });
+
+        const re = event.custom({
+            type: 'industrialforegoing:dissolution_chamber',
+            input: ingredients,
+            inputFluid: `{FluidName:"${recipe.inputFluid}",Amount:${recipe.inputFluidAmount}}`,
+            processingTime: recipe.processingTime,
+            output: { item: recipe.outputItem, count: recipe.outputItemCount },
+            outputFluid: `{FluidName:"${recipe.outputFluid}",Amount:${recipe.outputFluidAmount}}`
+        });
+
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -19,8 +19,7 @@ onEvent('recipes', (event) => {
             inputFluid: '', // optional
             inputFluidAmount: 0, // leave at 0 for no fluid
             processingTime: 50,
-            outputItemName: '',
-            outputItemCount: 1,
+            outputItem: { item: '', count: 1 },
             outputFluid: '', // optional
             outputFluidAmount: 0, // leave at 0 for no fluid
             id: ''
@@ -40,8 +39,7 @@ onEvent('recipes', (event) => {
             inputFluid: 'tconstruct:molten_obsidian',
             inputFluidAmount: 1000,
             processingTime: 600,
-            outputItem: 'rftoolsbuilder:shield_block1',
-            outputItemCount: 1,
+            outputItem: { item: 'rftoolsbuilder:shield_block1', count: 1 },
             outputFluid: '',
             outputFluidAmount: 0,
             id: 'rftoolsbuilder:shield_block1'
@@ -60,7 +58,7 @@ onEvent('recipes', (event) => {
             input: ingredients,
             inputFluid: `{FluidName:"${recipe.inputFluid}",Amount:${recipe.inputFluidAmount}}`,
             processingTime: recipe.processingTime,
-            output: { item: recipe.outputItem, count: recipe.outputItemCount },
+            output: recipe.outputItem,
             outputFluid: `{FluidName:"${recipe.outputFluid}",Amount:${recipe.outputFluidAmount}}`
         });
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -39,7 +39,7 @@ onEvent('recipes', (event) => {
             ],
             inputFluid: 'tconstruct:molten_obsidian',
             inputFluidAmount: 1000,
-            processingTime: 50,
+            processingTime: 600,
             outputItem: 'rftoolsbuilder:shield_block1',
             outputItemCount: 1,
             outputFluid: '',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/assembly.js
@@ -7,16 +7,14 @@ onEvent('recipes', (event) => {
         {
             input: 'thermal:machine_frame',
             input_count: 2,
-            output: 'kubejs:rftools_frame_parts',
-            output_count: 1,
+            output: { item: 'kubejs:rftools_frame_parts', count: 1 },
             program: 'drill',
             id: 'rftoolsbase:machine_frame'
         },
         {
             input: 'kubejs:rftools_frame_parts',
             input_count: 1,
-            output: 'rftoolsbase:machine_frame',
-            output_count: 1,
+            output: { item: 'rftoolsbase:machine_frame', count: 1 },
             program: 'laser',
             id: 'rftoolsbase:machine_frame'
         }
@@ -31,10 +29,7 @@ onEvent('recipes', (event) => {
         let re = event.custom({
             type: `pneumaticcraft:assembly_${recipe.program}`,
             input: constructed_input,
-            result: {
-                item: recipe.output,
-                count: recipe.output_count
-            },
+            result: recipe.output,
             program: recipe.program
         });
         if (recipe.id) {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/assembly.js
@@ -1,0 +1,44 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    recipes = [
+        {
+            input: 'thermal:machine_frame',
+            input_count: 2,
+            output: 'kubejs:rftools_frame_parts',
+            output_count: 1,
+            program: 'drill',
+            id: 'rftoolsbase:machine_frame'
+        },
+        {
+            input: 'kubejs:rftools_frame_parts',
+            input_count: 1,
+            output: 'rftoolsbase:machine_frame',
+            output_count: 1,
+            program: 'laser',
+            id: 'rftoolsbase:machine_frame'
+        }
+    ];
+    recipes.forEach((recipe) => {
+        let constructed_input = recipe.input.charAt(0) == '#' ? { tag: recipe.input.slice(1) } : { item: recipe.input };
+        if (recipe.input_count) {
+            constructed_input.type = 'pneumaticcraft:stacked_item';
+            constructed_input.count = recipe.input_count;
+        }
+
+        let re = event.custom({
+            type: `pneumaticcraft:assembly_${recipe.program}`,
+            input: constructed_input,
+            result: {
+                item: recipe.output,
+                count: recipe.output_count
+            },
+            program: recipe.program
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/rftools/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/rftools/shaped.js
@@ -1,0 +1,116 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    /*
+        ,
+        {
+            output: '',
+            pattern: ['', '', ''],
+            key: {
+                A: ''
+            },
+            id: ''
+        }
+    */
+
+    const newRecipes = [
+        {
+            output: 'rftoolsutility:screen_controller',
+            pattern: ['ABA', 'DCD', 'ADA'],
+            key: {
+                A: 'minecraft:redstone',
+                B: 'minecraft:ender_pearl',
+                C: 'rftoolsbase:machine_base',
+                D: '#forge:glass'
+            },
+            id: 'rftoolsutility:screen_controller'
+        },
+        {
+            output: 'rftoolsutility:module_template',
+            pattern: ['ABA', 'BCB', 'ABA'],
+            key: {
+                A: '#forge:gems/dimensional',
+                B: '#forge:ingots/iron_aluminum',
+                C: 'pneumaticcraft:printed_circuit_board'
+            },
+            id: 'rftoolsutility:module_template'
+        },
+        {
+            output: 'rftoolsutility:matter_receiver',
+            pattern: ['AAA', 'BCB', 'DDD'],
+            key: {
+                A: '#forge:ingots/iron_aluminum',
+                B: 'minecraft:redstone',
+                C: 'rftoolsbase:machine_base',
+                D: 'minecraft:ender_pearl'
+            },
+            id: 'rftoolsutility:matter_receiver'
+        },
+        {
+            output: 'rftoolsutility:matter_transmitter',
+            pattern: ['DDD', 'BCB', 'AAA'],
+            key: {
+                A: '#forge:ingots/iron_aluminum',
+                B: 'minecraft:redstone',
+                C: 'rftoolsbase:machine_base',
+                D: 'minecraft:ender_pearl'
+            },
+            id: 'rftoolsutility:matter_transmitter'
+        },
+        {
+            output: 'rftoolsutility:charged_porter',
+            pattern: [' C ', 'CBC', 'ACA'],
+            key: {
+                A: '#forge:ingots/iron_aluminum',
+                B: 'pneumaticcraft:printed_circuit_board',
+                C: 'minecraft:ender_pearl'
+            },
+            id: 'rftoolsutility:charged_porter'
+        },
+        {
+            output: 'rftoolsbuilder:shape_card_pump',
+            pattern: ['ABA', 'CDC', 'AEA'],
+            key: {
+                A: 'minecraft:redstone',
+                B: 'minecraft:water_bucket',
+                C: 'pneumaticcraft:printed_circuit_board',
+                D: 'rftoolsbuilder:shape_card_def',
+                E: 'minecraft:lava_bucket'
+            },
+            id: 'rftoolsbuilder:shape_card_pump'
+        },
+        {
+            output: 'rftoolsbuilder:shape_card_quarry',
+            pattern: ['ABA', 'CDC', 'AEA'],
+            key: {
+                A: 'minecraft:redstone',
+                B: 'minecraft:diamond_pickaxe',
+                C: 'pneumaticcraft:printed_circuit_board',
+                D: 'rftoolsbuilder:shape_card_def',
+                E: 'minecraft:diamond_shovel'
+            },
+            id: 'rftoolsbuilder:shape_card_quarry'
+        },
+        {
+            output: 'rftoolsbase:machine_infuser',
+            pattern: ['ABA', 'DCD', 'ABA'],
+            key: {
+                A: '#forge:gems/dimensional',
+                B: 'minecraft:redstone',
+                C: 'rftoolsbase:machine_base',
+                D: '#forge:gems/diamond'
+            },
+            id: 'rftoolsbase:machine_infuser'
+        }
+    ];
+
+    newRecipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/rftools/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/rftools/shaped.js
@@ -103,6 +103,17 @@ onEvent('recipes', (event) => {
                 D: '#forge:gems/diamond'
             },
             id: 'rftoolsbase:machine_infuser'
+        },
+        {
+            output: 'rftoolsbuilder:builder',
+            pattern: ['ADA', 'BCB', 'ABA'],
+            key: {
+                A: 'minecraft:bricks',
+                B: 'minecraft:redstone',
+                C: 'rftoolsbase:machine_base',
+                D: 'minecraft:ender_pearl'
+            },
+            id: 'rftoolsbuilder:builder'
         }
     ];
 

--- a/kubejs/startup_scripts/item_registry.js
+++ b/kubejs/startup_scripts/item_registry.js
@@ -18,7 +18,8 @@ onEvent('item.registry', (event) => {
         'observatory_lens',
         'coarse_lapis_lazuli_compound',
         'smoldering_lapis_lazuli_compound',
-        'cutting_essence'
+        'cutting_essence',
+        'rftools_frame_parts'
     ];
 
     let metals = [


### PR DESCRIPTION
Gating for RFTools. Leaving the machine base as it's default recipe (which is just stone and gold/copper nuggets), which I'm using for things I want to pull earlier than RFTools.

Machine Base - uses PNC Assembly Line, converts 2 Thermal frames into an intermediary, which is converted into an RFTools frame. Intermediate item needs art.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693619-99960930-962d-40bd-9b37-2bd5c971f201.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693590-0e3414e6-f089-415d-8d25-f9e7e02fa1b9.png">

Screen Controller, Matter Transmitter/Receiver, Machine Infuser, Builder - converted to Machine Base (from Frame) to pull out of RFTools progression.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693291-43d70d19-4ff8-4b93-a179-b26520142497.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693328-5c7a99ff-df88-4297-bcba-5c11fe422306.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693342-abc29279-4223-43e9-8ebe-3826c66b1d8e.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693400-d8293d21-e80a-459a-86f2-68c102cada9e.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693271-90d47b9a-5661-4cbf-bc11-b087376aff88.png">

Module Template - requires a PNC PCB Board, gating it behind PNC; they will also need a Machine Frame for the environmental controller.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693459-65fc5cd9-7264-422b-8810-a397d8bd8bb6.png">

Charged Porter - also requires a PNC PCB, gating easy teleport from anywhere back to a matter receiver.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693479-c849c12b-82ba-48bd-9fe6-00a6472ed91a.png">

Builder's Pump & Quarry cards - Gated with PNC PCB, may need to be pulled further back. This leaves the builder available earlier for actual building and voiding purposes.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693497-633dc0f5-30ff-4197-bdc3-677568922fe0.png">

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693524-88863ce8-6222-450d-acb9-de5677a0ced0.png">

Shield Projector - Uses IF Dissolution Chamber so will require significant progression. Took the time to build out a nicely templated dissolution chamber script that can be used to refactor the base script.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/13169307/125693671-fd1bd2b3-f3a2-4152-8984-d4c1a61e03f9.png">

Dimension Builder - Create Mechanical Crafting, using Mek Ultimate Circuits/Atomic Alloys. Should gate it pretty late.

<img width="382" alt="image" src="https://user-images.githubusercontent.com/13169307/125693708-dc8b3c44-7457-4412-8b6b-c97fa325f137.png">