### PR TITLE
[Expert] Enchanting Tweaks

### DIFF
--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -340,9 +340,9 @@ const fluidsToHide = [
     that have been changed to use a different crafting type or that have been disabled. It allows creating a
     recipe pointer that will display in Patchouli but not in JEI.  
 
-    Use the below logger to discover the correct CategoryID. They do not match the recipe type.
+    Use the logger in the jei_hide_recipes script to discover the correct CategoryID. They do not match the recipe type.
 */
-//console.log('JEI RECIPE TYPES: ' + event.getCategoryIds());
+
 const recipesToHide = [
     {
         category: 'minecraft:crafting',
@@ -358,7 +358,12 @@ const recipesToHide = [
             'mythicbotany:wither_aconite_floating',
             'mythicbotany:raindeletia_floating',
             'mythicbotany:modified_gaia_pylon_with_alfsteel',
-            'mythicbotany:alfsteel_pylon'
+            'mythicbotany:alfsteel_pylon',
+            'naturesaura:gold_brick',
+            'naturesaura:generator_limit_remover',
+            'apotheosis:hellshelf',
+            'apotheosis:seashelf',
+            'apotheosis:endshelf'
         ]
     },
     {

--- a/kubejs/client_scripts/expert/item_modifiers/jei_hide_recipes.js
+++ b/kubejs/client_scripts/expert/item_modifiers/jei_hide_recipes.js
@@ -2,6 +2,7 @@ onEvent('jei.yeet.recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+    //console.log('JEI RECIPE TYPES: ' + event.getCategoryIds());
     recipesToHide.forEach((recipe) => {
         recipe.recipes_by_id.forEach((id) => {
             if (recipe.category == 'minecraft:crafting') {
@@ -17,6 +18,7 @@ onEvent('jei.yeet.recipes', (event) => {
                     // do nothing
                 }
             }
+            console.log(`Category: ${recipe.category}, Yeeting: ${id}`);
             event.yeet(recipe.category, id);
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -41,7 +41,10 @@ onEvent('recipes', (event) => {
         { output: 'botania:gaia_pylon', id: 'mythicbotany:modified_gaia_pylon_with_alfsteel' },
         { output: 'mythicbotany:alfsteel_pylon', id: 'mythicbotany:alfsteel_pylon' },
         { output: 'naturesaura:gold_brick', id: 'naturesaura:gold_brick' },
-        { output: 'naturesaura:generator_limit_remover', id: 'naturesaura:generator_limit_remover' }
+        { output: 'naturesaura:generator_limit_remover', id: 'naturesaura:generator_limit_remover' },
+        { output: 'apotheosis:hellshelf', id: 'apotheosis:hellshelf' },
+        { output: 'apotheosis:seashelf', id: 'apotheosis:seashelf' },
+        { output: 'apotheosis:endshelf', id: 'apotheosis:endshelf' }
     ];
 
     idRemovals.forEach((id) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/ars_nouveau/enchanting_apparatus.js
@@ -943,38 +943,6 @@ onEvent('recipes', (event) => {
             {
                 inputs: [
                     'ars_nouveau:greater_experience_gem',
-                    'botania:gaia_pylon',
-                    'ars_nouveau:greater_experience_gem',
-                    '#botania:runes/mana',
-                    '#botania:runes/vanaheim',
-                    'ars_nouveau:greater_experience_gem',
-                    'ars_nouveau:glyph_pickup',
-                    'ars_nouveau:greater_experience_gem'
-                ],
-                reagent: 'pedestals:coin/default',
-                output: 'pedestals:coin/xpenchanter',
-                count: 1,
-                id: 'pedestals:upgrades/enchanter'
-            },
-            {
-                inputs: [
-                    'ars_nouveau:greater_experience_gem',
-                    'mythicbotany:alfsteel_pylon',
-                    'ars_nouveau:greater_experience_gem',
-                    '#botania:runes/mana',
-                    '#botania:runes/vanaheim',
-                    'ars_nouveau:greater_experience_gem',
-                    'ars_nouveau:glyph_pickup',
-                    'ars_nouveau:greater_experience_gem'
-                ],
-                reagent: 'pedestals:coin/default',
-                output: 'pedestals:coin/xpanvil',
-                count: 1,
-                id: 'pedestals:upgrades/anvil'
-            },
-            {
-                inputs: [
-                    'ars_nouveau:greater_experience_gem',
                     'botania:rosa_arcana',
                     'ars_nouveau:greater_experience_gem',
                     '#botania:runes/mana',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar.js
@@ -205,8 +205,8 @@ onEvent('recipes', (event) => {
             output: Item.of('resourcefulbees:t4_apiary', 1),
             pattern: ['__B__', '_C_D_', 'E_A_E', '_D_C_', '__B__'],
             key: {
-                A: { item: 'resourcefulbees:t3_apiary'},
-                B: Item.of('naturesaura:effect_powder', {effect: 'naturesaura:animal'}).toJson(),
+                A: { item: 'resourcefulbees:t3_apiary' },
+                B: Item.of('naturesaura:effect_powder', { effect: 'naturesaura:animal' }).toJson(),
                 C: { tag: 'resourcefulbees:resourceful_honeycomb_block' },
                 D: { item: 'resourcefulbees:honey_fluid_bucket' },
                 E: { item: 'astralsorcery:illumination_powder' }
@@ -230,6 +230,120 @@ onEvent('recipes', (event) => {
                 'astralsorcery:built_in_effect_attunement_sparkle'
             ],
             id: 'resourcefulbees:t4_apiary'
+        },
+        {
+            output: Item.of('pedestals:coin/xpenchanter', 1),
+            pattern: ['AA_AA', 'ACB_A', '_DED_', 'A_FCA', 'AA_AA'],
+            key: {
+                A: { item: 'ars_nouveau:greater_experience_gem' },
+                B: { item: 'botania:gaia_pylon' },
+                C: { tag: 'botania:runes/vanaheim' },
+                D: { tag: 'botania:runes/mana' },
+                E: { item: 'pedestals:coin/default' },
+                F: { item: 'ars_nouveau:glyph_pickup' }
+            },
+            relay_inputs: [
+                { item: 'eidolon:shadow_gem' },
+                { tag: 'forge:inlays/arcane_gold' },
+                { tag: 'forge:inlays/arcane_gold' }
+            ],
+            altar_type: 3,
+            duration: 600,
+            starlight: 6400,
+            focus_constellation: 'astralsorcery:lucerna',
+            effects: [
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:gateway_edge',
+                'astralsorcery:built_in_effect_attunement_sparkle'
+            ],
+            id: 'pedestals:upgrades/enchanter'
+        },
+        {
+            output: Item.of('pedestals:coin/xpanvil', 1),
+            pattern: ['AA_AA', 'ACB_A', '_DED_', 'A_FCA', 'AA_AA'],
+            key: {
+                A: { item: 'ars_nouveau:greater_experience_gem' },
+                B: { item: 'mythicbotany:alfsteel_pylon' },
+                C: { tag: 'botania:runes/vanaheim' },
+                D: { tag: 'botania:runes/mana' },
+                E: { item: 'pedestals:coin/default' },
+                F: { item: 'ars_nouveau:glyph_pickup' }
+            },
+            relay_inputs: [
+                { item: 'betterendforge:aeternium_hammer' },
+                { tag: 'forge:ingots/netherite' },
+                { tag: 'forge:ingots/netherite' }
+            ],
+            altar_type: 3,
+            duration: 600,
+            starlight: 6400,
+            focus_constellation: 'astralsorcery:fornax',
+            effects: [
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:gateway_edge',
+                'astralsorcery:built_in_effect_attunement_sparkle'
+            ],
+            id: 'pedestals:upgrades/anvil'
+        },
+        {
+            output: Item.of('apotheosis:hellshelf', 1),
+            pattern: ['A___A', '__BC_', '_DED_', '_FB__', 'A___A'],
+            key: {
+                A: { item: 'tconstruct:scorched_bricks' },
+                B: { tag: 'botania:runes/fire' },
+                C: { item: 'resourcefulbees:ghast_honeycomb' },
+                D: { tag: 'botania:runes/muspelheim' },
+                E: { tag: 'forge:bookshelves' },
+                F: { item: 'powah:crystal_blazing' }
+            },
+            altar_type: 1,
+            duration: 200,
+            starlight: 1400,
+            effects: [
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:gateway_edge',
+                'astralsorcery:built_in_effect_attunement_sparkle'
+            ]
+        },
+        {
+            output: Item.of('apotheosis:seashelf', 1),
+            pattern: ['A___A', '__BC_', '_DED_', '_FB__', 'A___A'],
+            key: {
+                A: { item: 'upgrade_aquatic:prismarine_coral_block' },
+                B: { tag: 'botania:runes/water' },
+                C: { item: 'resourcefulbees:icy_honeycomb' },
+                D: { tag: 'botania:runes/vanaheim' },
+                E: { tag: 'forge:bookshelves' },
+                F: { item: 'powah:crystal_niotic' }
+            },
+            altar_type: 1,
+            duration: 200,
+            starlight: 1400,
+            effects: [
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:gateway_edge',
+                'astralsorcery:built_in_effect_attunement_sparkle'
+            ]
+        },
+        {
+            output: Item.of('apotheosis:endshelf', 1),
+            pattern: ['A___A', '__BC_', '_DED_', '_FB__', 'A___A'],
+            key: {
+                A: { item: 'betterendforge:flavolite_runed' },
+                B: { tag: 'botania:runes/mana' },
+                C: { item: 'resourcefulbees:enderium_honeycomb' },
+                D: { tag: 'botania:runes/nidavellir' },
+                E: { tag: 'forge:bookshelves' },
+                F: { item: 'betterendforge:eternal_crystal' }
+            },
+            altar_type: 1,
+            duration: 200,
+            starlight: 1400,
+            effects: [
+                'astralsorcery:built_in_effect_discovery_central_beam',
+                'astralsorcery:gateway_edge',
+                'astralsorcery:built_in_effect_attunement_sparkle'
+            ]
         }
     ];
 


### PR DESCRIPTION
Hellshelf:
![image](https://user-images.githubusercontent.com/9543430/128085537-23316e84-6c7b-4e31-a38a-a7a891357849.png)

Seashelf:
![image](https://user-images.githubusercontent.com/9543430/128085565-0b1e02bd-084c-44c2-8930-25aa6062642e.png)

Endshelf:
![image](https://user-images.githubusercontent.com/9543430/128086222-99a28b03-d700-460b-b223-77d1a5aa2fe1.png)

Got the override working by using patchouli safe removal methods. However, I've noticed that the JEI Yeeter is not working anymore. Not sure when this broke.

Given the placement of these shelves is at the same level as Pedestals XP enchanter and XP anvil, I figured those ought to move back a bit.

So:
XP Anvil
![image](https://user-images.githubusercontent.com/9543430/128097164-e11a49fa-f1d8-41db-891a-ee85e08aafb4.png)

Enchanter
![image](https://user-images.githubusercontent.com/9543430/128097175-2f9a0a25-b109-4ec1-b8a3-f8e6fc736dc2.png)