### PR TITLE
[Expert] Magic Tuning

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -254,6 +254,19 @@ onEvent('recipes', (event) => {
                 syphon: 200,
                 ticks: 200,
                 orbLevel: 1
+            },
+            {
+                inputs: [
+                    'aquaculture:fish_bones',
+                    '#forge:dusts/lapis',
+                    'minecraft:fermented_spider_eye',
+                    'undergarden:raw_dweller_meat'
+                ],
+                output: 'meetyourfight:fossil_bait',
+                count: 1,
+                syphon: 1000,
+                ticks: 200,
+                orbLevel: 2
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -59,7 +59,7 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                { item: 'undergarden:music_disc_relict', count: 1, return_chance: 1.0 },
+                { item: 'undergarden:music_disc_relict', count: 1 },
                 { item: 'aquaculture:fish_bones', count: 1 },
                 { tag: 'forge:dusts/lapis', count: 2 },
                 { item: 'minecraft:fermented_spider_eye', count: 2 },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -349,22 +349,6 @@ onEvent('recipes', (event) => {
                 sapling: 'undergarden:wigglewood_sapling',
                 id: 'naturesaura:tree_ritual/crushing_catalyst'
             },
-
-            // Recipes below this point have not yet been expertified. To Do.
-            {
-                inputs: [
-                    { tag: 'minecraft:saplings' },
-                    { item: 'minecraft:dandelion' },
-                    { item: 'minecraft:poppy' },
-                    { item: 'minecraft:wheat_seeds' },
-                    { item: 'minecraft:sugar_cane' },
-                    { item: 'naturesaura:gold_leaf' }
-                ],
-                sapling: 'quark:yellow_blossom_sapling',
-                output: { item: 'naturesaura:ancient_sapling', count: 2 },
-                time: 200,
-                id: 'naturesaura:tree_ritual/ancient_sapling'
-            },
             {
                 inputs: [
                     { item: 'naturesaura:infused_stone' },
@@ -372,18 +356,18 @@ onEvent('recipes', (event) => {
                     { tag: 'forge:ingots/tainted_gold' },
                     { tag: 'forge:ingots/infused_iron' },
                     { item: 'minecraft:fire_charge' },
-                    { item: 'minecraft:flint' },
-                    { item: 'minecraft:magma_block' },
-                    { item: 'naturesaura:token_fear' }
+                    { item: 'minecraft:flint_and_steel' },
+                    { item: 'tconstruct:magma_cake' },
+                    { item: 'naturesaura:token_anger' }
                 ],
-                sapling: 'quark:yellow_blossom_sapling',
+                sapling: 'quark:red_blossom_sapling',
                 output: { item: 'naturesaura:furnace_heater' },
                 time: 600,
                 id: 'naturesaura:tree_ritual/furnace_heater'
             },
             {
                 inputs: [
-                    { item: 'minecraft:diamond' },
+                    { tag: 'forge:gems/mana_diamond' },
                     { tag: 'forge:ingots/tainted_gold' },
                     { tag: 'forge:ingots/sky' },
                     { item: 'naturesaura:token_fear' }
@@ -393,6 +377,36 @@ onEvent('recipes', (event) => {
                 time: 200,
                 id: 'naturesaura:tree_ritual/break_prevention'
             },
+            {
+                inputs: [
+                    { item: 'atum:palm_sapling' },
+                    { item: 'atum:date' },
+                    { item: 'undergarden:veil_mushroom' },
+                    { item: 'atum:emmer_seeds' },
+                    { item: 'undergarden:glowing_kelp' },
+                    { item: 'naturesaura:gold_leaf' }
+                ],
+                sapling: 'quark:lavender_blossom_sapling',
+                output: { item: 'naturesaura:ancient_sapling', count: 2 },
+                time: 200,
+                id: 'naturesaura:tree_ritual/ancient_sapling'
+            },
+            {
+                inputs: [
+                    { item: 'naturesaura:gold_powder' },
+                    { item: 'naturesaura:gold_powder' },
+                    { tag: 'forge:ores/emerald' },
+                    { tag: 'forge:ores/cobalt' },
+                    { tag: 'botania:runes/spring' }
+                ],
+                sapling: 'quark:yellow_blossom_sapling',
+                output: { nbt: { effect: 'naturesaura:ore_spawn' }, item: 'naturesaura:effect_powder', count: 4 },
+                time: 400,
+                id: 'naturesaura:tree_ritual/ore_spawn_powder'
+            },
+
+            // Recipes below this point have not yet been expertified. To Do.
+
             {
                 inputs: [
                     { item: 'naturesaura:gold_powder' },
@@ -428,18 +442,6 @@ onEvent('recipes', (event) => {
                 output: { nbt: { effect: 'naturesaura:plant_boost' }, item: 'naturesaura:effect_powder', count: 24 },
                 time: 400,
                 id: 'naturesaura:tree_ritual/plant_powder'
-            },
-            {
-                inputs: [
-                    { item: 'naturesaura:gold_powder' },
-                    { item: 'naturesaura:gold_powder' },
-                    { tag: 'forge:ores/diamond' },
-                    { tag: 'forge:ores/redstone' }
-                ],
-                sapling: 'quark:yellow_blossom_sapling',
-                output: { nbt: { effect: 'naturesaura:ore_spawn' }, item: 'naturesaura:effect_powder', count: 4 },
-                time: 400,
-                id: 'naturesaura:tree_ritual/ore_spawn_powder'
             },
             {
                 inputs: [


### PR DESCRIPTION
Remove return chance on disc used for Swampjaw fight. Not working anyway.
Adds cheaper BM recipe that becomes available after the first craft in case people wish to summon again.

Extraneous Firestarter
![image](https://user-images.githubusercontent.com/9543430/127101755-f93b8f79-48fd-4c1b-9107-60ae6be57832.png)

Eir's Token
![image](https://user-images.githubusercontent.com/9543430/127102625-f5cb9b24-77c8-4eb0-aaa2-6159e7808264.png)

Ancient Sapling:
![image](https://user-images.githubusercontent.com/9543430/127103290-de0c5d65-199e-4d7f-8f75-2c639c8b43e7.png)

Powder of the Bountiful Core:
![image](https://user-images.githubusercontent.com/9543430/127104225-81740af9-af75-4d8e-8f72-a9cec78563c6.png)
This would be the first magic based ore generation. Placing it a bit earlier than Occultism lamps (iesnium is quite a haul to get to) because it takes a bit more effort to set up and run.