### PR TITLE
Nature's Aura Recipe Overhaul

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -16,8 +16,8 @@ onEvent('recipes', (event) => {
                     { item: 'thermal:earth_charge' },
                     { item: 'minecraft:fire_charge' }
                 ],
-                output: 'naturesaura:nature_altar',
-                count: 1,
+                output: { item: 'naturesaura:nature_altar' },
+                time: 500,
                 sapling: 'quark:yellow_blossom_sapling',
                 id: 'naturesaura:tree_ritual/nature_altar'
             },
@@ -37,8 +37,8 @@ onEvent('recipes', (event) => {
                     { item: 'architects_palette:sunmetal_blend' },
                     { item: 'botania:pink_shiny_flower' }
                 ],
-                output: 'naturesaura:token_joy',
-                count: 2,
+                output: { item: 'naturesaura:token_joy', count: 2 },
+                time: 200,
                 sapling: 'quark:yellow_blossom_sapling',
                 id: 'naturesaura:tree_ritual/token_joy'
             },
@@ -58,8 +58,8 @@ onEvent('recipes', (event) => {
                     { item: 'astralsorcery:nocturnal_powder' },
                     { item: 'upgrade_aquatic:thrasher_tooth' }
                 ],
-                output: 'naturesaura:token_fear',
-                count: 2,
+                output: { item: 'naturesaura:token_fear', count: 2 },
+                time: 200,
                 sapling: 'architects_palette:twisted_sapling',
                 id: 'naturesaura:tree_ritual/token_fear'
             },
@@ -74,8 +74,8 @@ onEvent('recipes', (event) => {
                     { item: 'alexsmobs:komodo_spit' },
                     { item: 'powah:charged_snowball' }
                 ],
-                output: 'naturesaura:token_anger',
-                count: 2,
+                output: { item: 'naturesaura:token_anger', count: 2 },
+                time: 200,
                 sapling: 'quark:red_blossom_sapling',
                 id: 'naturesaura:tree_ritual/token_anger'
             },
@@ -95,8 +95,8 @@ onEvent('recipes', (event) => {
                     { item: 'minecraft:ghast_tear' },
                     { item: 'botania:black_shiny_flower' }
                 ],
-                output: 'naturesaura:token_sorrow',
-                count: 2,
+                output: { item: 'naturesaura:token_sorrow', count: 2 },
+                time: 200,
                 sapling: 'byg:joshua_sapling',
                 id: 'naturesaura:tree_ritual/token_sorrow'
             },
@@ -111,8 +111,8 @@ onEvent('recipes', (event) => {
                     { item: 'thermal:phytogro' }, //topright
                     { item: 'botania:livingwood' } //bottomleft
                 ],
-                output: 'naturesaura:oak_generator',
-                count: 1,
+                output: { item: 'naturesaura:oak_generator' },
+                time: 600,
                 sapling: 'quark:yellow_blossom_sapling',
                 id: 'naturesaura:oak_generator'
             },
@@ -127,8 +127,8 @@ onEvent('recipes', (event) => {
                     { tag: 'forge:ingots/nether_brick' }, //topright
                     { item: 'minecraft:soul_sand' } //bottomleft
                 ],
-                output: 'naturesaura:animal_generator',
-                count: 1,
+                output: { item: 'naturesaura:animal_generator' },
+                time: 600,
                 sapling: 'quark:blue_blossom_sapling',
                 id: 'naturesaura:animal_generator'
             },
@@ -143,8 +143,8 @@ onEvent('recipes', (event) => {
                     { item: 'minecraft:firework_rocket' }, //topright
                     { item: 'naturesaura:token_rage' } //bottomleft
                 ],
-                output: 'naturesaura:firework_generator',
-                count: 1,
+                output: { item: 'naturesaura:firework_generator' },
+                time: 600,
                 sapling: 'quark:blue_blossom_sapling',
                 id: 'naturesaura:firework_generator'
             },
@@ -159,8 +159,8 @@ onEvent('recipes', (event) => {
                     { item: 'botania:livingwood' }, //topright
                     { item: 'botania:livingwood' } //bottomleft
                 ],
-                output: 'naturesaura:flower_generator',
-                count: 1,
+                output: { item: 'naturesaura:flower_generator' },
+                time: 600,
                 sapling: 'quark:yellow_blossom_sapling',
                 id: 'naturesaura:flower_generator'
             },
