### PR TITLE
Create Sequenced Assembly Script

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/create/sequenced_assembly.js
@@ -1,0 +1,147 @@
+onEvent('recipes', (event) => {
+    const recipes = [
+        /*{
+            input: 'input_item_here',
+            output: [
+                Item.of('6x create:large_cogwheel').withChance(32.0), //withChance sets a weight for the output, default is 1 without it
+                Item.of('secondary_outputs').withChance(2.0),
+,               'more_secondaries_with_weight_1'
+            ],
+            transitionalItem: 'transitional_item_here', //required, but can be same as input item apparently
+            loops: 1, //required
+            sequence: [
+                {
+                    type: 'sequence_type_here',  //options are deploying, cutting, filling, pressing
+                    input: 'input_items_fluids_or_array_here',
+                    output: 'output_item_here',
+                    processingTime: 50 // for cutting recipes
+                }
+            ],
+            id: 'recipe_id_here'
+        }*/
+        
+        {
+            input: 'create:andesite_alloy',
+            outputs: [
+                Item.of('12x create:cogwheel'),
+            ],
+            transitionalItem: 'create:incomplete_cogwheel',
+            loops: 4,
+            sequence: [
+                {
+                    type: 'deploying',
+                    input: [
+                        'create:incomplete_cogwheel',
+                        '#minecraft:wooden_buttons'
+                    ],
+                    output: 'create:incomplete_cogwheel'
+                },
+                {
+                    type: 'cutting',
+                    input: 'create:incomplete_cogwheel',
+                    output: 'create:incomplete_cogwheel',
+                    processingTime: 50
+                }
+            ],
+            id: 'create:sequenced_assembly/cogwheel'
+        },
+        {
+            input: 'create:andesite_alloy',
+            outputs: [
+                Item.of('6x create:large_cogwheel'),
+            ],
+            transitionalItem: 'create:incomplete_large_cogwheel',
+            loops: 3,
+            sequence: [
+                {
+                    type: 'deploying',
+                    input: [
+                        'create:incomplete_large_cogwheel',
+                        '#minecraft:planks'
+                    ],
+                    output: 'create:incomplete_large_cogwheel'
+                },
+                {
+                    type: 'deploying',
+                    input: [
+                        'create:incomplete_large_cogwheel',
+                        '#minecraft:wooden_buttons'
+                    ],
+                    output: 'create:incomplete_large_cogwheel'
+                },
+                {
+                    type: 'cutting',
+                    input: 'create:incomplete_large_cogwheel',
+                    output: 'create:incomplete_large_cogwheel',
+                    processingTime: 50
+                }
+            ],
+            id: 'create:sequenced_assembly/large_cogwheel'
+        },
+        {
+            input: '#forge:plates/gold',
+            outputs: [
+                'create:precision_mechanism',
+            ],
+            transitionalItem: 'create:incomplete_precision_mechanism',
+            loops: 5,
+            sequence: [
+                {
+                    type: 'deploying',
+                    input: [
+                        'create:incomplete_precision_mechanism',
+                        'create:cogwheel'
+                    ],
+                    output: 'create:incomplete_precision_mechanism'
+                },
+                {
+                    type: 'deploying',
+                    input: [
+                        'create:incomplete_precision_mechanism',
+                        'create:large_cogwheel'
+                    ],
+                    output: 'create:incomplete_precision_mechanism'
+                },
+                {
+                    type: 'deploying',
+                    input: [
+                        'create:incomplete_precision_mechanism',
+                        '#forge:nuggets/iron'
+                    ],
+                    output: 'create:incomplete_precision_mechanism'
+                }
+            ],
+            id: 'create:precision_mechanism'
+        }
+
+    ];
+
+    recipes.forEach((recipe) => {
+        let sequence = [];
+
+        recipe.sequence.forEach((step) => { 
+            if (step.type == 'deploying'){
+                sequence.push(event.recipes.create.deploying(step.output,step.input))
+            }
+            else if (step.type == 'cutting'){
+                sequence.push(event.recipes.create.cutting(step.output,step.input).processingTime(step.processingTime))
+            }
+            else if (step.type == 'filling'){
+                sequence.push(event.recipes.create.filling(step.output,step.input))
+            }
+            else if (step.type == 'pressing'){
+                sequence.push(event.recipes.create.pressing(step.output,step.input))
+            }
+        });
+
+        const re = event.recipes.create.sequenced_assembly(
+            recipe.outputs,
+            recipe.input,
+            sequence
+        ).loops(recipe.loops).transitionalItem(recipe.transitionalItem)
+
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -1,8 +1,4 @@
 onEvent('recipes', (event) => {
-    if (global.isExpertMode == false) {
-        return;
-    }
-
     const recipes = [
 /*
         {


### PR DESCRIPTION
Fixes #2835. I hate to ping you @NillerMedDild, but you may want to review this (and push an update) quickly, as this issue makes the Mechanical Arm and Rotational Speed Controller impossible to craft.

The default Create recipe for the Precision Mechanism has a chance output for "create:golden_sheet", which seems to be invalidating the recipe since we've removed it.

`{
      "item": "create:golden_sheet",
      "chance": 8.0
    }`

Implemented a clean-ish script for doing Sequenced Assembly, and am overriding all 3 default recipes to fix the above issue and remove the chance of "salvage" - for these at least the idea of chance failure seems like a super frustrating mechanic for a factory.

<img width="388" alt="image" src="https://user-images.githubusercontent.com/13169307/127509344-1b2d15dc-1370-405b-97cb-22b219868e5b.png">

<img width="388" alt="image" src="https://user-images.githubusercontent.com/13169307/127509377-cabe62b3-c571-4f90-9392-b7863db37f6c.png">

<img width="388" alt="image" src="https://user-images.githubusercontent.com/13169307/127509420-3058e059-bb36-4567-81e1-44d9bea65444.png">