### PR TITLE
Correctly expand Create and IE sawing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -1,4 +1,7 @@
 onEvent('recipes', (event) => {
+    event.remove({ type: 'create:cutting', input: '#minecraft:logs' });
+    event.remove({ type: 'immersiveengineering:sawmill', input: '#minecraft:logs' });
+
     event.remove({ type: 'mekanism:combining' });
     event.remove({ type: 'minecraft:smelting', output: 'minecraft:obsidian' });
     event.remove({ type: 'minecraft:blasting', output: 'minecraft:obsidian' });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_sawables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/unification/unify_sawables.js
@@ -13,18 +13,6 @@ onEvent('recipes', (event) => {
 });
 
 function create_cutting(event, variant, sawDust, treeBark) {
-    var modID = variant.logBlock.split(':')[0];
-
-    // mod blacklist
-    if (
-        modID == 'minecraft' ||
-        variant.modId == 'autumnity' ||
-        variant.modId == 'atmospheric' ||
-        variant.modId == 'upgrade_aquatic'
-    ) {
-        return;
-    }
-
     data = {
         recipes: [
             {
@@ -82,11 +70,6 @@ function create_cutting(event, variant, sawDust, treeBark) {
 }
 
 function immersiveengineering_sawing(event, variant, sawDust, treeBark) {
-    // mod blacklist
-    if (variant.modId == 'minecraft') {
-        return;
-    }
-
     event.recipes.immersiveengineering
         .sawmill(Item.of(variant.plankBlock, 6), variant.logBlockStripped, [
             {


### PR DESCRIPTION
Had not noticed that the first batch of changes still had an exclusion list.

Removed exclusion list, removed default recipes entirely. Replace all with recipes that strip and return bark from bark/wood blocks, and normalizes output to 6 planks per log