@@ -175,8 +175,8 @@ onEvent('recipes', (event) => {
                     { tag: 'forge:ingots/nether_brick' }, //topright
                     { item: 'naturesaura:token_joy' } //bottomleft
                 ],
-                output: 'naturesaura:slime_split_generator',
-                count: 1,
+                output: { item: 'naturesaura:slime_split_generator' },
+                time: 600,
                 sapling: 'quark:lavender_blossom_sapling',
                 id: 'naturesaura:slime_split_generator'
             },
@@ -191,8 +191,8 @@ onEvent('recipes', (event) => {
                     { item: 'integratedterminals:chorus_glass' }, //topright
                     { item: 'naturesaura:token_rage' } //bottomleft
                 ],
-                output: 'naturesaura:chorus_generator',
-                count: 1,
+                output: { item: 'naturesaura:chorus_generator' },
+                time: 600,
                 sapling: 'architects_palette:twisted_sapling',
                 id: 'naturesaura:chorus_generator'
             },
@@ -207,8 +207,8 @@ onEvent('recipes', (event) => {
                     { item: 'eidolon:fungus_sprouts' }, //topright
                     { tag: 'forge:ingots/nether_brick' } //bottomleft
                 ],
-                output: 'naturesaura:potion_generator',
-                count: 1,
+                output: { item: 'naturesaura:potion_generator' },
+                time: 600,
                 sapling: 'quark:lavender_blossom_sapling',
                 id: 'naturesaura:potion_generator'
             },
@@ -223,8 +223,8 @@ onEvent('recipes', (event) => {
                     { item: 'botania:mossy_livingwood_planks' }, //topright
                     { item: 'botania:mossy_livingwood_planks' } //bottomleft
                 ],
-                output: 'naturesaura:moss_generator',
-                count: 1,
+                output: { item: 'naturesaura:moss_generator' },
+                time: 600,
                 sapling: 'architects_palette:twisted_sapling',
                 id: 'naturesaura:moss_generator'
             },
@@ -239,8 +239,8 @@ onEvent('recipes', (event) => {
                     { item: 'rsgauges:arrow_target' }, //topright
                     { item: 'naturesaura:token_anger' } //bottomleft
                 ],
-                output: 'naturesaura:projectile_generator',
-                count: 1,
+                output: { item: 'naturesaura:projectile_generator' },
+                time: 600,
                 sapling: 'quark:yellow_blossom_sapling',
                 id: 'naturesaura:projectile_generator'
             },
@@ -255,8 +255,8 @@ onEvent('recipes', (event) => {
                     { item: 'astralsorcery:rock_crystal' }, //topright
                     { tag: 'forge:ingots/starmetal' } //bottomleft
                 ],
-                output: 'naturesstarlight:crystal_generator',
-                count: 1,
+                output: { item: 'naturesstarlight:crystal_generator' },
+                time: 600,
                 sapling: 'quark:lavender_blossom_sapling',
                 id: 'naturesstarlight:crystal_generator'
             },
@@ -269,8 +269,8 @@ onEvent('recipes', (event) => {
                     { item: 'minecraft:conduit' }, //topleft
                     { item: 'botania:livingrock' } //bottomright
                 ],
-                output: 'botania:runic_altar',
-                count: 1,
+                output: { item: 'botania:runic_altar' },
+                time: 600,
                 sapling: 'quark:lavender_blossom_sapling',
                 id: 'botania:runic_altar'
             },
