### PR TITLE
Expand Alt Material crafting, fix stoneworks crafting, make osmium available through IE's Excavator

### DIFF
--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -1558,7 +1558,7 @@
 				""
 				"https://wiki.aidancbrady.com/wiki/Fission_Reactor"
 				""
-				"The reactor may go critical and explode if it overheats, the leading cause of which is that it has run out of coolant. Therefore, the circuit breaker should trigger on High Temperature. It may also be prudent to build a second circuit breaker for Excess Waste to prevent venting radiation into the surrounding environment."
+				"The reactor may go super-critical and explode if it overheats, the leading cause of which is that it has run out of coolant. Therefore, the circuit breaker should trigger on High Temperature. It may also be prudent to build a second circuit breaker for Excess Waste to prevent venting radiation into the surrounding environment."
 				""
 				"Warning: Enigmatica 6 has tweaked Steam Production rates, so do not assume your reactor is safe. Test rigorously!"
 			]
@@ -2224,6 +2224,7 @@
 				"Redeemable once only. "
 			]
 			dependencies: ["0000000000000793"]
+			optional: true
 			id: "00000000000007E4"
 			tasks: [
 				{

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/replace_input.js
@@ -254,7 +254,12 @@ onEvent('recipes', (event) => {
             type: 'storage_blocks',
             replace: 'iron',
             replaceWith: 'lead',
-            items: ['travel_anchors:travel_anchor', 'thermal:machine_press', 'bloodmagic:alchemicalreactionchamber']
+            items: [
+                'travel_anchors:travel_anchor',
+                'thermal:machine_press',
+                'bloodmagic:alchemicalreactionchamber',
+                'integrateddynamics:squeezer'
+            ]
         },
         {
             type: 'storage_blocks',
@@ -295,7 +300,9 @@ onEvent('recipes', (event) => {
                 'ars_nouveau:crystallizer',
                 'ars_nouveau:volcanic_accumulator',
                 'pneumaticcraft:gun_ammo',
-                'ars_nouveau:marvelous_clay'
+                'ars_nouveau:marvelous_clay',
+                'ars_nouveau:ritual',
+                'ars_nouveau:sconce'
             ]
         },
         {
@@ -377,7 +384,8 @@ onEvent('recipes', (event) => {
                 'xnet:antenna',
                 'transport:fluid_loader',
                 'resourcefulbees:centrifuge_casing',
-                'engineersdecor:metal_bar'
+                'engineersdecor:metal_bar',
+                'integrateddynamics:drying_basin'
             ]
         },
         {
@@ -401,13 +409,19 @@ onEvent('recipes', (event) => {
             type: 'ingots',
             replace: 'iron',
             replaceWith: 'lead',
-            items: ['travel_anchors:travel_anchor', 'travel_anchors:travel_staff']
+            items: ['travel_anchors:travel_anchor', 'travel_anchors:travel_staff', 'integrateddynamics:squeezer']
         },
         {
             type: 'ingots',
             replace: 'iron',
             replaceWith: 'tin',
-            items: ['bloodmagic:soulsnare', 'modularrouters:bulk_item_filter']
+            items: ['bloodmagic:soulsnare', 'modularrouters:bulk_item_filter', 'chisel:auto_chisel']
+        },
+        {
+            type: 'ingots',
+            replace: 'iron',
+            replaceWith: 'osmium',
+            items: ['integrateddynamics:part_machine_reader', 'integratedcrafting:crafting/part_interface_crafting']
         },
         {
             type: 'nuggets',
@@ -438,7 +452,7 @@ onEvent('recipes', (event) => {
             type: 'nuggets',
             replace: 'gold',
             replaceWith: 'silver',
-            items: ['botania:spark']
+            items: ['botania:spark', 'chisel:hitech_chisel']
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -688,7 +688,7 @@ onEvent('recipes', (event) => {
             pattern: ['pcp', 'gmf', 'aba'],
             key: {
                 p: '#forge:plastic',
-                c: 'minecraft:crafting_table',
+                c: '#forge:workbenches',
                 g: 'minecraft:diamond_pickaxe',
                 m: '#industrialforegoing:machine_frame/advanced',
                 f: 'minecraft:furnace',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -206,6 +206,59 @@ onEvent('recipes', (event) => {
                 output: 'ars_nouveau:mana_bloom_crop',
                 count: 1,
                 id: 'ars_nouveau:mana_bloom_crop'
+            },
+            {
+                inputs: [
+                    'ars_nouveau:glyph_amplify',
+                    '#forge:storage_blocks/gold_brass',
+                    '#forge:storage_blocks/gold_brass',
+                    '#forge:storage_blocks/mana',
+                    '#forge:storage_blocks/mana'
+                ],
+                reagent: 'minecraft:diamond_sword',
+                output: 'ars_nouveau:enchanters_sword',
+                count: 1,
+                id: 'ars_nouveau:enchanters_sword'
+            },
+            {
+                inputs: [
+                    '#forge:storage_blocks/gold_brass',
+                    '#forge:storage_blocks/gold_brass',
+                    '#forge:storage_blocks/mana',
+                    '#forge:storage_blocks/mana'
+                ],
+                reagent: 'minecraft:shield',
+                output: 'ars_nouveau:enchanters_shield',
+                count: 1,
+                id: 'ars_nouveau:enchanters_shield'
+            },
+            {
+                inputs: [
+                    'ars_nouveau:blaze_fiber',
+                    'ars_nouveau:blaze_fiber',
+                    '#forge:storage_blocks/mana',
+                    '#forge:storage_blocks/gold_brass'
+                ],
+                reagent: 'minecraft:glass_bottle',
+                output: 'ars_nouveau:potion_flask',
+                count: 1,
+                id: 'ars_nouveau:potion_flask'
+            },
+            {
+                inputs: [
+                    'ars_nouveau:glyph_extract',
+                    'ars_nouveau:glyph_extract',
+                    '#forge:storage_blocks/gold_brass',
+                    '#forge:storage_blocks/gold_brass',
+                    '#forge:rods/blaze',
+                    '#forge:rods/blaze',
+                    '#forge:rods/blaze',
+                    '#forge:rods/blaze'
+                ],
+                reagent: 'ars_nouveau:potion_jar',
+                output: 'ars_nouveau:potion_melder',
+                count: 1,
+                id: 'ars_nouveau:potion_melder'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/minerals.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/minerals.js
@@ -63,7 +63,10 @@ onEvent('recipes', (event) => {
                 id: 'bituminous_coal'
             },
             {
-                ores: [{ chance: 1.0, output: { tag: 'forge:chunks/tin' } }],
+                ores: [
+                    { chance: 7.0, output: { tag: 'forge:chunks/tin' } },
+                    { chance: 3.0, output: { tag: 'forge:chunks/osmium' } }
+                ],
                 dimensions: ['minecraft:overworld', 'undergarden:undergarden', 'atum:atum'],
                 weight: 20,
                 fail_chance: 0.05,

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/material_substitutes.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/material_substitutes.js
@@ -7,7 +7,7 @@ onEvent('item.tags', (event) => {
             },
             {
                 base: 'iron',
-                substitutes: ['aluminum', 'copper', 'lead', 'tin', 'brass', 'invar']
+                substitutes: ['aluminum', 'copper', 'lead', 'tin', 'brass', 'invar', 'osmium']
             }
         ];
     types.forEach((type) => {


### PR DESCRIPTION
Expand Alt Material replacements to cover some new Ars items and a few older things that seemed deserving.

Fix Material Stoneworks requiring vanilla crafting table. Now accepts any forge workbench. Resolves #2850

Add Osmium as an output of the Tin Mineral nodes for IE, as there was no node for Osmium.