### PR TITLE
[Expert] More tweak

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/replace_input.js
@@ -43,6 +43,11 @@ onEvent('recipes', (event) => {
             filter: { id: 'occultism:crafting/storage_remote_inert' },
             toReplace: 'minecraft:stone_button',
             replaceWith: '#forge:nuggets/silver'
+        },
+        {
+            filter: { id: '/wilden_summon/' },
+            toReplace: 'minecraft:lapis_block',
+            replaceWith: 'meetyourfight:velvet_fortune'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/book_upgrade.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/book_upgrade.js
@@ -21,8 +21,8 @@ onEvent('recipes', (event) => {
         {
             inputs: [
                 'ars_nouveau:apprentice_spell_book',
+                'ars_nouveau:wilden_tribute',
                 'minecraft:totem_of_undying',
-                '#forge:gems/amber',
                 '#forge:gems/amber',
                 '#forge:gems/amber',
                 'betterendforge:enchanted_petal',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -1100,6 +1100,19 @@ onEvent('recipes', (event) => {
                 count: 1,
                 id: 'pedestals:upgrades/fluidpump'
             },
+            {
+                inputs: [
+                    '#forge:storage_blocks/mana',
+                    '#forge:storage_blocks/gold_brass',
+                    'ars_nouveau:glyph_projectile',
+                    '#botania:runes/air',
+                    '#botania:runes/air'
+                ],
+                reagent: 'botania:livingwood_bow',
+                output: 'ars_nouveau:spell_bow',
+                count: 1,
+                id: 'ars_nouveau:spell_bow'
+            },
 
             /// Patchouli Removals
             {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/altar.js
@@ -173,6 +173,15 @@ onEvent('recipes', (event) => {
                 altarLevel: 0,
                 consumptionRate: 25,
                 drainRate: 5
+            },
+            {
+                input: 'ars_nouveau:ritual_warping',
+                output: 'waystones:warp_stone',
+                syphon: 50000,
+                altarLevel: 2,
+                consumptionRate: 1000,
+                drainRate: 100,
+                id: 'waystones:warp_stone'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
@@ -51,6 +51,19 @@ onEvent('recipes', (event) => {
                 rolls: 1
             },
             id: 'pneumaticcraft:explosion_crafting/compressed_iron_block'
+        },
+        {
+            inputs: [
+                { item: 'bloodmagic:fortune_anointment', count: 1 },
+                { item: 'atum:coin_gold', count: 7 },
+                { item: 'resourcefulbees:nether_quartz_honeycomb', count: 7 }
+            ],
+            output: {
+                entries: [{ result: { item: 'meetyourfight:devils_ante', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            },
+            id: 'meetyourfight:devils_ante'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/shaped.js
@@ -29,7 +29,7 @@ onEvent('recipes', (event) => {
             output: 'naturesaura:offering_table',
             pattern: ['BAB', 'CBD', 'EEE'],
             key: {
-                A: '#forge:ingots/infused_iron',
+                A: 'ars_nouveau:wilden_tribute',
                 B: 'naturesaura:infused_stone',
                 C: 'naturesaura:token_fear',
                 D: 'naturesaura:token_sorrow',


### PR DESCRIPTION
Enchanter's Bow
![image](https://user-images.githubusercontent.com/9543430/127800824-740c6d56-d2a7-4e93-aad9-31a715156e29.png)
This is a very powerful weapon with the right spells. Seemed fitting to push back access a bit.

Re-integrate Wilden boss back into Tier 3 book:
![image](https://user-images.githubusercontent.com/9543430/127891196-2a0047a9-ffed-4a43-8b02-bcf410742530.png)

Offering Table now gated behind Wilden boss too
![image](https://user-images.githubusercontent.com/9543430/127804682-d006e361-f2e8-48e0-8fa2-cfdccfdcfcd1.png)

Devil's Ante
![image](https://user-images.githubusercontent.com/9543430/127886830-c8cb86d5-6518-4ec4-81ad-4c274e65bb76.png)

Warp Stone
![image](https://user-images.githubusercontent.com/9543430/127874427-0726e17f-15e7-4396-90da-b897f39ae8e1.png)

Plenty of waystones can be found in world. This mostly limits obtaining personal teleportation from anywhere. Blood Magic felt like a good place to stick it. Before this, Ars offers great teleportation options earlier on.