### PR TITLE
Rework Neptune's Bounty drops

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/aquaculture/neptunes_bounty.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/aquaculture/neptunes_bounty.js
@@ -1,0 +1,45 @@
+onEvent('server.datapack.high_priority', (event) => {
+    let loot_table = {
+        pools: [
+            {
+                rolls: 1,
+                entries: [
+                    {
+                        type: 'loot_table',
+                        weight: 1,
+                        name: 'aquaculture:box/neptunes_bounty_junk'
+                    }
+                ]
+            },
+            {
+                rolls: { min: 1, max: 5 },
+                bonus_rolls: { min: 0, max: 3 },
+                entries: [
+                    {
+                        type: 'item',
+                        weight: 1,
+                        name: 'aquaculture:neptunium_nugget',
+                        functions: [
+                            {
+                                function: 'set_count',
+                                count: { min: 1, max: 4 }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                rolls: 1,
+                entries: [
+                    {
+                        type: 'loot_table',
+                        weight: 1,
+                        name: 'aquaculture:box/neptunes_bounty_junk'
+                    }
+                ]
+            }
+        ]
+    };
+
+    event.addJson(`aquaculture:loot_tables/box/neptunes_bounty.json`, loot_table);
+});


### PR DESCRIPTION
Normally with aquaculture, any excess armor/tools you fish up but don't want can be smelted down to recover a bit of neptunium. We've disabled that, however, so many times a neptune's bounty chest is just useless duplicate gear.

This would change that, removing all direct armor drops and instead giving nuggets directly. This sets the value pretty low by default, averaging out to a little less than we get currently, but evening out the distribution a bit. It also lets Luck apply to the rolls, potentially boosting yields greatly.