### PR TITLE
mekanism quest improvements

### DIFF
--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -533,7 +533,7 @@
 								Count: 1b
 							}
 							{
-								id: "mekanism:osmium_compressor"
+								id: "mekanism:`osmium`_compressor"
 								Count: 1b
 							}
 						]
@@ -837,6 +837,10 @@
 								}
 								{
 									id: "mekanism:clump_copper"
+									Count: 1b
+								}
+								{
+									id: "mekanism:clump_osmium"
 									Count: 1b
 								}
 								{
@@ -2423,6 +2427,10 @@
 									Count: 1b
 								}
 								{
+									id: "mekanism:shard_osmium"
+									Count: 1b
+								}
+								{
 									id: "mekanism:shard_tin"
 									Count: 1b
 								}
@@ -2532,6 +2540,10 @@
 							}
 							{
 								id: "mekanism:crystal_copper"
+								Count: 1b
+							}
+							{
+								id: "mekanism:crystal_osmium"
 								Count: 1b
 							}
 							{

--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -533,7 +533,7 @@
 								Count: 1b
 							}
 							{
-								id: "mekanism:`osmium`_compressor"
+								id: "mekanism:osmium_compressor"
 								Count: 1b
 							}
 						]

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_epic.json
@@ -6,23 +6,45 @@
             "entries": [
                 {
                     "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "mekanism:advanced_chemical_tank",
+                    "weight": 2,
+                    "name": "mekanism:enriched_carbon",
                     "functions": [
                         {
-                            "function": "set_nbt",
-                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:carbon\",amount:5120}}]}}"
+                            "function": "set_count",
+                            "count": 32
                         }
                     ]
                 },
                 {
                     "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "mekanism:advanced_chemical_tank",
+                    "weight": 2,
+                    "name": "mekanism:enriched_redstone",
                     "functions": [
                         {
-                            "function": "set_nbt",
-                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:redstone\",amount:5120}}]}}"
+                            "function": "set_count",
+                            "count": 32
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:enriched_diamond",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:enriched_refined_obsidian",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 8
                         }
                     ]
                 },
@@ -55,7 +77,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 32
                         }
                     ]
                 },
@@ -66,7 +88,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 32
                         }
                     ]
                 },
@@ -77,9 +99,14 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 32
                         }
                     ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 2,
+                    "name": "mekanism:elite_tier_installer"
                 },
                 {
                     "type": "minecraft:item",

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_epic.json
@@ -11,7 +11,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 32
+                            "count": 16
                         }
                     ]
                 },
@@ -22,7 +22,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 32
+                            "count": 16
                         }
                     ]
                 },
@@ -33,7 +33,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 8
+                            "count": 16
                         }
                     ]
                 },

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_legendary.json
@@ -51,7 +51,18 @@
                 {
                     "type": "minecraft:item",
                     "weight": 1,
-                    "name": "mekanism:ultimate_induction_cell",
+                    "name": "mekanism:elite_induction_cell",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_induction_provider",
                     "functions": [
                         {
                             "function": "set_count",
@@ -66,7 +77,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 1
+                            "count": 4
                         }
                     ]
                 }

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_rare.json
@@ -73,22 +73,11 @@
                 {
                     "type": "minecraft:item",
                     "weight": 1,
-                    "name": "mekanism:dynamic_tank",
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": 28
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 1,
                     "name": "mekanism:basic_pressurized_tube",
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 32
                         }
                     ]
                 },
@@ -99,7 +88,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 32
                         }
                     ]
                 },
@@ -110,14 +99,31 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 32
                         }
                     ]
                 },
                 {
                     "type": "minecraft:item",
                     "weight": 1,
-                    "name": "mekanism:elite_tier_installer"
+                    "name": "mekanism:basic_tier_installer",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "minecraft:item",
+                    "weight": 1,
+                    "name": "mekanism:advanced_tier_installer",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
                 }
             ]
         }

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_mekanism_loot_rare.json
@@ -7,39 +7,6 @@
                 {
                     "type": "minecraft:item",
                     "weight": 1,
-                    "name": "mekanism:advanced_chemical_tank",
-                    "functions": [
-                        {
-                            "function": "set_nbt",
-                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:fungi\",amount:128000}}]}}"
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "mekanism:advanced_chemical_tank",
-                    "functions": [
-                        {
-                            "function": "set_nbt",
-                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:bio\",amount:128000}}]}}"
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "mekanism:advanced_chemical_tank",
-                    "functions": [
-                        {
-                            "function": "set_nbt",
-                            "tag": "{mekData:{InfusionTanks:[{Tank:0,stored:{infuseTypeName:\"mekanism:ethene\",amount:16000}}]}}"
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 1,
                     "name": "mekanism:upgrade_speed",
                     "functions": [
                         {


### PR DESCRIPTION
reasoning for my changes:

 - **add osmium to ore multiplication**: why should osmium not work?
 
  - **change infuse types to item form**: no one wants to get a pressurized tube and pump the infuse into the infuser, using enriched items is far easier and does the same thing
  
 - **increase amount of tubes / pipes / cables to 32 from 16**: 16 never feels like enough to be a suitable reward while 32 might leave you with some left over for next time
 
 - **downgrade the induction cell to elite from ultimate**: with more than one player you end up with more of these than you'll ever need, so it seems fair to nerf that just a little
 
 - **add the advanced induction provider to quest rewards**: more transfer speed is always good; if induction cells can be given then why not providers?
 
 - **move the elite tier installer to the epic loot box (from rare)**: you get the rare loot boxes so early on that you can't even use the elite installer for quite a while, so moving it to the epic loot box (which also can drop an ultimate tier installer) makes sense
 
 - **add basic and advanced tier installers to the rare loot box rewards**: these will be far more useful than the elite installers that were here previously and also serve as a replacement
 
 - **remove biomass and fungi from quest rewards**: be honest, have you ever wished you had 128 buckets of fungi in your world? it's just disappointing to get this as a reward

all changes were tested in game.