### PR TITLE
[Expert] Early game utility tweaks and some shuffling of items to keep them available at relevant progression points

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -228,6 +228,22 @@ onEvent('jei.information', (event) => {
         {
             items: ['quark:root_item'],
             description: ['Drops occasionally when breaking Cave Roots.']
+        },
+        {
+            items: ['meetyourfight:phantoplasm'],
+            description: ['Drops from the Bellringer. Craft a Haunted Bell to summon.']
+        },
+        {
+            items: ['meetyourfight:mossy_tooth'],
+            description: ['Drops from Swampjaw. Craft a Fossil Bait to summon.']
+        },
+        {
+            items: ['meetyourfight:fortunes_favor'],
+            description: [`Drops from Dame Fortuna. Craft a Devil's Ante to summon.`]
+        },
+        {
+            items: ['atum:ectoplasm'],
+            description: [`Drops from Wraiths in the sandy wastes of Atum.`]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -36,11 +36,6 @@ onEvent('recipes', (event) => {
                 pressure: 1.5,
                 output: [{ item: 'create:wheat_flour', count: 2 }],
                 id: 'wheat_flour'
-            },
-            {
-                ingredients: [{ type: 'pneumaticcraft:stacked_item', item: 'minecraft:snow_block', count: 4 }],
-                pressure: 2.0,
-                output: [{ item: 'betterendforge:dense_snow', count: 1 }]
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -39,7 +39,8 @@ onEvent('recipes', (event) => {
         { output: 'botania:mana_pylon', id: 'botania:mana_pylon' },
         { output: 'botania:natura_pylon', id: 'botania:natura_pylon' },
         { output: 'botania:gaia_pylon', id: 'mythicbotany:modified_gaia_pylon_with_alfsteel' },
-        { output: 'mythicbotany:alfsteel_pylon', id: 'mythicbotany:alfsteel_pylon' }
+        { output: 'mythicbotany:alfsteel_pylon', id: 'mythicbotany:alfsteel_pylon' },
+        { output: 'naturesaura:gold_brick', id: 'naturesaura:gold_brick' }
     ];
 
     idRemovals.forEach((id) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -40,7 +40,8 @@ onEvent('recipes', (event) => {
         { output: 'botania:natura_pylon', id: 'botania:natura_pylon' },
         { output: 'botania:gaia_pylon', id: 'mythicbotany:modified_gaia_pylon_with_alfsteel' },
         { output: 'mythicbotany:alfsteel_pylon', id: 'mythicbotany:alfsteel_pylon' },
-        { output: 'naturesaura:gold_brick', id: 'naturesaura:gold_brick' }
+        { output: 'naturesaura:gold_brick', id: 'naturesaura:gold_brick' },
+        { output: 'naturesaura:generator_limit_remover', id: 'naturesaura:generator_limit_remover' }
     ];
 
     idRemovals.forEach((id) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/book_upgrade.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/book_upgrade.js
@@ -21,7 +21,7 @@ onEvent('recipes', (event) => {
         {
             inputs: [
                 'ars_nouveau:apprentice_spell_book',
-                'minecraft:nether_star',
+                'minecraft:totem_of_undying',
                 '#forge:gems/amber',
                 '#forge:gems/amber',
                 '#forge:gems/amber',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/glyph_recipe.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/glyph_recipe.js
@@ -122,6 +122,12 @@ onEvent('recipes', (event) => {
             output: 'ars_nouveau:glyph_pickup',
             tier: 'ONE',
             id: 'ars_nouveau:glyph_pickup'
+        },
+        {
+            input: 'naturesaura:furnace_heater',
+            output: 'ars_nouveau:glyph_smelt',
+            tier: 'TWO',
+            id: 'ars_nouveau:glyph_smelt'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/petal_apothecary.js
@@ -99,6 +99,10 @@ onEvent('recipes', (event) => {
             ],
             output: { item: 'botania:gourmaryllis' },
             id: 'botania:petal_apothecary/gourmaryllis'
+        },
+        {
+            inputs: [{ item: 'minecraft:mossy_stone_bricks' }, { item: 'naturesaura:gold_fiber' }],
+            output: { item: 'naturesaura:gold_brick' }
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
@@ -84,6 +84,16 @@ onEvent('recipes', (event) => {
                 C: 'architects_palette:abyssaline'
             },
             id: 'botania:ender_eye_block'
+        },
+        {
+            output: 'botania:forest_eye',
+            pattern: ['ABA', 'BCB', 'ABA'],
+            key: {
+                A: '#forge:ingots/infused_iron',
+                B: 'naturesaura:infused_stone',
+                C: 'minecraft:ender_eye'
+            },
+            id: 'botania:forest_eye'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
@@ -15,17 +15,11 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
+                { tag: 'forge:ingots/terminite' },
                 { item: 'botania:mana_pearl' },
                 { item: 'resourcefulbees:terrestrial_honeycomb' },
-                { item: 'resourcefulbees:terrestrial_honeycomb' },
-                { item: 'resourcefulbees:terrestrial_honeycomb' },
                 { item: 'botania:mana_diamond' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
+                { tag: 'forge:ingots/iesnium' },
                 { item: 'botania:quartz_mana' }
             ],
             output: { item: 'botania:terrasteel_ingot' },
@@ -33,17 +27,11 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
+                { tag: 'forge:ingots/terminite' },
                 { item: 'botania:mana_pearl' },
-                { tag: 'forge:nuggets/manasteel' },
-                { tag: 'forge:nuggets/manasteel' },
-                { tag: 'forge:nuggets/manasteel' },
+                { tag: 'forge:ingots/manasteel' },
                 { item: 'botania:mana_diamond' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
+                { tag: 'forge:ingots/iesnium' },
                 { item: 'botania:quartz_mana' }
             ],
             output: { item: 'botania:terrasteel_ingot' },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
@@ -51,6 +51,23 @@ onEvent('recipes', (event) => {
             },
             consume_fluid: 1.0,
             id: 'ars_nouveau:mythical_clay'
+        },
+        {
+            inputs: [
+                { item: 'eidolon:enchanted_ash', count: 1 },
+                { item: 'atum:coin_gold', count: 6 },
+                { item: 'meetyourfight:phantoplasm', count: 1 },
+                { tag: 'forge:dusts/mana', count: 1 },
+                { tag: 'forge:dusts/lapis', count: 1 }
+            ],
+            fluid: { fluid: 'water' },
+            output: {
+                entries: [{ result: { item: 'meetyourfight:spectres_eye', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            },
+            consume_fluid: 1.0,
+            id: 'meetyourfight:spectres_eye'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -159,6 +159,20 @@ onEvent('recipes', (event) => {
                 rolls: 1
             },
             id: 'atum:scarab'
+        },
+        {
+            inputs: [
+                { item: 'minecraft:bell', count: 1 },
+                { item: 'atum:ectoplasm', count: 3 },
+                { tag: 'forge:dusts/fluorite', count: 1 },
+                { tag: 'atum:relic_non_dirty', count: 1 }
+            ],
+            output: {
+                entries: [{ result: { item: 'meetyourfight:haunted_bell', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            },
+            id: 'meetyourfight:haunted_bell'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -12,90 +12,80 @@ onEvent('recipes', (event) => {
             ],
             output: { item: 'resourcefulbees:terrestrial_bee_spawn_egg' },
             mana: 2000000,
-            fromColor: 255,
-            toColor: 65280
+            fromColor: parseInt('0xFFFFFF'),
+            toColor: parseInt('0x00FF00')
         },
         {
             inputs: [
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
+                { tag: 'forge:ingots/terminite' },
                 { item: 'botania:mana_pearl' },
                 { item: 'resourcefulbees:terrestrial_honeycomb' },
-                { item: 'resourcefulbees:terrestrial_honeycomb' },
-                { item: 'resourcefulbees:terrestrial_honeycomb' },
                 { item: 'botania:mana_diamond' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
+                { tag: 'forge:ingots/iesnium' },
                 { item: 'botania:quartz_mana' }
             ],
             output: { item: 'botania:terrasteel_ingot' },
             mana: 300000,
-            fromColor: 255,
-            toColor: 65280
+            fromColor: parseInt('0xFFFFFF'),
+            toColor: parseInt('0x00FF00')
         },
         {
             inputs: [
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
-                { tag: 'forge:nuggets/terminite' },
+                { tag: 'forge:ingots/terminite' },
                 { item: 'botania:mana_pearl' },
-                { tag: 'forge:nuggets/manasteel' },
-                { tag: 'forge:nuggets/manasteel' },
-                { tag: 'forge:nuggets/manasteel' },
+                { tag: 'forge:ingots/manasteel' },
                 { item: 'botania:mana_diamond' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
-                { tag: 'forge:nuggets/iesnium' },
+                { tag: 'forge:ingots/iesnium' },
                 { item: 'botania:quartz_mana' }
             ],
             output: { item: 'botania:terrasteel_ingot' },
             mana: 500000,
-            fromColor: 255,
-            toColor: 65280,
+            fromColor: parseInt('0xFFFFFF'),
+            toColor: parseInt('0x00FF00'),
             id: 'mythicbotany:mythicbotany_infusion/terrasteel_ingot'
         },
         {
             inputs: [
-                { tag: 'forge:nuggets/nebu' },
-                { tag: 'forge:nuggets/nebu' },
-                { tag: 'forge:nuggets/nebu' },
+                { tag: 'forge:ingots/nebu' },
                 { item: 'botania:pixie_dust' },
                 { item: 'resourcefulbees:elven_honeycomb' },
-                { item: 'resourcefulbees:elven_honeycomb' },
-                { item: 'resourcefulbees:elven_honeycomb' },
                 { item: 'botania:dragonstone' },
-                { tag: 'forge:nuggets/utherium' },
-                { tag: 'forge:nuggets/utherium' },
-                { tag: 'forge:nuggets/utherium' },
+                { tag: 'forge:ingots/utherium' },
                 { item: 'create:polished_rose_quartz' }
             ],
             output: { item: 'mythicbotany:alfsteel_ingot' },
             mana: 1500000,
-            fromColor: 16711821,
-            toColor: 16750080
+            fromColor: parseInt('0xFF008D'),
+            toColor: parseInt('0xFF9600')
         },
         {
             inputs: [
-                { tag: 'forge:nuggets/nebu' },
-                { tag: 'forge:nuggets/nebu' },
-                { tag: 'forge:nuggets/nebu' },
+                { tag: 'forge:ingots/nebu' },
                 { item: 'botania:pixie_dust' },
-                { tag: 'forge:nuggets/elementium' },
-                { tag: 'forge:nuggets/elementium' },
-                { tag: 'forge:nuggets/elementium' },
+                { tag: 'forge:ingots/elementium' },
                 { item: 'botania:dragonstone' },
-                { tag: 'forge:nuggets/utherium' },
-                { tag: 'forge:nuggets/utherium' },
-                { tag: 'forge:nuggets/utherium' },
+                { tag: 'forge:ingots/utherium' },
                 { item: 'create:polished_rose_quartz' }
             ],
             output: { item: 'mythicbotany:alfsteel_ingot' },
             mana: 2000000,
-            fromColor: 16711821,
-            toColor: 16750080,
+            fromColor: parseInt('0xFF008D'),
+            toColor: parseInt('0xFF9600'),
             id: 'mythicbotany:mythicbotany_infusion/alfsteel_ingot'
+        },
+        {
+            inputs: [
+                { item: 'naturesaura:infused_stone' },
+                { item: 'naturesaura:token_euphoria' },
+                { item: 'naturesaura:token_rage' },
+                { tag: 'forge:ingots/infused_iron' },
+                { item: 'naturesaura:token_grief' },
+                { item: 'naturesaura:token_terror' }
+            ],
+            output: { item: 'naturesaura:generator_limit_remover' },
+            mana: 2000000,
+            fromColor: parseInt('0xFF9900'),
+            toColor: parseInt('0x00FF1A')
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/altar.js
@@ -56,7 +56,6 @@ onEvent('recipes', (event) => {
                 input: 'minecraft:vine',
                 output: 'quark:root',
                 aura_type: 'naturesaura:nether',
-                catalyst: 'naturesaura:conversion_catalyst',
                 aura: 30000,
                 time: 250
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
@@ -66,6 +66,38 @@ onEvent('recipes', (event) => {
                 C: 'minecraft:lodestone'
             },
             id: 'naturesaura:hopper_upgrade'
+        },
+        {
+            output: 'naturesaura:aura_cache',
+            pattern: ['BAB', 'ACA', 'BAB'],
+            key: {
+                A: '#forge:ingots/infused_iron',
+                B: 'naturesaura:infused_stone',
+                C: 'resourcefulbees:wooden_honey_tank'
+            },
+            id: 'naturesaura:aura_cache'
+        },
+        {
+            output: 'naturesaura:animal_container',
+            pattern: ['ABA', 'CDC', 'DDD'],
+            key: {
+                A: '#resourcefulbees:resourceful_honeycomb',
+                B: 'botania:forest_eye',
+                C: '#forge:crops',
+                D: 'naturesaura:infused_brick'
+            },
+            id: 'naturesaura:animal_container'
+        },
+        {
+            output: 'naturesaura:aura_detector',
+            pattern: ['ADA', 'DBD', 'ACA'],
+            key: {
+                A: 'naturesaura:infused_stone',
+                B: 'botania:forest_eye',
+                C: 'botania:redstone_root',
+                D: '#forge:ingots/infused_iron'
+            },
+            id: 'naturesaura:aura_detector'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
@@ -98,6 +98,16 @@ onEvent('recipes', (event) => {
                 D: '#forge:ingots/infused_iron'
             },
             id: 'naturesaura:aura_detector'
+        },
+        {
+            output: 'naturesaura:placer',
+            pattern: ['ACA', 'ABA', 'ACA'],
+            key: {
+                A: 'undergarden:tremblecrust',
+                B: 'botania:corporea_funnel',
+                C: '#forge:ingots/infused_iron'
+            },
+            id: 'naturesaura:placer'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
@@ -36,6 +36,36 @@ onEvent('recipes', (event) => {
                 E: 'naturesaura:ancient_bark'
             },
             id: 'naturesaura:offering_table'
+        },
+        {
+            output: Item.of('naturesaura:field_creator', 2),
+            pattern: ['AAA', 'ACA', 'ABA'],
+            key: {
+                A: 'atum:crystal_glass',
+                B: 'naturesaura:token_anger',
+                C: 'botania:corporea_block'
+            },
+            id: 'naturesaura:field_creator'
+        },
+        {
+            output: 'naturesaura:pickup_stopper',
+            pattern: ['CAC', 'CBC', 'CAC'],
+            key: {
+                A: '#forge:ingots/infused_iron',
+                B: '#forge:storage_blocks/lead',
+                C: 'naturesaura:gold_brick'
+            },
+            id: 'naturesaura:pickup_stopper'
+        },
+        {
+            output: 'naturesaura:hopper_upgrade',
+            pattern: ['BAB', 'ACA', 'BAB'],
+            key: {
+                A: '#forge:ingots/infused_iron',
+                B: '#forge:plates/lead',
+                C: 'minecraft:lodestone'
+            },
+            id: 'naturesaura:hopper_upgrade'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
@@ -103,7 +103,7 @@ onEvent('recipes', (event) => {
             output: 'naturesaura:placer',
             pattern: ['ACA', 'ABA', 'ACA'],
             key: {
-                A: 'undergarden:tremblecrust',
+                A: 'naturesaura:gold_brick',
                 B: 'botania:corporea_funnel',
                 C: '#forge:ingots/infused_iron'
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -289,6 +289,38 @@ onEvent('recipes', (event) => {
                 count: 1,
                 sapling: 'minecraft:oak_sapling',
                 id: 'resourcefulbees:t3_apiary'
+            },
+            {
+                inputs: [
+                    { item: 'meetyourfight:spectres_eye' }, //top
+                    { tag: 'forge:ingots/silver' }, //bottom
+                    { item: 'naturesaura:gold_leaf' }, //left
+                    { item: 'naturesaura:gold_leaf' }, //right
+                    { item: 'farmersdelight:tree_bark' }, //topleft
+                    { item: 'farmersdelight:tree_bark' }, //bottomright
+                    { item: 'farmersdelight:tree_bark' }, //topright
+                    { item: 'farmersdelight:tree_bark' } //bottomleft
+                ],
+                output: 'naturesaura:eye',
+                count: 1,
+                sapling: 'byg:blue_enchanted_sapling',
+                id: 'naturesaura:tree_ritual/eye'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:eye' }, //top
+                    { tag: 'forge:ingots/sky' }, //bottom
+                    { tag: 'forge:ingots/sky' }, //left
+                    { item: 'naturesaura:end_flower' }, //right
+                    { item: 'naturesaura:gold_leaf' }, //topleft
+                    { item: 'naturesaura:gold_leaf' }, //bottomright
+                    { item: 'botania:lens_normal' }, //topright
+                    { item: 'upgrade_aquatic:elder_eye' } //bottomleft
+                ],
+                output: 'naturesaura:eye_improved',
+                count: 1,
+                sapling: 'byg:blue_enchanted_sapling',
+                id: 'naturesaura:tree_ritual/eye_improved'
             }
             /*
             ,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -321,6 +321,33 @@ onEvent('recipes', (event) => {
                 count: 1,
                 sapling: 'byg:blue_enchanted_sapling',
                 id: 'naturesaura:tree_ritual/eye_improved'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_brick' }, //top
+                    { item: 'naturesaura:infused_stone' }, //bottom
+                    { item: 'botania:brewery' }, //left
+                    { tag: 'forge:ingots/sky' }, //right
+                    { item: 'naturesaura:gold_leaf' }, //topleft
+                    { item: 'eidolon:gold_inlay' } //bottomright
+                ],
+                output: 'naturesaura:conversion_catalyst',
+                count: 1,
+                sapling: 'architects_palette:twisted_sapling',
+                id: 'naturesaura:tree_ritual/conversion_catalyst'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_brick' }, //top
+                    { item: 'naturesaura:infused_stone' }, //bottom
+                    { tag: 'forge:ingots/andesite_alloy' }, //left
+                    { tag: 'forge:ingots/andesite_alloy' }, //right
+                    { item: 'naturesaura:token_anger' } //topleft
+                ],
+                output: 'naturesaura:crushing_catalyst',
+                count: 1,
+                sapling: 'undergarden:wigglewood_sapling',
+                id: 'naturesaura:tree_ritual/crushing_catalyst'
             }
             /*
             ,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/pressure_chamber.js
@@ -6,51 +6,34 @@ onEvent('recipes', (event) => {
     const recipes = [
         {
             inputs: [
-                {
-                    tag: 'forge:gems/coal_coke',
-                    count: 2
-                },
-                {
-                    tag: 'forge:ingots/iron',
-                    count: 4
-                },
-                {
-                    tag: 'forge:obsidian',
-                    count: 1
-                }
+                { type: 'pneumaticcraft:stacked_item', tag: 'forge:gems/coal_coke', count: 2 },
+                { type: 'pneumaticcraft:stacked_item', tag: 'forge:ingots/iron', count: 4 },
+                { type: 'pneumaticcraft:stacked_item', tag: 'forge:obsidian', count: 1 }
             ],
             pressure: 2.0,
-            results: [
-                {
-                    item: 'pneumaticcraft:ingot_iron_compressed',
-                    count: 4
-                }
-            ],
+            results: [{ type: 'pneumaticcraft:stacked_item', item: 'pneumaticcraft:ingot_iron_compressed', count: 4 }],
             id: 'pneumaticcraft:pressure_chamber/compressed_iron_ingot'
         },
         {
             inputs: [
-                {
-                    tag: 'forge:storage_blocks/coal_coke',
-                    count: 2
-                },
-                {
-                    tag: 'forge:storage_blocks/iron',
-                    count: 4
-                },
-                {
-                    tag: 'forge:obsidian',
-                    count: 9
-                }
+                { type: 'pneumaticcraft:stacked_item', tag: 'forge:storage_blocks/coal_coke', count: 2 },
+                { type: 'pneumaticcraft:stacked_item', tag: 'forge:storage_blocks/iron', count: 4 },
+                { type: 'pneumaticcraft:stacked_item', tag: 'forge:obsidian', count: 9 }
             ],
             pressure: 2.0,
-            results: [
-                {
-                    item: 'pneumaticcraft:compressed_iron_block',
-                    count: 4
-                }
-            ],
+            results: [{ type: 'pneumaticcraft:stacked_item', item: 'pneumaticcraft:compressed_iron_block', count: 4 }],
             id: 'pneumaticcraft:pressure_chamber/compressed_iron_block'
+        },
+        {
+            inputs: [{ type: 'pneumaticcraft:stacked_item', item: 'minecraft:snow_block', count: 4 }],
+            pressure: 1.5,
+            results: [{ item: 'betterendforge:dense_snow', count: 1 }]
+        },
+        {
+            inputs: [{ type: 'pneumaticcraft:stacked_item', item: 'betterendforge:dense_snow', count: 4 }],
+            pressure: 1.5,
+            results: [{ item: 'minecraft:ice', count: 1 }],
+            id: 'pneumaticcraft:pressure_chamber/ice'
         }
     ];
 


### PR DESCRIPTION
Re-arranging early items
As rare items go, the totem probably is more interesting to obtain. Reverting to it from nether star for Tier 3 spell book
![image](https://user-images.githubusercontent.com/9543430/126578922-45fe21f8-5d56-438e-a7a0-57f0243d2aaf.png)

Aura Field Generators can be crafted earlier:
![image](https://user-images.githubusercontent.com/9543430/126582752-8e995f9f-8c94-4f32-9690-70efe5570f7b.png)

Item Grounder:
![image](https://user-images.githubusercontent.com/9543430/126585889-eba86564-24d0-4bd8-b2ab-1da6ba8a04db.png)

Golden Stone Bricks:
![image](https://user-images.githubusercontent.com/9543430/126585942-de00bb91-0c5c-4324-9956-5cc69d45f953.png)

Smelt Glyph now depends on NA:
![image](https://user-images.githubusercontent.com/9543430/126586775-f43d864e-fd18-4024-a432-1de5d9c94851.png)

Hopper Enhancement - early ranged pickup
![image](https://user-images.githubusercontent.com/9543430/126587385-e7f85ed8-c959-494b-a3c2-fc1ecf3a4831.png)

Add descriptions to help with obtaining Meet your Fight items.

Haunted Bell for Meet your Fight. Any cleaned relic from Atum.
![image](https://user-images.githubusercontent.com/9543430/126650093-a239c751-9c90-4f26-9b87-59084a41c648.png)

Spectres Eye:
![image](https://user-images.githubusercontent.com/9543430/126653621-cba442ef-e6d3-463c-8dbe-2dcfd9fe0559.png)

Environmental Eye
![image](https://user-images.githubusercontent.com/9543430/126643419-5baf0f6d-552b-486b-8162-9f6eed7087f1.png)

Environmental Ocular
![image](https://user-images.githubusercontent.com/9543430/126647053-06159ae6-9ca4-4f18-ab98-50714952a8ea.png)

Corporeal Eye. Any #forge:crop and any comb
![image](https://user-images.githubusercontent.com/9543430/126676556-631bd9b3-6779-4434-8a37-5ddb7d558ead.png)

Eye of Ancients:
![image](https://user-images.githubusercontent.com/9543430/126676623-4ad15f58-8a7f-48c6-98f4-38d91ab5ab30.png)

Aura Detector:
![image](https://user-images.githubusercontent.com/9543430/126678438-d3aedb84-beeb-4f5d-873c-559ab7676c16.png)

Snow to Dense snow
![image](https://user-images.githubusercontent.com/9543430/126708225-ee172623-c4f6-453d-90fd-60fd169279aa.png)

Dense snow to ice
![image](https://user-images.githubusercontent.com/9543430/126708303-a7283ce0-6e7d-4543-abe0-5aa4262ff3c1.png)

Also fixes stacked recipes in Pressure Chamber

Nugget recipes for terrasteel and alfsteel don't work. much sads. stackable items are a no-go. So it's back to ingots and more expensive recipes.
![image](https://user-images.githubusercontent.com/9543430/126725311-fc999bdf-f796-4810-b62b-21f55d12a765.png)

Creational Catalyst moved to mana infuser:
![image](https://user-images.githubusercontent.com/9543430/126725351-846b44c6-0975-4aaf-a304-d70f49bd9a89.png)

Remove Transmutation Catalyst from Root recipe, since that made it unobtainable
![image](https://user-images.githubusercontent.com/9543430/126726735-80c18288-fe23-4e11-af13-07eb6c9154b7.png)

Transmutation Catalyst:
![image](https://user-images.githubusercontent.com/9543430/126727580-e5ceec61-8c53-4773-8fae-ee8069d53248.png)

Crumbling Catalyst:
![image](https://user-images.githubusercontent.com/9543430/126728117-27030b44-1f81-4e89-a15e-6247195c32e5.png)

Imperceptible Builder:
![image](https://user-images.githubusercontent.com/9543430/126729000-6e6dc43e-caa2-4028-9487-5bcd8a7ccdbc.png)
