### PR TITLE
Require 16 stone bricks instead of 8 for nature altar quest

### DIFF
--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -229,7 +229,7 @@
 					id: "0000000000000332"
 					type: "item"
 					item: "minecraft:stone_bricks"
-					count: 8L
+					count: 16L
 				}
 				{
 					id: "0000000000000333"


### PR DESCRIPTION
i prepared 8 stone bricks to build it with the schematicannon, only to be surprised that it needed 16 in total:

![2021-08-12_21 14 37](https://user-images.githubusercontent.com/3179271/129255312-5fd62cd7-675d-435d-b482-e5d6fddc6797.png)

![Screen Shot 2021-08-12 at 21 15 29](https://user-images.githubusercontent.com/3179271/129255456-dc49a696-ab02-427e-b423-dbe292e1c7d8.png)
