### PR TITLE
List names of mods excluded in the server installer

### DIFF
--- a/server_files/server-setup-config.yaml
+++ b/server_files/server-setup-config.yaml
@@ -58,15 +58,14 @@ install:
     formatSpecific:
         # optional paramenter used for curse to specify a whole project to ignore (mostly if it is client side only)
         ignoreProject:
-            - 254284
-            - 231275
-            - 237701
-            - 391382
-            - 238372
-            - 271740
-            - 358191
-            - 237701
-            - 470193
+            - 254284 #AmbientSounds 4
+            - 231275 #Ding
+            - 237701 #ReAuth
+            - 391382 #More Overlays Updated
+            - 238372 #Neat
+            - 271740 #Toast Control
+            - 358191 #PackMenu
+            - 470193 #Connectivity
 
     # The base path where the server should be installed to, ~ for current path
     baseInstallPath: ~


### PR DESCRIPTION
https://github.com/Yoosk/ServerStarter/blob/8a6ab8fe2592b2d5f7908f42eb1ed8124e512975/server-setup-config.yaml#L67

was digging through the serverstarter repo to try and make one for a pack that didn't have one, and i noticed that in their above example they added the names of the mods in comments after the id to better keep track.

i took the liberty to do the same to the server configuration file for enigmatica 6 to make it more easily maintainable.

(funny enough ReAuth/237701 was in there twice, thanks to this not anymore, also make it easier to see which is missing :3)