### PR TITLE
Remove conflicting stone brick smelting recipe

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -90,6 +90,7 @@ onEvent('recipes', (event) => {
         'create:fill_minecraft_bucket_with_create_honey',
 
         'eidolon:tallow',
+        'eidolon:smelt_stone_brick',
         'engineersdecor:dependent/slag_brick_block_recipe',
 
         'environmental:misc/cherries/cherry_pie',


### PR DESCRIPTION
Eidolon stone bricks can be crafted via stone cutting instead from smooth stone. Resolves #796