### PR TITLE
Re-add ingot to alloy heated mixing

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/mixing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/mixing.js
@@ -97,16 +97,32 @@ onEvent('recipes', (event) => {
                 output: Item.of('emendatusenigmatica:bronze_crushed', 4)
             },
             {
+                inputs: ['#forge:ingots/copper', '#forge:ingots/copper', '#forge:ingots/copper', '#forge:ingots/tin'],
+                output: Item.of('emendatusenigmatica:bronze_ingot', 4)
+            },
+            {
                 inputs: ['#create:crushed_ores/copper', '#create:crushed_ores/nickel'],
                 output: Item.of('emendatusenigmatica:constantan_crushed', 2)
+            },
+            {
+                inputs: ['#forge:ingots/copper', '#forge:ingots/nickel'],
+                output: Item.of('emendatusenigmatica:constantan_ingot', 2)
             },
             {
                 inputs: ['#create:crushed_ores/gold', '#create:crushed_ores/silver'],
                 output: Item.of('emendatusenigmatica:electrum_crushed', 2)
             },
             {
+                inputs: ['#forge:ingots/gold', '#forge:ingots/silver'],
+                output: Item.of('emendatusenigmatica:electrum_ingot', 2)
+            },
+            {
                 inputs: ['#create:crushed_ores/iron', '#create:crushed_ores/iron', '#create:crushed_ores/nickel'],
                 output: Item.of('emendatusenigmatica:invar_crushed', 3)
+            },
+            {
+                inputs: ['#forge:ingots/iron', '#forge:ingots/iron', '#forge:ingots/nickel'],
+                output: Item.of('emendatusenigmatica:invar_ingot', 3)
             },
             {
                 inputs: ['#forge:ingots/iron', '#forge:ingots/lead'],
@@ -150,6 +166,16 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
+                    '#forge:dusts/coal_coke',
+                    '#forge:ingots/iron',
+                    '#forge:ingots/iron',
+                    '#forge:ingots/iron',
+                    '#forge:ingots/iron'
+                ],
+                output: Item.of('emendatusenigmatica:steel_ingot', 4)
+            },
+            {
+                inputs: [
                     '#create:crushed_ores/copper',
                     '#create:crushed_ores/copper',
                     '#create:crushed_ores/copper',
@@ -160,6 +186,19 @@ onEvent('recipes', (event) => {
                     '#forge:dusts/redstone'
                 ],
                 output: Item.of('emendatusenigmatica:signalum_crushed', 4)
+            },
+            {
+                inputs: [
+                    '#forge:ingots/copper',
+                    '#forge:ingots/copper',
+                    '#forge:ingots/copper',
+                    '#forge:ingots/silver',
+                    '#forge:dusts/redstone',
+                    '#forge:dusts/redstone',
+                    '#forge:dusts/redstone',
+                    '#forge:dusts/redstone'
+                ],
+                output: Item.of('emendatusenigmatica:signalum_ingot', 4)
             },
             {
                 inputs: [
@@ -174,6 +213,17 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
+                    '#forge:ingots/tin',
+                    '#forge:ingots/tin',
+                    '#forge:ingots/tin',
+                    '#forge:ingots/silver',
+                    '#forge:dusts/glowstone',
+                    '#forge:dusts/glowstone'
+                ],
+                output: Item.of('emendatusenigmatica:lumium_ingot', 4)
+            },
+            {
+                inputs: [
                     '#create:crushed_ores/lead',
                     '#create:crushed_ores/lead',
                     '#create:crushed_ores/lead',
@@ -182,6 +232,17 @@ onEvent('recipes', (event) => {
                     '#forge:ender_pearls'
                 ],
                 output: Item.of('emendatusenigmatica:enderium_crushed', 2)
+            },
+            {
+                inputs: [
+                    '#forge:ingots/lead',
+                    '#forge:ingots/lead',
+                    '#forge:ingots/lead',
+                    '#forge:dusts/diamond',
+                    '#forge:ender_pearls',
+                    '#forge:ender_pearls'
+                ],
+                output: Item.of('emendatusenigmatica:enderium_ingot', 2)
             },
             {
                 inputs: ['#forge:ingots/netherite', 'betterendforge:terminite_ingot'],


### PR DESCRIPTION
Goofed this up. I thought Create's only way of making Brass was with the crushed ore. hadn't realized there was a recipe to mix ingots directly. So when I re-did the rest to use EE crushed ore, I broke the ingot recipes.

Fixed. Can now do either crushed ore or ingot to alloy.

Resolves: #2765