### PR TITLE
Alternate recipe for antimatter through powah

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/powah/energizing.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/powah/energizing.js
@@ -44,6 +44,14 @@ onEvent('recipes', (event) => {
                     item: 'powah:spirited_crystal_block',
                     count: 1
                 }
+            },
+            {
+                ingredients: [{ item: 'minecraft:chorus_fruit' }],
+                energy: '1000000000',
+                result: {
+                    item: 'mekanism:pellet_antimatter',
+                    count: 1
+                }
             }
         ]
     };


### PR DESCRIPTION
on my current playthrough server we used powah this time around instead of one of our basemates setting up mekanism reactors, we slowly made out way up to nitro & eventually i also automated all the generators from industrial foregoing in order to activate the 25m/t mycelium reactor.

during this run i also grew (extra) fond of the infinity tools, and would thus like to charge them, but at the rate of 25m per tick it would appear to take 60+ ish real life years? not really feasible.

it would therefore be nice to have a powah/other way of obtaining antimatter and/or artifact tier infinity tools, this draft accomplishes it by adding a direct chorus -> antimatter recipe in the empowerer, leaving the rest or it as-is.

(i picked chorus just because it is also purple & came to mind, i don't think its _that_ out of place here)

originally i had picked 10 billion since [100 would be needed to process 10 buckets into a full charge](https://github.com/NillerMedDild/Enigmatica6/blob/29398af2801055b711dffa09f7d04eb14b34b476/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/mekanism/nucleosynthesizing.js#L23) but that took kinda long, so i lowered it to 1 billion, in my testing setup this seems quite fair, since 15 energizing rods for powah is getting on the silly side, and a too high number would prompt for a pincushion, below are some of the numbers of my testing setup:

`15 nitro rods = 60k/t = ~14 minutes`

![Screen Shot 2021-08-13 at 19 31 46](https://user-images.githubusercontent.com/3179271/129397537-fa7d6bd8-c181-4c48-9e21-6a84943cdcba.png)

ps: i have no experience in how long it takes to get antimatter through mekanism the long way round, but i am guessing that this recipe will take longer in comparison, and tbh that sounds fair since you're skipping the mekanism reactors entirely :3