### PR TITLE
Start server by utilizing screen for easier management

### DIFF
--- a/server_files/start-server.sh
+++ b/server_files/start-server.sh
@@ -31,7 +31,11 @@ else
         echo "Neither wget or curl were found on your system. Please install one and try again"
     fi
 fi
-java -jar serverstarter-2.0.1.jar
+echo "Starting server in screen"
+echo "Detach from screen console by doing Control + A and then Control + D"
+echo "Reattach to screen console by doing 'screen -r enigmatica6'"
+echo "List available screen console by doing 'screen -list'"
+screen -dmS enigmatica6 java -jar serverstarter-2.0.1.jar
 if [[ $DO_RAMDISK -eq 1 ]]; then
     sudo umount "$SAVE_DIR"
     rm -rf "$SAVE_DIR"


### PR DESCRIPTION
Currently when not using screen even when detaching from the console the server still shuts down. By utilizing screen you are given the ability to manage your started server easier and detach without closing down the server.

Possible Considerations

What distributions have screen preinstalled.
- [x] Ubuntu (Confirmed) 
- [ ] Debian (Unknown)
- [ ] Fedora (Unknown)
- [ ] CentOS (Unknown)

What about utilizing Systemctl instead?