### PR TITLE
16 advanced pressure tubes -> 4 compressed iron blocks

### DIFF
--- a/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_pneumaticcraft_loot_epic.json
@@ -40,11 +40,11 @@
                 {
                     "type": "minecraft:item",
                     "weight": 1,
-                    "name": "pneumaticcraft:advanced_pressure_tube",
+                    "name": "pneumaticcraft:compressed_iron_block",
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 4
                         }
                     ]
                 }


### PR DESCRIPTION
> suggestion: replace the advances tubes with their ingredients

on last playthrough i got enough of them for 4 spawners and a small quantity of pipes, never causing me to automate them, on my current map i decided to automate it with the assembly system, but by the time i automated the entire process from start to finish i already had over a stack of the tubes piled up from rewards, probably never really needing more of them.

the other assembly controller recipes are either useless, or already automated with the lesser tier methods from pneumaticraft, effectively the assembly setup will now be gathering dust till the end of time.

changing the rewards to not include the finished tubes would nicely gate the advanced tubes, spawner & aerial interface behind the assembly setup, instead of just being rewarded randomly. (it would make it feel much more rewarding to get it up)

screenshot of my compactmachine setup since pulls with pics have more flair:
![2021-08-12_09 57 59](https://user-images.githubusercontent.com/3179271/129160038-774bf75b-5a2e-4552-bccf-5bb18c2f56f8.png)

(ps, the/a recipe for the advanced tubes is 1 block for 8, so the reward pretty much stays the same, just needs processing)