### PR TITLE
Remove Duplicate Dim Shard processing recipe from Enrichment Chamber

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/enriching.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/enriching.js
@@ -6,10 +6,6 @@ onEvent('recipes', (event) => {
                 output: Item.of('betterendforge:crystal_shards', 4)
             },
             {
-                input: '#forge:ores/dimensional',
-                output: Item.of('emendatusenigmatica:dimensional_gem', 8)
-            },
-            {
                 input: '#forge:ores/ender',
                 output: Item.of('#forge:shards/ender', 3)
             },


### PR DESCRIPTION
Remove Duplicate Dim Shard processing recipe from Enrichment Chamber
Already handled by unification script