### PR TITLE
Fix Tetra Geodes again?

### DIFF
--- a/kubejs/data/tetra/loot_tables/actions/geode.json
+++ b/kubejs/data/tetra/loot_tables/actions/geode.json
@@ -1,0 +1,266 @@
+{
+    "pools": [
+        {
+            "name": "geode_extended",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "group",
+                    "weight": 8,
+                    "children": [
+                        {
+                            "type": "minecraft:item",
+                            "name": "minecraft:gold_nugget",
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "minecraft:iron_nugget",
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:copper_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:aluminum_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:silver_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:lead_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:nickel_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:uranium_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:osmium_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:tin_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "minecraft:item",
+                            "name": "emendatusenigmatica:zinc_nugget",
+                            "expand": true,
+                            "functions": [
+                                { "function": "set_count", "count": { "min": 4, "max": 12 } },
+                                {
+                                    "function": "minecraft:apply_bonus",
+                                    "enchantment": "minecraft:fortune",
+                                    "formula": "uniform_bonus_count",
+                                    "parameters": { "bonusMultiplier": 3 }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "tetra:pristine_diamond",
+                    "weight": 6,
+                    "conditions": [
+                        { "condition": "tetra:random_chance_with_fortune", "chance": 0.1, "fortuneMultiplier": 0.15 }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "tetra:pristine_emerald",
+                    "weight": 4,
+                    "conditions": [
+                        { "condition": "tetra:random_chance_with_fortune", "chance": 0.1, "fortuneMultiplier": 0.15 }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "tetra:pristine_lapis",
+                    "weight": 8,
+                    "conditions": [
+                        { "condition": "tetra:random_chance_with_fortune", "chance": 0.1, "fortuneMultiplier": 0.15 }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:diamond",
+                    "weight": 4,
+                    "conditions": [
+                        { "condition": "tetra:random_chance_with_fortune", "chance": 0.5, "fortuneMultiplier": 0.2 }
+                    ],
+                    "functions": [
+                        {
+                            "function": "minecraft:apply_bonus",
+                            "enchantment": "minecraft:fortune",
+                            "formula": "uniform_bonus_count",
+                            "parameters": { "bonusMultiplier": 1 }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:emerald",
+                    "weight": 2,
+                    "conditions": [
+                        { "condition": "tetra:random_chance_with_fortune", "chance": 0.5, "fortuneMultiplier": 0.2 }
+                    ],
+                    "functions": [
+                        {
+                            "function": "minecraft:apply_bonus",
+                            "enchantment": "minecraft:fortune",
+                            "formula": "uniform_bonus_count",
+                            "parameters": { "bonusMultiplier": 1 }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:flint",
+                    "weight": 4,
+                    "functions": [
+                        { "function": "set_count", "count": { "min": 1, "max": 3 } },
+                        {
+                            "function": "minecraft:apply_bonus",
+                            "enchantment": "minecraft:fortune",
+                            "formula": "uniform_bonus_count",
+                            "parameters": { "bonusMultiplier": 4 }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:redstone",
+                    "weight": 5,
+                    "functions": [
+                        { "function": "set_count", "count": { "min": 1, "max": 5 } },
+                        {
+                            "function": "minecraft:apply_bonus",
+                            "enchantment": "minecraft:fortune",
+                            "formula": "uniform_bonus_count",
+                            "parameters": { "bonusMultiplier": 3 }
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "name": "minecraft:lapis_lazuli",
+                    "weight": 5,
+                    "functions": [
+                        { "function": "set_count", "count": { "min": 1, "max": 5 } },
+                        {
+                            "function": "minecraft:apply_bonus",
+                            "enchantment": "minecraft:fortune",
+                            "formula": "uniform_bonus_count",
+                            "parameters": { "bonusMultiplier": 3 }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Seems like we've fixed this a few times :D Not sure where it went.

Nuggets produced from Geodes are only from EE now and have been expanded to cover other base metal types from the overworld.

Resolves #2773