### PR TITLE
Bee Crafting - move to Jarred Bees

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/astralsorcery/altar.js
@@ -1,7 +1,7 @@
 onEvent('recipes', (event) => {
     const recipes = [
         {
-            output: Item.of('resourcefulbees:starry_bee_spawn_egg', 1),
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:starry_bee", BeeType: "starry", Color: "#002184"}),
             pattern: ['_____', '__E__', '_DCB_', '__A__', '_____'],
             key: {
                 A: {
@@ -12,7 +12,7 @@ onEvent('recipes', (event) => {
                     canBeCelestialCrystal: true
                 },
                 B: { item: 'resourcefulbees:gold_honeycomb' },
-                C: { item: 'resourcefulbees:iron_bee_spawn_egg' },
+                C: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:iron_bee", BeeType: "iron", Color: "#ffcc99"}).weakNBT().toJson(),
                 D: { item: 'resourcefulbees:iron_honeycomb' },
                 E: { item: 'astralsorcery:colored_lens_spectral' }
             },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/altar.js
@@ -10,15 +10,16 @@ onEvent('recipes', (event) => {
                 drainRate: 5,                       //How much LP is lost per operation when the altar is empty
                 id: 'input item here'
             }*/
-
+            
             {
-                input: 'resourcefulbees:bronze_bee_spawn_egg',
-                output: 'resourcefulbees:bloody_bee_spawn_egg',
+                input: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:bronze_bee", BeeType: "bronze", Color: "#d38c53"}).weakNBT(),
+                output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:bloody_bee", BeeType: "bloody", Color: "#80251f"}),
                 syphon: 50000,
                 altarLevel: 3,
                 consumptionRate: 50,
                 drainRate: 50
             }
+            
         ]
     };
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/elven_trade.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/elven_trade.js
@@ -1,10 +1,8 @@
 onEvent('recipes', (event) => {
     const recipes = [
         {
-            inputs: [{ item: 'resourcefulbees:mana_bee_spawn_egg' }],
-            output: {
-                item: 'resourcefulbees:elven_bee_spawn_egg'
-            }
+            inputs: [Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson()],
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:elven_bee", BeeType: "elven", Color: "#ff66cc"}).toJson()
         },
         {
             inputs: [{ item: 'resourcefulbees:elven_honeycomb' }, { item: 'resourcefulbees:elven_honeycomb' }],

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/mana_infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/botania/mana_infusion.js
@@ -1,9 +1,8 @@
 onEvent('recipes', (event) => {
     const recipes = [
         {
-            input: 'resourcefulbees:iron_bee_spawn_egg',
-            output: 'resourcefulbees:mana_bee_spawn_egg',
-            count: 1,
+            input: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:iron_bee", BeeType: "iron", Color: "#ffcc99"}),
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}),
             mana: 99999
         }
     ];
@@ -11,8 +10,8 @@ onEvent('recipes', (event) => {
     recipes.forEach((recipe) => {
         let constructed_recipe = {
             type: 'botania:mana_infusion',
-            input: Ingredient.of(recipe.input).toJson(),
-            output: { item: recipe.output, count: recipe.count },
+            input: Item.of(recipe.input).weakNBT().toJson(),
+            output: Item.of(recipe.output).toJson(),
             mana: recipe.mana
         };
         if (recipe.catalyst) {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/industrialforegoing/dissolution_chamber.js
@@ -46,18 +46,18 @@ onEvent('recipes', (event) => {
         {
             inputs: [
                 '#forge:ingots/pink_slime', // top left
-                'resourcefulbees:iron_bee_spawn_egg', // top 
+                'resourcefulbees:bee_jar', // top 
                 '#forge:ingots/pink_slime', // top right
-                '#resourcefulbees:resourceful_honeycomb_block', // left
-                '#resourcefulbees:resourceful_honeycomb_block', // right
-                'resourcefulbees:wax', // bottom left
-                'resourcefulbees:bee_jar', // bottom
-                'resourcefulbees:wax'  // bottom right
+                'resourcefulbees:iron_honeycomb_block', // left
+                'resourcefulbees:iron_honeycomb_block', // right
+                'resourcefulbees:iron_honey_block', // bottom left
+                '#industrialforegoing:machine_frame/advanced', // bottom
+                'resourcefulbees:iron_honey_block'  // bottom right
             ],
             inputFluid: 'industrialforegoing:pink_slime',
             inputFluidAmount: 1000,
             processingTime: 600,
-            outputItem: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:industrious_bee", BeeType: "industrious", Color: "#209EBD"}).toJson(),
+            outputItem: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:industrious_bee", BeeType: "industrious", Color: "#ce7dce"}).toJson(),
             outputFluid: '',
             outputFluidAmount: 0
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/animal_spawner.js
@@ -51,7 +51,11 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'resourcefulbees:iron_bee_spawn_egg',
+                    //'resourcefulbees:iron_bee_spawn_egg',
+                    {
+                        hasNBT: true,
+                        item: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:iron_bee", BeeType: "iron", Color: "#ffcc99"}).weakNBT().toJson()
+                    },
                     'resourcefulbees:iron_honeycomb',
                     'naturesaura:infused_iron_block'
                 ],
@@ -61,7 +65,11 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'resourcefulbees:gold_bee_spawn_egg',
+                    //'resourcefulbees:gold_bee_spawn_egg',
+                    {
+                        hasNBT: true,
+                        item: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:gold_bee", BeeType: "gold", Color: "#ffdc00"}).weakNBT().toJson()
+                    },
                     'resourcefulbees:gold_honeycomb',
                     'naturesaura:tainted_gold_block'
                 ],
@@ -71,7 +79,11 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'resourcefulbees:gold_bee_spawn_egg',
+                    //'resourcefulbees:gold_bee_spawn_egg',
+                    {
+                        hasNBT: true,
+                        item: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:gold_bee", BeeType: "gold", Color: "#ffdc00"}).weakNBT().toJson()
+                    },
                     'resourcefulbees:tainted_honeycomb',
                     'naturesaura:sky_ingot'
                 ],
@@ -106,7 +118,12 @@ onEvent('recipes', (event) => {
         let ingredients = [Ingredient.of('naturesaura:birth_spirit').toJson()];
 
         recipe.inputs.forEach((input) => {
-            ingredients.push(Ingredient.of(input).toJson());
+            if (input.hasNBT){
+                ingredients.push(input.item)
+            }
+            else {
+                ingredients.push(Ingredient.of(input).toJson())
+            };
         });
 
         const re = event.custom({

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/casting_table.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/tconstruct/casting_table.js
@@ -21,8 +21,9 @@ onEvent('recipes', (event) => {
                 name: 'kubejs:molten_cobalt_bee',
                 amount: 500
             },
-            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:cobalt_bee", BeeType: "cobalt", Color: "#209EBD"}).toJson(),
-            cooling_time: 200
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:cobalt_bee", BeeType: "cobalt", Color: "#209EBD"}).toResultJson(),
+            cooling_time: 200,
+            id: 'tconstruct:kjs_cobalt_bee_jar'
         },
         {
             cast: {
@@ -33,8 +34,9 @@ onEvent('recipes', (event) => {
                 name: 'kubejs:liquid_skyslime_bee',
                 amount: 500
             },
-            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:skyslime_bee", BeeType: "skyslime", Color: "#72CFCB"}).toJson(),
-            cooling_time: 100
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:skyslime_bee", BeeType: "skyslime", Color: "#72CFCB"}).toResultJson(),
+            cooling_time: 100,
+            id: 'tconstruct:kjs_skyslime_bee_jar'
         },
         {
             cast: {
@@ -45,8 +47,9 @@ onEvent('recipes', (event) => {
                 name: 'kubejs:liquid_ichor_bee',
                 amount: 500
             },
-            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:ichor_bee", BeeType: "ichor", Color: "#FDAB69"}).toJson(),
-            cooling_time: 100
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:ichor_bee", BeeType: "ichor", Color: "#FDAB69"}).toResultJson(),
+            cooling_time: 100,
+            id: 'tconstruct:kjs_ichor_bee_jar'
         },
         {
             cast: {
@@ -57,8 +60,9 @@ onEvent('recipes', (event) => {
                 name: 'kubejs:liquid_enderslime_bee',
                 amount: 500
             },
-            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:enderslime_bee", BeeType: "enderslime", Color: "#C75EFF"}).toJson(),
-            cooling_time: 100
+            result: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:enderslime_bee", BeeType: "enderslime", Color: "#C75EFF"}).toResultJson(),
+            cooling_time: 100,
+            id: 'tconstruct:kjs_enderslime_bee_jar'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
@@ -12,7 +12,7 @@ onEvent('recipes', (event) => {
             ],
             output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrestrial_bee", BeeType: "terrestrial", Color: "#5bf23d"}).toJson(),
             mana: 2000000,
-            id: 'resourcefulbees:terrestrial_bee_spawn_egg_plate'
+            id: 'botania:terra_plate/terrestrial_bee_plate'
         },
         {
             inputs: [
@@ -24,7 +24,8 @@ onEvent('recipes', (event) => {
                 { item: 'botania:quartz_mana' }
             ],
             output: { item: 'botania:terrasteel_ingot' },
-            mana: 300000
+            mana: 300000,
+            id: 'botania:terra_plate/terrasteel_ingot_honeycomb'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
@@ -5,13 +5,14 @@ onEvent('recipes', (event) => {
     const recipes = [
         {
             inputs: [
-                { item: 'resourcefulbees:mana_bee_spawn_egg' },
+                Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson(),
                 { item: 'botania:mana_pearl' },
                 { item: 'botania:mana_diamond' },
                 { item: 'botania:quartz_mana' }
             ],
-            output: { item: 'resourcefulbees:terrestrial_bee_spawn_egg' },
-            mana: 2000000
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrestrial_bee", BeeType: "terrestrial", Color: "#5bf23d"}).toJson(),
+            mana: 2000000,
+            id: 'resourcefulbees:terrestrial_bee_spawn_egg_plate'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -5,15 +5,16 @@ onEvent('recipes', (event) => {
     const recipes = [
         {
             inputs: [
-                { item: 'resourcefulbees:mana_bee_spawn_egg' },
+                Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson(),
                 { item: 'botania:mana_pearl' },
                 { item: 'botania:mana_diamond' },
                 { item: 'botania:quartz_mana' }
             ],
-            output: { item: 'resourcefulbees:terrestrial_bee_spawn_egg' },
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrestrial_bee", BeeType: "terrestrial", Color: "#5bf23d"}).toJson(),
             mana: 2000000,
             fromColor: parseInt('0xFFFFFF'),
-            toColor: parseInt('0x00FF00')
+            toColor: parseInt('0x00FF00'),
+            id: 'resourcefulbees:terrestrial_bee_spawn_egg_infusion'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -25,10 +25,11 @@ onEvent('recipes', (event) => {
                 { tag: 'forge:ingots/iesnium' },
                 { item: 'botania:quartz_mana' }
             ],
-            output: { item: 'mythicbotany:terrasteel_ingot_honeycomb' },
+            output: { item: 'botania:terrasteel_ingot' },
             mana: 300000,
             fromColor: parseInt('0xFFFFFF'),
-            toColor: parseInt('0x00FF00')
+            toColor: parseInt('0x00FF00'),
+            id: 'mythicbotany:mythicbotany_infusion/terrasteel_ingot_honeycomb'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -14,7 +14,7 @@ onEvent('recipes', (event) => {
             mana: 2000000,
             fromColor: parseInt('0xFFFFFF'),
             toColor: parseInt('0x00FF00'),
-            id: 'resourcefulbees:terrestrial_bee_spawn_egg_infusion'
+            id: 'mythicbotany:terrestrial_bee_spawn_egg_infusion'
         },
         {
             inputs: [
@@ -25,7 +25,7 @@ onEvent('recipes', (event) => {
                 { tag: 'forge:ingots/iesnium' },
                 { item: 'botania:quartz_mana' }
             ],
-            output: { item: 'botania:terrasteel_ingot' },
+            output: { item: 'mythicbotany:terrasteel_ingot_honeycomb' },
             mana: 300000,
             fromColor: parseInt('0xFFFFFF'),
             toColor: parseInt('0x00FF00')

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/terra_plate.js
@@ -4,31 +4,30 @@ onEvent('recipes', (event) => {
     }
     const recipes = [
         {
-            inputs: [Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson()],
-            output: {
-                item: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrastrial_bee", BeeType: "terrastrial", Color: "#5bf23d"}).toJson()
-            },
-            mana: 1000000,
-            id: 'resourcefulbees:terrestrial_bee_spawn_egg_plate'
+            inputs: [
+                Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson()
+            ],
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrestrial_bee", BeeType: "terrestrial", Color: "#5bf23d"}).toJson(),
+            mana: 2000000,
+            id: 'botania:terra_plate/terrestrial_bee_plate'
         },
         {
             inputs: [
-                { item: 'resourcefulbees:terrestrial_honeycomb' },
                 { item: 'botania:mana_pearl' },
+                { item: 'resourcefulbees:terrestrial_honeycomb' },
                 { item: 'botania:mana_diamond' }
             ],
-            output: {
-                item: 'botania:terrasteel_ingot'
-            },
-            mana: 300000
+            output: { item: 'botania:terrasteel_ingot' },
+            mana: 300000,
+            id: 'botania:terra_plate/terrasteel_ingot_honeycomb'
         }
     ];
 
     recipes.forEach((recipe) => {
         const re = event.custom({
             type: 'botania:terra_plate',
-            ingredients: recipe.inputs,
-            result: recipe.output,
+            ingredients: recipe.inputs.map((input) => Ingredient.of(input).toJson()),
+            result: Item.of(recipe.output).toJson(),
             mana: recipe.mana
         });
         if (recipe.id) {

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/botania/terra_plate.js
@@ -4,11 +4,12 @@ onEvent('recipes', (event) => {
     }
     const recipes = [
         {
-            inputs: [{ item: 'resourcefulbees:mana_bee_spawn_egg' }],
+            inputs: [Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson()],
             output: {
-                item: 'resourcefulbees:terrestrial_bee_spawn_egg'
+                item: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrastrial_bee", BeeType: "terrastrial", Color: "#5bf23d"}).toJson()
             },
-            mana: 1000000
+            mana: 1000000,
+            id: 'resourcefulbees:terrestrial_bee_spawn_egg_plate'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
@@ -11,7 +11,7 @@ onEvent('recipes', (event) => {
             mana: 2000000,
             fromColor: 255,
             toColor: 65280,
-            id: 'resourcefulbees:terrestrial_bee_spawn_egg_infusion'
+            id: 'mythicbotany:terrestrial_bee_spawn_egg_infusion'
         },
         {
             inputs: [
@@ -20,7 +20,7 @@ onEvent('recipes', (event) => {
                 { item: 'botania:mana_diamond' }
             ],
             output: {
-                item: 'botania:terrasteel_ingot'
+                item: 'mythicbotany:terrasteel_ingot_honeycomb'
             },
             mana: 300000,
             fromColor: 255,

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
@@ -5,14 +5,13 @@ onEvent('recipes', (event) => {
     const recipes = [
         {
             inputs: [
-                { item: 'resourcefulbees:mana_bee_spawn_egg' }
+                Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson()
             ],
-            output: {
-                item: 'resourcefulbees:terrestrial_bee_spawn_egg'
-            },
+            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrastrial_bee", BeeType: "terrastrial", Color: "#5bf23d"}).toJson(),
             mana: 2000000,
             fromColor: 255,
-            toColor: 65280
+            toColor: 65280,
+            id: 'resourcefulbees:terrestrial_bee_spawn_egg_infusion'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/mythicbotany/infusion.js
@@ -20,11 +20,12 @@ onEvent('recipes', (event) => {
                 { item: 'botania:mana_diamond' }
             ],
             output: {
-                item: 'mythicbotany:terrasteel_ingot_honeycomb'
+                item: 'botania:terrasteel_ingot'
             },
             mana: 300000,
             fromColor: 255,
-            toColor: 65280
+            toColor: 65280,
+            id: 'mythicbotany:mythicbotany_infusion/terrasteel_ingot_honeycomb'
         },
         {
             inputs: [


### PR DESCRIPTION
REQUIRES at least kubejs-forge-1605.3.15-build.80 and NBT-Ingredient-Predicate-1.3. I'm leaving this as a draft to start as we need to wait until we're ready to upgrade both.

Moves all bee crafting recipes using spawn eggs to use `.weakNBT()` with equivalent jarred bees. If we stick to this for bees that are crafted things should be more consistent - getting recipes for empty bee jars in JEI should bring up all crafted bees in that case since the only difference is NBT. This is possible via the weak-matching provided by the above mods, and will allow a bee picked up from the world in a jar to match despite having 45-46 tags vs. the 3 tags in the recipe. Once we've updated to Resourceful Bees 0.9.9.x we should even be able to bring the number of tags in the recipes down to 1.

Note: Industrial Foregoing's Dissolution Chamber does not appear to work with `.weakNBT()` ingredients, so I've adjusted the recipe to otherwise exclude the spawn egg and explicitly require Iron Bee products & an advanced machine frame. Should get the job done while I investigate with Max and Buuz.

Recipes now look as follows:

Elven Bee:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/13169307/129505259-4fc1b74e-d22a-49a7-8288-15f229ca1e45.png">

Mana Bee:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/13169307/129505279-b2fed0bf-f92f-48fb-a36a-a759b268d568.png">

Industrious Bee:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/13169307/129505358-5638c416-2ee4-4ebe-b2fa-0892a26960fb.png">

Starry Bee:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/13169307/129505385-11e901a6-014d-4bf2-ac33-d61fe90ec856.png">

Bloody Bee:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/13169307/129505421-b2ec5ccc-ec32-4865-a4ce-3d4bb393d6c3.png">

Terrestrial Bee:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/13169307/129505648-325629ed-5ced-4c38-980c-b099b8bb6672.png">
and:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/13169307/129572857-3f183d3d-7271-4ff7-91b1-850f0c34227f.png">

Nature's Aura Bees:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/13169307/129505704-793d8f7f-2f34-4a31-a75b-6b486d4c0f05.png">