@@ -285,9 +285,9 @@ onEvent('recipes', (event) => {
                     { item: 'resourcefulbees:honey_fluid_bucket' }, //topright
                     { item: 'resourcefulbees:honey_fluid_bucket' } //bottomleft
                 ],
-                output: 'resourcefulbees:t3_apiary',
-                count: 1,
-                sapling: 'minecraft:oak_sapling',
+                output: { item: 'resourcefulbees:t3_apiary' },
+                time: 300,
+                sapling: 'quark:yellow_blossom_sapling',
                 id: 'resourcefulbees:t3_apiary'
             },
             {
@@ -301,8 +301,8 @@ onEvent('recipes', (event) => {
                     { item: 'farmersdelight:tree_bark' }, //topright
                     { item: 'farmersdelight:tree_bark' } //bottomleft
                 ],
-                output: 'naturesaura:eye',
-                count: 1,
+                output: { item: 'naturesaura:eye' },
+                time: 250,
                 sapling: 'byg:blue_enchanted_sapling',
                 id: 'naturesaura:tree_ritual/eye'
             },
@@ -317,8 +317,8 @@ onEvent('recipes', (event) => {
                     { item: 'botania:lens_normal' }, //topright
                     { item: 'upgrade_aquatic:elder_eye' } //bottomleft
                 ],
-                output: 'naturesaura:eye_improved',
-                count: 1,
+                output: { item: 'naturesaura:eye_improved' },
+                time: 500,
                 sapling: 'byg:blue_enchanted_sapling',
                 id: 'naturesaura:tree_ritual/eye_improved'
             },
@@ -331,8 +331,8 @@ onEvent('recipes', (event) => {
                     { item: 'naturesaura:gold_leaf' }, //topleft
                     { item: 'eidolon:gold_inlay' } //bottomright
                 ],
-                output: 'naturesaura:conversion_catalyst',
-                count: 1,
+                output: { item: 'naturesaura:conversion_catalyst' },
+                time: 600,
                 sapling: 'architects_palette:twisted_sapling',
                 id: 'naturesaura:tree_ritual/conversion_catalyst'
             },
@@ -344,10 +344,130 @@ onEvent('recipes', (event) => {
                     { tag: 'forge:ingots/andesite_alloy' }, //right
                     { item: 'naturesaura:token_anger' } //topleft
                 ],
-                output: 'naturesaura:crushing_catalyst',
-                count: 1,
+                output: { item: 'naturesaura:crushing_catalyst' },
+                time: 600,
                 sapling: 'undergarden:wigglewood_sapling',
                 id: 'naturesaura:tree_ritual/crushing_catalyst'
+            },
+
+            // Recipes below this point have not yet been expertified. To Do.
+            {
+                inputs: [
+                    { tag: 'minecraft:saplings' },
+                    { item: 'minecraft:dandelion' },
+                    { item: 'minecraft:poppy' },
+                    { item: 'minecraft:wheat_seeds' },
+                    { item: 'minecraft:sugar_cane' },
+                    { item: 'naturesaura:gold_leaf' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:ancient_sapling', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/ancient_sapling'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:infused_stone' },
+                    { item: 'naturesaura:infused_stone' },
+                    { tag: 'forge:ingots/tainted_gold' },
+                    { tag: 'forge:ingots/infused_iron' },
+                    { item: 'minecraft:fire_charge' },
+                    { item: 'minecraft:flint' },
+                    { item: 'minecraft:magma_block' },
+                    { item: 'naturesaura:token_fear' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:furnace_heater' },
+                time: 600,
+                id: 'naturesaura:tree_ritual/furnace_heater'
+            },
+            {
+                inputs: [
+                    { item: 'minecraft:diamond' },
+                    { tag: 'forge:ingots/tainted_gold' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:token_fear' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:break_prevention' },
+                time: 200,
+                id: 'naturesaura:tree_ritual/break_prevention'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:aura_cache' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:cache_recharge' }, item: 'naturesaura:effect_powder', count: 32 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/cache_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'minecraft:egg' }
+                ],
+                sapling: 'quark:lavender_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:animal' }, item: 'naturesaura:effect_powder', count: 8 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/animal_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'minecraft:wheat' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:plant_boost' }, item: 'naturesaura:effect_powder', count: 24 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/plant_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ores/diamond' },
+                    { tag: 'forge:ores/redstone' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:ore_spawn' }, item: 'naturesaura:effect_powder', count: 4 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/ore_spawn_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'minecraft:netherrack' },
+                    { item: 'minecraft:grass' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:nether_grass' }, item: 'naturesaura:effect_powder', count: 24 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/nether_grass_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'astralsorcery:illumination_powder' },
+                    { item: 'astralsorcery:aquamarine' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: {
+                    nbt: { effect: 'naturesstarlight:starlight_increase' },
+                    item: 'naturesaura:effect_powder',
+                    count: 8
+                },
+                time: 400,
+                id: 'naturesstarlight:tree_ritual/starlight_increase_powder'
             }
             /*
             ,
@@ -376,8 +496,8 @@ onEvent('recipes', (event) => {
             type: 'naturesaura:tree_ritual',
             ingredients: recipe.inputs,
             sapling: { item: recipe.sapling },
-            output: { item: recipe.output, count: recipe.count },
-            time: 500
+            output: recipe.output,
+            time: recipe.time
         });
         if (recipe.id) {
             re.id(recipe.id);

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/naturesaura/tree_ritual.js
@@ -1,0 +1,293 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const data = {
+        recipes: [
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_brick' },
+                    { item: 'naturesaura:infused_stone' },
+                    { item: 'minecraft:brewing_stand' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:gold_leaf' },
+                    { item: 'minecraft:glowstone' }
+                ],
+                sapling: 'quark:lavender_blossom_sapling',
+                output: { item: 'naturesaura:conversion_catalyst' },
+                time: 600,
+                id: 'naturesaura:tree_ritual/conversion_catalyst'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_brick' },
+                    { item: 'naturesaura:infused_stone' },
+                    { item: 'minecraft:piston' },
+                    { item: 'minecraft:flint' },
+                    { item: 'naturesaura:token_anger' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:crushing_catalyst' },
+                time: 600,
+                id: 'naturesaura:tree_ritual/crushing_catalyst'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:aura_cache' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:cache_recharge' }, item: 'naturesaura:effect_powder', count: 32 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/cache_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'minecraft:egg' }
+                ],
+                sapling: 'quark:lavender_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:animal' }, item: 'naturesaura:effect_powder', count: 8 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/animal_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'minecraft:wheat' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:plant_boost' }, item: 'naturesaura:effect_powder', count: 24 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/plant_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ores/diamond' },
+                    { tag: 'forge:ores/redstone' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:ore_spawn' }, item: 'naturesaura:effect_powder', count: 4 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/ore_spawn_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'minecraft:netherrack' },
+                    { item: 'minecraft:grass' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:nether_grass' }, item: 'naturesaura:effect_powder', count: 24 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/nether_grass_powder'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'astralsorcery:illumination_powder' },
+                    { item: 'astralsorcery:aquamarine' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: {
+                    nbt: { effect: 'naturesstarlight:starlight_increase' },
+                    item: 'naturesaura:effect_powder',
+                    count: 8
+                },
+                time: 400,
+                id: 'naturesstarlight:tree_ritual/starlight_increase_powder'
+            },
+            {
+                inputs: [
+                    { item: 'minecraft:diamond' },
+                    { tag: 'forge:ingots/tainted_gold' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:token_fear' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:break_prevention' },
+                time: 200,
+                id: 'naturesaura:tree_ritual/break_prevention'
+            },
+            {
+                inputs: [
+                    { tag: 'minecraft:saplings' },
+                    { item: 'minecraft:dandelion' },
+                    { item: 'minecraft:poppy' },
+                    { item: 'minecraft:wheat_seeds' },
+                    { item: 'minecraft:sugar_cane' },
+                    { item: 'naturesaura:gold_leaf' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:ancient_sapling', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/ancient_sapling'
+            },
+            {
+                inputs: [
+                    {
+                        type: 'forge:nbt',
+                        item: 'naturesaura:aura_bottle',
+                        count: 1,
+                        nbt: '{stored_type:"naturesaura:overworld"}'
+                    },
+                    { item: 'naturesaura:gold_leaf' },
+                    { item: 'minecraft:ghast_tear' },
+                    [
+                        { item: 'minecraft:beef' },
+                        { item: 'minecraft:mutton' },
+                        { item: 'minecraft:chicken' },
+                        { item: 'minecraft:porkchop' },
+                        { item: 'minecraft:rabbit' },
+                        { item: 'simplefarming:raw_horse_meat' },
+                        { item: 'environmental:venison' },
+                        { item: 'environmental:duck' }
+                    ],
+                    { item: 'minecraft:glass' },
+                    { tag: 'minecraft:fishes' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:token_sorrow', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/token_sorrow'
+            },
+            {
+                inputs: [
+                    {
+                        type: 'forge:nbt',
+                        item: 'naturesaura:aura_bottle',
+                        count: 1,
+                        nbt: '{stored_type:"naturesaura:overworld"}'
+                    },
+                    { item: 'naturesaura:gold_leaf' },
+                    { tag: 'minecraft:small_flowers' },
+                    { item: 'minecraft:apple' },
+                    { item: 'minecraft:torch' },
+                    { tag: 'forge:ingots/iron' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:token_joy', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/token_joy'
+            },
+            {
+                inputs: [
+                    {
+                        type: 'forge:nbt',
+                        item: 'naturesaura:aura_bottle',
+                        count: 1,
+                        nbt: '{stored_type:"naturesaura:nether"}'
+                    },
+                    { item: 'naturesaura:gold_leaf' },
+                    { item: 'minecraft:rotten_flesh' },
+                    { item: 'minecraft:feather' },
+                    { item: 'minecraft:bone' },
+                    { item: 'minecraft:soul_sand' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:token_fear', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/token_fear'
+            },
+            {
+                inputs: [
+                    {
+                        type: 'forge:nbt',
+                        item: 'naturesaura:aura_bottle',
+                        count: 1,
+                        nbt: '{stored_type:"naturesaura:nether"}'
+                    },
+                    { item: 'naturesaura:gold_leaf' },
+                    { item: 'minecraft:magma_block' },
+                    { item: 'minecraft:blaze_powder' },
+                    { item: 'minecraft:gunpowder' },
+                    { item: 'minecraft:ender_pearl' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:token_anger', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/token_anger'
+            },
+            {
+                inputs: [
+                    { item: 'minecraft:stone' },
+                    { item: 'minecraft:stone' },
+                    { item: 'minecraft:stone' },
+                    { item: 'naturesaura:gold_leaf' },
+                    { tag: 'forge:ingots/gold' },
+                    { item: 'naturesaura:token_joy' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:nature_altar' },
+                time: 500,
+                id: 'naturesaura:tree_ritual/nature_altar'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:infused_stone' },
+                    { item: 'naturesaura:infused_stone' },
+                    { tag: 'forge:ingots/tainted_gold' },
+                    { tag: 'forge:ingots/infused_iron' },
+                    { item: 'minecraft:fire_charge' },
+                    { item: 'minecraft:flint' },
+                    { item: 'minecraft:magma_block' },
+                    { item: 'naturesaura:token_fear' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:furnace_heater' },
+                time: 600,
+                id: 'naturesaura:tree_ritual/furnace_heater'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:eye' },
+                    { tag: 'forge:ingots/sky' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:end_flower' },
+                    { item: 'naturesaura:gold_leaf' },
+                    { item: 'naturesaura:gold_leaf' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:eye_improved' },
+                time: 500,
+                id: 'naturesaura:tree_ritual/eye_improved'
+            },
+            {
+                inputs: [
+                    { item: 'minecraft:spider_eye' },
+                    { tag: 'forge:ingots/gold' },
+                    { item: 'naturesaura:gold_leaf' },
+                    { item: 'naturesaura:gold_leaf' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { item: 'naturesaura:eye' },
+                time: 250,
+                id: 'naturesaura:tree_ritual/eye'
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.custom({
+            type: 'naturesaura:tree_ritual',
+            ingredients: recipe.inputs,
+            sapling: { item: recipe.sapling },
+            output: recipe.output,
+            time: recipe.time
+        });
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});


### PR DESCRIPTION
Oak trees consistently grow in ways that NA cannot detect, leading to frustrating failures about a quarter of the time...

Quark saplings do not have this issue. So all recipes have been re-written to use them instead as the growth catalyst. Figure they're abundantly available, so shouldn't cause a big issue for people getting into the mod. Lemme know if you'd prefer different trees though.

Also expands a few recipes either allowing tags where not previously supported, or allowing extra item types (expanded meats for Token of Sorrow).

Also reworks all Expert recipes so they have differing completion times.