### PR TITLE
[Expert] More Botania tweaks, some continuation of Blood Magic, and Starting Pedestals

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -1053,5 +1053,40 @@
 				item: "occultism:storage_stabilizer_tier4"
 			}]
 		}
+		{
+			x: 0.0d
+			y: 9.5d
+			dependencies: ["6191E6C529A75F79"]
+			id: "2599ACB5A056BE45"
+			tasks: [{
+				id: "6CA19080160E1119"
+				type: "item"
+				item: {
+					id: "bloodmagic:ritualdiviner"
+					Count: 1b
+					tag: {
+						current_ritual: "green_grove"
+						direction: 5
+					}
+				}
+			}]
+		}
+		{
+			x: 2.0d
+			y: 12.0d
+			dependencies: ["61C9960AEED0B5AA"]
+			id: "2C6622C35D170DE7"
+			tasks: [{
+				id: "0F1F93977C676257"
+				type: "item"
+				item: {
+					id: "bloodmagic:ritualdivinerdusk"
+					Count: 1b
+					tag: {
+						current_ritual: "lava"
+					}
+				}
+			}]
+		}
 	]
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -19,7 +19,9 @@ onEvent('recipes', (event) => {
         /create:crafting\/materials\/andesite_alloy/,
         'immersiveengineering:crafting/component_iron',
         'immersiveengineering:crafting/component_steel',
-        'minecraft:stick'
+        'minecraft:stick',
+        'pedestals:upgrades/breaker2',
+        'pedestals:ingot_gold_from_upgrades'
     ];
 
     const outputRemovals = ['tiab:timeinabottle'];

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -331,7 +331,6 @@ onEvent('recipes', (event) => {
                 count: 1,
                 id: 'botania:mana_tablet'
             },
-
             {
                 inputs: [
                     '#resourcefulbees:resourceful_honeycomb_block',
@@ -347,6 +346,70 @@ onEvent('recipes', (event) => {
                 output: 'resourcefulbees:t2_apiary',
                 count: 1,
                 id: 'resourcefulbees:t2_apiary'
+            },
+            {
+                inputs: [
+                    '#forge:gems/mana_diamond',
+                    'bloodmagic:firescribetool',
+                    '#forge:gems/mana_diamond',
+                    'bloodmagic:airscribetool',
+                    'bloodmagic:earthscribetool',
+                    '#forge:gems/mana_diamond',
+                    'bloodmagic:waterscribetool',
+                    '#forge:gems/mana_diamond'
+                ],
+                reagent: 'botania:livingwood_twig',
+                output: 'bloodmagic:ritualdiviner',
+                count: 1,
+                id: 'bloodmagic:ritual_diviner_0'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'naturesaura:sky_sword',
+                    'botania:pixie_dust',
+                    'atum:montu_godshard',
+                    '#botania:runes/muspelheim',
+                    'botania:pixie_dust',
+                    'naturesaura:token_rage',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/attack',
+                count: 1,
+                id: 'pedestals:upgrades/attack'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'immersiveengineering:sawblade',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/earth',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_pickup',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/sawmill',
+                count: 1,
+                id: 'pedestals:upgrades/sawmill'
+            },
+            {
+                inputs: [
+                    'powah:capacitor_spirited',
+                    'thermal:rf_coil',
+                    'powah:capacitor_spirited',
+                    'immersiveengineering:coil_lv',
+                    'immersiveengineering:coil_lv',
+                    'powah:capacitor_spirited',
+                    'thermal:rf_coil',
+                    'powah:capacitor_spirited'
+                ],
+                reagent: 'pedestals:coin/sawmill',
+                output: 'pedestals:coin/rfsawmill',
+                count: 1,
+                id: 'pedestals:upgrades/rfsawmill'
             },
 
             /// Patchouli Removals

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -411,6 +411,151 @@ onEvent('recipes', (event) => {
                 count: 1,
                 id: 'pedestals:upgrades/rfsawmill'
             },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_fell',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/air',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_aoe',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/chopper',
+                count: 1,
+                id: 'pedestals:upgrades/chopper'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_touch',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/earth',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_break',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/breaker',
+                count: 1,
+                id: 'pedestals:upgrades/breaker'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_freeze',
+                    'botania:pixie_dust',
+                    '#botania:runes/fire',
+                    '#botania:runes/water',
+                    'botania:pixie_dust',
+                    'botania:ender_eye_block',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/cobble',
+                count: 1,
+                id: 'pedestals:upgrades/cobblegen'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'minecraft:piston',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/sloth',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_pickup',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/compactor2',
+                count: 1,
+                id: 'pedestals:upgrades/compactor2'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_craft',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/sloth',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_pickup',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/crafter1',
+                count: 1,
+                id: 'pedestals:upgrades/crafter1'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_touch',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/earth',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_place_block',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/placer',
+                count: 1,
+                id: 'pedestals:upgrades/placer'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_smelt',
+                    'botania:pixie_dust',
+                    'naturesaura:token_anger',
+                    '#botania:runes/summer',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_pickup',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/smelter',
+                count: 1,
+                id: 'pedestals:upgrades/smelter'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'botania:corporea_spark',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/greed',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_pickup',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                output: 'pedestals:coin/import',
+                count: 1,
+                id: 'pedestals:upgrades/import'
+            },
+            {
+                inputs: [
+                    'botania:pixie_dust',
+                    'botania:corporea_spark',
+                    'botania:pixie_dust',
+                    'naturesaura:token_joy',
+                    '#botania:runes/greed',
+                    'botania:pixie_dust',
+                    'ars_nouveau:glyph_ender_inventory',
+                    'botania:pixie_dust'
+                ],
+                reagent: 'pedestals:coin/default',
+                // Not a typo, items are misnamed.
+                output: 'pedestals:coin/enderexport',
+                count: 1,
+                id: 'pedestals:upgrades/enderimport'
+            },
 
             /// Patchouli Removals
             {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -120,6 +120,51 @@ onEvent('recipes', (event) => {
                 consumptionRate: 30,
                 drainRate: 50,
                 id: 'bloodmagic:altar/masterbloodorb'
+            },
+            {
+                input: '#botania:runes/air',
+                output: 'bloodmagic:airscribetool',
+                syphon: 1000,
+                altarLevel: 2,
+                consumptionRate: 5,
+                drainRate: 5,
+                id: 'bloodmagic:altar/air_tool'
+            },
+            {
+                input: '#botania:runes/fire',
+                output: 'bloodmagic:firescribetool',
+                syphon: 1000,
+                altarLevel: 2,
+                consumptionRate: 5,
+                drainRate: 5,
+                id: 'bloodmagic:altar/fire_tool'
+            },
+            {
+                input: '#botania:runes/water',
+                output: 'bloodmagic:waterscribetool',
+                syphon: 1000,
+                altarLevel: 2,
+                consumptionRate: 5,
+                drainRate: 5,
+                id: 'bloodmagic:altar/water_tool'
+            },
+            {
+                input: '#botania:runes/earth',
+                output: 'bloodmagic:earthscribetool',
+                syphon: 1000,
+                altarLevel: 2,
+                consumptionRate: 5,
+                drainRate: 5,
+                id: 'bloodmagic:altar/earth_tool'
+            },
+            {
+                input: '#botania:runes/nidavellir',
+                output: 'bloodmagic:duskscribetool',
+                syphon: 2000,
+                altarLevel: 3,
+                consumptionRate: 20,
+                drainRate: 10,
+                id: 'bloodmagic:altar/dusk_tool'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/shaped.js
@@ -191,6 +191,26 @@ onEvent('recipes', (event) => {
                 E: 'ars_nouveau:glyph_delay'
             },
             id: 'bloodmagic:blood_rune_charging'
+        },
+        {
+            output: 'bloodmagic:ritualstone',
+            pattern: ['CBC', 'BAB', 'CBC'],
+            key: {
+                A: { type: 'bloodmagic:bloodorb', orb_tier: 2 },
+                B: 'bloodmagic:reinforcedslate',
+                C: 'architects_palette:abyssaline'
+            },
+            id: 'bloodmagic:ritual_stone_blank'
+        },
+        {
+            output: 'bloodmagic:masterritualstone',
+            pattern: ['CBC', 'BAB', 'CBC'],
+            key: {
+                A: { type: 'bloodmagic:bloodorb', orb_tier: 3 },
+                B: 'bloodmagic:ritualstone',
+                C: 'architects_palette:abyssaline'
+            },
+            id: 'bloodmagic:ritual_stone_master'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
@@ -74,6 +74,16 @@ onEvent('recipes', (event) => {
                 D: '#forge:gems/mana'
             },
             id: 'botania:hourglass'
+        },
+        {
+            output: 'botania:ender_eye_block',
+            pattern: ['ABA', 'BCB', 'ABA'],
+            key: {
+                A: 'create:polished_rose_quartz',
+                B: 'minecraft:ender_eye',
+                C: 'architects_palette:abyssaline'
+            },
+            id: 'botania:ender_eye_block'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -69,7 +69,7 @@ onEvent('recipes', (event) => {
                 { tag: 'forge:nuggets/utherium' },
                 { tag: 'forge:nuggets/utherium' },
                 { tag: 'forge:nuggets/utherium' },
-                { item: 'create:rose_quartz' }
+                { item: 'create:polished_rose_quartz' }
             ],
             output: { item: 'mythicbotany:alfsteel_ingot' },
             mana: 1500000,
@@ -89,7 +89,7 @@ onEvent('recipes', (event) => {
                 { tag: 'forge:nuggets/utherium' },
                 { tag: 'forge:nuggets/utherium' },
                 { tag: 'forge:nuggets/utherium' },
-                { item: 'create:rose_quartz' }
+                { item: 'create:polished_rose_quartz' }
             ],
             output: { item: 'mythicbotany:alfsteel_ingot' },
             mana: 2000000,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pedestals/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pedestals/shaped.js
@@ -1,0 +1,38 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    /*
+        ,
+        {
+            output: '',
+            pattern: ['', '', ''],
+            key: {
+                A: ''
+            },
+            id: ''
+        }
+    */
+
+    const newRecipes = [
+        {
+            output: 'pedestals:pedestal/stone333',
+            pattern: ['ABA', ' C ', 'CCC'],
+            key: {
+                A: 'botania:livingrock_slab',
+                B: 'botania:light_relay',
+                C: 'botania:livingrock'
+            },
+            id: 'pedestals:pedestal'
+        }
+    ];
+
+    newRecipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/tconstruct/casting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/tconstruct/casting.js
@@ -1,0 +1,20 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [
+            {
+                inputs: [Item.of('#forge:ingots/cobalt', 3), 'thermal:blizz_powder'],
+                outputs: [Item.of('undergarden:froststeel_ingot', 3)]
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.recipes.thermal.smelter(recipe.outputs, recipe.inputs);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/tconstruct/induction_smelter.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/tconstruct/induction_smelter.js
@@ -1,0 +1,43 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+    var data = {
+        recipes: [
+            {
+                fluid: 'tconstruct:molten_hepatizon',
+                fluid_amount: 576,
+                casts: [{ item: 'botania:ender_eye_block' }],
+                cast_consumed: true,
+                output: 'betterendforge:infusion_pedestal',
+                cooling_time: 233,
+                id: 'betterendforge:infusion_pedestal'
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        let constructed_recipe = {
+            type: 'tconstruct:casting_basin',
+            fluid: {
+                name: recipe.fluid,
+                amount: recipe.fluid_amount
+            },
+            result: recipe.output,
+            cooling_time: recipe.cooling_time
+        };
+
+        if (recipe.casts) {
+            constructed_recipe.cast = {
+                type: 'mantle:intersection',
+                ingredients: recipe.casts
+            };
+            constructed_recipe.cast_consumed = recipe.cast_consumed;
+        }
+
+        const re = event.custom(constructed_recipe);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});


### PR DESCRIPTION
Meant to use polished rose quartz for Alfsteel:
![image](https://user-images.githubusercontent.com/9543430/125702589-6d5158ca-a2c8-4b20-a6fc-1449e8ff7b93.png)

Better End Infusion Pedestal now a casting recipe:
![image](https://user-images.githubusercontent.com/9543430/125702573-6c7e86ba-fc1a-4924-bc4f-5d79d5585ef0.png)

Ender Overseer overhauled:
![image](https://user-images.githubusercontent.com/9543430/125702628-ea06df8d-7b50-4281-89c5-88abdb567c31.png)

Blood Magic Inscription tools now take equivalent Botania Runes:
![image](https://user-images.githubusercontent.com/9543430/125703482-578f281d-cd98-420b-af87-589c483afa87.png)

Or Nidavellir in the case of the Dusk inscription tool:
![image](https://user-images.githubusercontent.com/9543430/125704183-9614e6f5-7a7f-4bba-b9cb-4176b7e5e5fd.png)

BM Ritual Stones now use abyssaline
![image](https://user-images.githubusercontent.com/9543430/125708821-643ad6ef-ff61-4c5c-8ed2-5c34463114ee.png)

![image](https://user-images.githubusercontent.com/9543430/125708827-e6016c84-42f6-4af7-bc14-8ee9fc5fb5c3.png)

Pedestals:
![image](https://user-images.githubusercontent.com/9543430/125715776-60ad1891-cdbc-4308-a44b-6a58b5a2dfc5.png)

Attack Upgrade:
![image](https://user-images.githubusercontent.com/9543430/125715658-f3277f09-93ed-41cc-a56c-ff373f06cd54.png)

Saw Upgrade:
![image](https://user-images.githubusercontent.com/9543430/125716980-b7639968-7ec0-4af2-bc49-c7ecf3ee3b0e.png)

RF Saw Upgrade:
![image](https://user-images.githubusercontent.com/9543430/125717777-617493d7-c747-4e88-b593-68b9707113ca.png)

Will work through the rest as time permits, but this gives a rough idea of how these recipes will look.