### PR TITLE
Fix More Bee Mutations

### DIFF
--- a/config/resourcefulbees/bees/natural/Obsidian.json
+++ b/config/resourcefulbees/bees/natural/Obsidian.json
@@ -23,7 +23,7 @@
         "mutations" : [
           {
             "type": "BLOCK",
-            "inputID": "tag:forge:netherrack",
+            "inputID": "minecraft:netherrack",
             "outputs": [
               {"outputID": "minecraft:obsidian", "weight": 10}
             ]

--- a/config/resourcefulbees/bees/special/Boobee.json
+++ b/config/resourcefulbees/bees/special/Boobee.json
@@ -24,7 +24,7 @@
         "mutations": [
             {
                 "type": "BLOCK",
-                "inputID": "tag:forge:netherrack",
+                "inputID": "tag:forge:sand",
                 "outputs": [{ "outputID": "minecraft:tnt", "weight": 10 }]
             }
         ]


### PR DESCRIPTION
Move both Obsidian and Boobee mutations to minecraft:netherrack and forge:sand respectively.