### PR TITLE
Fix Ghast Bee Mutation

### DIFF
--- a/config/resourcefulbees/bees/nether/Ghast.json
+++ b/config/resourcefulbees/bees/nether/Ghast.json
@@ -23,7 +23,7 @@
         "mutations" : [
           {
             "type": "BLOCK",
-            "inputID": "tag:forge:netherrack",
+            "inputID": "tag:forge:sand",
             "outputs": [
               {"outputID": "minecraft:tnt", "weight": 10}
             ]


### PR DESCRIPTION
Move to Sand -> TNT to avoid the Ghast Bee mutating it's own flower's block. Fixes #2952.