### PR TITLE
Speed up Occultism Rituals

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/ritual.js
@@ -1,0 +1,704 @@
+onEvent('recipes', (event) => {
+    const data = {
+        recipes: [
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:familiar',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_djinni',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:bats',
+                    display_name: 'ritual.occultism.sacrifice.bats'
+                },
+                entity_to_summon: 'occultism:bat_familiar',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_bat'
+                },
+                ingredients: [
+                    { item: 'minecraft:golden_carrot' },
+                    { item: 'minecraft:spider_eye' },
+                    { item: 'minecraft:glowstone' },
+                    { item: 'minecraft:lava_bucket' },
+                    { item: 'minecraft:torch' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_bat'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:familiar',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:possess_foliot',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:cows',
+                    display_name: 'ritual.occultism.sacrifice.cows'
+                },
+                entity_to_summon: 'occultism:deer_familiar',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_deer'
+                },
+                ingredients: [
+                    { tag: 'forge:rods/wooden' },
+                    { tag: 'forge:rods/wooden' },
+                    { tag: 'forge:rods/wooden' },
+                    { tag: 'forge:rods/wooden' },
+                    { tag: 'forge:string' },
+                    { tag: 'forge:string' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_deer'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:familiar',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:possess_foliot',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:zombies',
+                    display_name: 'ritual.occultism.sacrifice.zombies'
+                },
+                entity_to_summon: 'occultism:greedy_familiar',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_greedy'
+                },
+                ingredients: [
+                    { tag: 'forge:chests' },
+                    { tag: 'forge:storage_blocks/iron' },
+                    { item: 'minecraft:dispenser' },
+                    { item: 'minecraft:hopper' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_greedy'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_tamed',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_djinni',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:parrots',
+                    display_name: 'ritual.occultism.sacrifice.parrots'
+                },
+                entity_to_summon: 'occultism:otherworld_bird',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_otherworld_bird'
+                },
+                ingredients: [
+                    { tag: 'forge:feathers' },
+                    { tag: 'forge:feathers' },
+                    { item: 'minecraft:cobweb' },
+                    { tag: 'minecraft:leaves' },
+                    { tag: 'forge:string' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_otherworld_bird'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_with_chance_of_chicken_tamed',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:possess_foliot',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:chicken',
+                    display_name: 'ritual.occultism.sacrifice.chicken'
+                },
+                entity_to_summon: 'minecraft:parrot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_parrot'
+                },
+                ingredients: [
+                    { tag: 'forge:feathers' },
+                    { tag: 'forge:dyes/green' },
+                    { tag: 'forge:dyes/yellow' },
+                    { tag: 'forge:dyes/red' },
+                    { tag: 'forge:dyes/blue' },
+                    { tag: 'forge:string' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_parrot'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_djinni',
+                duration: 6,
+                entity_to_sacrifice: {
+                    tag: 'forge:pigs',
+                    display_name: 'ritual.occultism.sacrifice.pigs'
+                },
+                entity_to_summon: 'occultism:possessed_enderman',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/possess_enderman'
+                },
+                ingredients: [
+                    { tag: 'forge:bones' },
+                    { tag: 'forge:string' },
+                    { tag: 'forge:end_stones' },
+                    { item: 'minecraft:rotten_flesh' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/possess_enderman'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                duration: 3,
+                pentacle_id: 'occultism:possess_foliot',
+                item_to_use: {
+                    item: 'minecraft:egg'
+                },
+                entity_to_summon: 'occultism:possessed_endermite',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/possess_endermite'
+                },
+                ingredients: [
+                    { item: 'minecraft:dirt' },
+                    { item: 'minecraft:stone' },
+                    { item: 'minecraft:dirt' },
+                    { item: 'minecraft:stone' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/possess_endermite'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:possess_foliot',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:chicken',
+                    display_name: 'ritual.occultism.sacrifice.chicken'
+                },
+                entity_to_summon: 'occultism:possessed_skeleton',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/possess_skeleton'
+                },
+                ingredients: [
+                    { tag: 'forge:bones' },
+                    { tag: 'forge:bones' },
+                    { tag: 'forge:bones' },
+                    { tag: 'forge:bones' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/possess_skeleton'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_afrit'
+                },
+                pentacle_id: 'occultism:summon_afrit',
+                duration: 12,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier3',
+                entity_to_summon: 'occultism:afrit',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_afrit_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:gems/diamond' },
+                    { tag: 'forge:dusts/iesnium' },
+                    { tag: 'forge:dusts/iesnium' },
+                    { tag: 'forge:gems/emerald' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_afrit_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_afrit'
+                },
+                pentacle_id: 'occultism:summon_afrit',
+                duration: 6,
+                spirit_max_age: 120,
+                spirit_job_type: 'occultism:rain_weather',
+                entity_to_sacrifice: {
+                    tag: 'forge:cows',
+                    display_name: 'ritual.occultism.sacrifice.cows'
+                },
+                entity_to_summon: 'occultism:afrit',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_afrit_rain_weather'
+                },
+                ingredients: [
+                    { tag: 'forge:sand' },
+                    { tag: 'forge:gems/diamond' },
+                    { item: 'minecraft:cactus' },
+                    { item: 'minecraft:dead_bush' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_afrit_rain_weather'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_afrit'
+                },
+                pentacle_id: 'occultism:summon_afrit',
+                duration: 6,
+                spirit_max_age: 240,
+                spirit_job_type: 'occultism:thunder_weather',
+                entity_to_sacrifice: {
+                    tag: 'forge:cows',
+                    display_name: 'ritual.occultism.sacrifice.cows'
+                },
+                entity_to_summon: 'occultism:afrit',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_afrit_thunder_weather'
+                },
+                ingredients: [
+                    { tag: 'forge:bones' },
+                    { tag: 'forge:gunpowder' },
+                    { tag: 'forge:gunpowder' },
+                    { item: 'minecraft:ghast_tear' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_afrit_thunder_weather'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 6,
+                spirit_max_age: 60,
+                spirit_job_type: 'occultism:clear_weather',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_clear_weather'
+                },
+                ingredients: [
+                    { tag: 'forge:crops/beetroot' },
+                    { tag: 'forge:crops/carrot' },
+                    { tag: 'forge:crops/potato' },
+                    { tag: 'forge:crops/wheat' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_djinni_clear_weather'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 9,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier2',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:dusts/iron' },
+                    { tag: 'forge:dusts/gold' },
+                    { tag: 'forge:dusts/copper' },
+                    { tag: 'forge:dusts/silver' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_djinni_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 6,
+                spirit_max_age: 60,
+                spirit_job_type: 'occultism:day_time',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_day_time'
+                },
+                ingredients: [
+                    { item: 'minecraft:torch' },
+                    { tag: 'minecraft:saplings' },
+                    { item: 'minecraft:wheat' },
+                    { tag: 'forge:dyes/yellow' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_djinni_day_time'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:manage_machine',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_manage_machine'
+                },
+                ingredients: [
+                    { tag: 'forge:storage_blocks/coal' },
+                    { tag: 'forge:ingots/gold' },
+                    { tag: 'forge:ingots/iron' },
+                    { item: 'minecraft:furnace' }
+                ],
+                result: {
+                    item: 'occultism:book_of_calling_djinni_manage_machine'
+                },
+                id: 'occultism:ritual/summon_djinni_manage_machine'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 6,
+                spirit_max_age: 60,
+                spirit_job_type: 'occultism:night_time',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_night_time'
+                },
+                ingredients: [
+                    { tag: 'minecraft:beds' },
+                    { item: 'minecraft:rotten_flesh' },
+                    { tag: 'forge:bones' },
+                    { tag: 'forge:dyes/black' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_djinni_night_time'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:manage_machine',
+                entity_to_summon: 'occultism:cleaner',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_cleaner'
+                },
+                ingredients: [
+                    { item: 'occultism:brush' },
+                    { tag: 'forge:chests' },
+                    { item: 'minecraft:dispenser' },
+                    { item: 'minecraft:hopper' }
+                ],
+                result: {
+                    item: 'occultism:book_of_calling_foliot_cleaner'
+                },
+                id: 'occultism:ritual/summon_foliot_cleaner'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier1',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:ores/iron' },
+                    { tag: 'forge:ores/gold' },
+                    { tag: 'forge:ores/copper' },
+                    { tag: 'forge:ores/silver' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_foliot_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:lumberjack',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_lumberjack'
+                },
+                ingredients: [
+                    { tag: 'occultism:saplings/otherworld' },
+                    { item: 'minecraft:oak_sapling' },
+                    { item: 'minecraft:birch_sapling' },
+                    { item: 'minecraft:spruce_sapling' },
+                    { tag: 'forge:tools/metal/axes' }
+                ],
+                result: {
+                    item: 'occultism:book_of_calling_foliot_lumberjack'
+                },
+                id: 'occultism:ritual/summon_foliot_lumberjack'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 3,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:trade_otherstone_t1',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_otherstone_trader'
+                },
+                ingredients: [
+                    { item: 'minecraft:stone' },
+                    { item: 'minecraft:granite' },
+                    { item: 'minecraft:diorite' },
+                    { item: 'minecraft:andesite' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_foliot_otherstone_trader'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 3,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:trade_otherworld_saplings_t1',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_sapling_trader'
+                },
+                ingredients: [
+                    { item: 'minecraft:oak_sapling' },
+                    { item: 'minecraft:birch_sapling' },
+                    { item: 'minecraft:spruce_sapling' },
+                    { item: 'minecraft:jungle_sapling' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_foliot_sapling_trader'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:transport_items',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_transport_items'
+                },
+                ingredients: [
+                    { item: 'minecraft:minecart' },
+                    { tag: 'forge:chests' },
+                    { item: 'minecraft:dispenser' },
+                    { item: 'minecraft:hopper' }
+                ],
+                result: {
+                    item: 'occultism:book_of_calling_foliot_transport_items'
+                },
+                id: 'occultism:ritual/summon_foliot_transport_items'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_marid'
+                },
+                pentacle_id: 'occultism:summon_marid',
+                duration: 3,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier4',
+                entity_to_summon: 'occultism:marid',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_marid_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:storage_blocks/diamond' },
+                    { item: 'minecraft:ghast_tear' },
+                    { tag: 'forge:storage_blocks/iesnium' },
+                    { tag: 'forge:storage_blocks/emerald' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_marid_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_wild_hunt',
+                activation_item: {
+                    item: 'minecraft:skeleton_skull'
+                },
+                pentacle_id: 'occultism:summon_wild_greater_spirit',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'occultism:wild_hunt_sacrifices',
+                    display_name: 'ritual.occultism.sacrifice.villagers_or_players'
+                },
+                entity_to_summon: 'occultism:wild_hunt_wither_skeleton',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_wild_hunt'
+                },
+                ingredients: [
+                    { tag: 'forge:storage_blocks/copper' },
+                    { tag: 'forge:storage_blocks/silver' },
+                    { tag: 'forge:storage_blocks/gold' },
+                    { tag: 'forge:gems/diamond' },
+                    { tag: 'forge:netherrack' },
+                    { item: 'minecraft:soul_sand' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_wild_hunt'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_djinni',
+                duration: 30,
+                entity_to_sacrifice: {
+                    tag: 'forge:parrots',
+                    display_name: 'ritual.occultism.sacrifice.parrots'
+                },
+                entity_to_summon: 'occultism:otherworld_bird',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_wild_otherworld_bird'
+                },
+                ingredients: [
+                    { tag: 'forge:feathers' },
+                    { tag: 'forge:feathers' },
+                    { item: 'minecraft:cobweb' },
+                    { tag: 'minecraft:leaves' },
+                    { tag: 'forge:eggs' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_wild_otherworld_bird'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_foliot',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'forge:chicken',
+                    display_name: 'ritual.occultism.sacrifice.chicken'
+                },
+                entity_to_summon: 'minecraft:parrot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_wild_parrot'
+                },
+                ingredients: [
+                    { tag: 'forge:feathers' },
+                    { tag: 'forge:dyes/green' },
+                    { tag: 'forge:dyes/yellow' },
+                    { tag: 'forge:dyes/red' },
+                    { tag: 'forge:dyes/blue' },
+                    { tag: 'forge:eggs' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_wild_parrot'
+            }
+        ]
+    };
+
+    data.recipes.forEach((recipe) => {
+        const re = event.custom(recipe);
+        if (recipe.id) {
+            re.id(recipe.id);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/ritual.js
@@ -1,5 +1,5 @@
 onEvent('recipes', (event) => {
-    if (global.isExpertMode == false) {
+    if (global.isNormalMode == false) {
         return;
     }
     const data = {
@@ -15,14 +15,15 @@ onEvent('recipes', (event) => {
                 ritual_dummy: {
                     item: 'occultism:ritual_dummy/craft_infused_lenses'
                 },
-                ngredients: [
+                ingredients: [
                     { item: 'occultism:lenses' },
-                    { tag: 'forge:ingots/lumium' },
-                    { tag: 'forge:ingots/lumium' },
-                    { tag: 'forge:ingots/arcane_gold' },
-                    { item: 'bloodmagic:reagentsight' }
+                    { tag: 'forge:ingots/silver' },
+                    { tag: 'forge:ingots/silver' },
+                    { tag: 'forge:ingots/gold' }
                 ],
-                result: { item: 'occultism:infused_lenses' },
+                result: {
+                    item: 'occultism:infused_lenses'
+                },
                 id: 'occultism:ritual/craft_infused_lenses'
             },
             {
@@ -37,14 +38,15 @@ onEvent('recipes', (event) => {
                     item: 'occultism:ritual_dummy/craft_infused_pickaxe'
                 },
                 ingredients: [
+                    { tag: 'forge:rods/wooden' },
+                    { tag: 'forge:rods/wooden' },
                     { item: 'occultism:spirit_attuned_pickaxe_head' },
-                    { item: 'betterendforge:leather_wrapped_stick' },
-                    { item: 'eidolon:ender_calx' },
-                    { item: 'betterendforge:leather_wrapped_stick' },
-                    { tag: 'forge:nuggets/nebu' },
-                    { tag: 'forge:nuggets/nebu' }
+                    { tag: 'forge:ingots/silver' },
+                    { tag: 'forge:ingots/silver' }
                 ],
-                result: { item: 'occultism:infused_pickaxe' },
+                result: {
+                    item: 'occultism:infused_pickaxe'
+                },
                 id: 'occultism:ritual/craft_infused_pickaxe'
             },
             {
@@ -59,16 +61,18 @@ onEvent('recipes', (event) => {
                     item: 'occultism:ritual_dummy/craft_soul_gem'
                 },
                 ingredients: [
-                    { item: 'eidolon:lesser_soul_gem' },
-                    { item: 'eidolon:gold_inlay' },
-                    { item: 'bloodmagic:reagentholding' },
-                    { item: 'eidolon:gold_inlay' },
-                    { item: 'glassential:glass_ghostly' },
-                    { item: 'glassential:glass_ghostly' },
-                    { item: 'glassential:glass_ghostly' },
-                    { item: 'glassential:glass_ghostly' }
+                    { tag: 'forge:gems/diamond' },
+                    { tag: 'forge:ingots/copper' },
+                    { tag: 'forge:ingots/silver' },
+                    { tag: 'forge:ingots/gold' },
+                    { item: 'minecraft:soul_sand' },
+                    { item: 'minecraft:soul_sand' },
+                    { item: 'minecraft:soul_sand' },
+                    { item: 'minecraft:soul_sand' }
                 ],
-                result: { item: 'occultism:soul_gem' },
+                result: {
+                    item: 'occultism:soul_gem'
+                },
                 id: 'occultism:ritual/craft_soul_gem'
             },
             {
@@ -88,16 +92,14 @@ onEvent('recipes', (event) => {
                     item: 'occultism:ritual_dummy/summon_wild_afrit'
                 },
                 ingredients: [
-                    { item: 'eidolon:gold_inlay' },
-                    { tag: 'botania:runes/fire' },
-                    { item: 'eidolon:crimson_essence' },
-                    { tag: 'botania:runes/wrath' },
-                    { item: 'ars_nouveau:red_archwood_wood' },
-                    { item: 'ars_nouveau:red_archwood_wood' },
-                    { item: 'ars_nouveau:red_archwood_wood' },
-                    { item: 'ars_nouveau:red_archwood_wood' }
+                    { tag: 'forge:netherrack' },
+                    { tag: 'forge:gems/quartz' },
+                    { item: 'minecraft:flint_and_steel' },
+                    { item: 'minecraft:gunpowder' }
                 ],
-                result: { item: 'occultism:jei_dummy/none' },
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
                 id: 'occultism:ritual/summon_wild_afrit'
             },
             {
@@ -112,20 +114,14 @@ onEvent('recipes', (event) => {
                     item: 'occultism:ritual_dummy/craft_dimensional_matrix'
                 },
                 ingredients: [
-                    { tag: 'quark:crystal_clusters' },
-                    { tag: 'quark:crystal_clusters' },
-                    { tag: 'quark:crystal_clusters' },
-                    { tag: 'quark:crystal_clusters' },
-                    { item: 'eidolon:ender_calx' },
-                    { item: 'eidolon:ender_calx' },
-                    { item: 'eidolon:ender_calx' },
-                    { item: 'eidolon:ender_calx' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' }
+                    { tag: 'forge:storage_blocks/quartz' },
+                    { tag: 'forge:storage_blocks/quartz' },
+                    { tag: 'forge:storage_blocks/quartz' },
+                    { tag: 'forge:ender_pearls' }
                 ],
-                result: { item: 'occultism:dimensional_matrix' },
+                result: {
+                    item: 'occultism:dimensional_matrix'
+                },
                 id: 'occultism:ritual/craft_dimensional_matrix'
             },
             {
@@ -141,19 +137,13 @@ onEvent('recipes', (event) => {
                 },
                 ingredients: [
                     { item: 'occultism:otherstone_pedestal' },
-                    { tag: 'forge:storage_blocks/bronze' },
-                    { tag: 'botania:runes/greed' },
-                    { tag: 'forge:storage_blocks/bronze' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { tag: 'quark:runes' },
-                    { tag: 'quark:runes' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' }
+                    { tag: 'forge:storage_blocks/copper' },
+                    { item: 'minecraft:blaze_powder' },
+                    { item: 'occultism:spirit_attuned_gem' }
                 ],
-                result: { item: 'occultism:storage_stabilizer_tier1' },
+                result: {
+                    item: 'occultism:storage_stabilizer_tier1'
+                },
                 id: 'occultism:ritual/craft_stabilizer_tier1'
             },
             {
@@ -170,18 +160,13 @@ onEvent('recipes', (event) => {
                 ingredients: [
                     { item: 'occultism:storage_stabilizer_tier1' },
                     { tag: 'forge:storage_blocks/silver' },
-                    { tag: 'botania:runes/pride' },
-                    { tag: 'forge:storage_blocks/silver' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { tag: 'forge:gems/dimensional' },
-                    { tag: 'forge:gems/dimensional' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' },
-                    { item: 'bloodmagic:defaultcrystal' }
+                    { item: 'minecraft:ghast_tear' },
+                    { item: 'occultism:spirit_attuned_gem' },
+                    { item: 'occultism:spirit_attuned_gem' }
                 ],
-                result: { item: 'occultism:storage_stabilizer_tier2' },
+                result: {
+                    item: 'occultism:storage_stabilizer_tier2'
+                },
                 id: 'occultism:ritual/craft_stabilizer_tier2'
             },
             {
@@ -197,19 +182,13 @@ onEvent('recipes', (event) => {
                 },
                 ingredients: [
                     { item: 'occultism:storage_stabilizer_tier2' },
-                    { tag: 'forge:storage_blocks/electrum' },
-                    { tag: 'botania:runes/sloth' },
-                    { tag: 'forge:storage_blocks/electrum' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'astralsorcery:celestial_crystal' },
-                    { item: 'astralsorcery:celestial_crystal' },
-                    { item: 'bloodmagic:steadfastcrystal' },
-                    { item: 'bloodmagic:steadfastcrystal' },
-                    { item: 'bloodmagic:steadfastcrystal' },
-                    { item: 'bloodmagic:steadfastcrystal' }
+                    { tag: 'forge:storage_blocks/gold' },
+                    { item: 'minecraft:nether_star' },
+                    { item: 'occultism:spirit_attuned_crystal' }
                 ],
-                result: { item: 'occultism:storage_stabilizer_tier3' },
+                result: {
+                    item: 'occultism:storage_stabilizer_tier3'
+                },
                 id: 'occultism:ritual/craft_stabilizer_tier3'
             },
             {
@@ -226,18 +205,13 @@ onEvent('recipes', (event) => {
                 ingredients: [
                     { item: 'occultism:storage_stabilizer_tier3' },
                     { tag: 'forge:storage_blocks/iesnium' },
-                    { tag: 'botania:runes/envy' },
-                    { tag: 'forge:storage_blocks/iesnium' },
+                    { item: 'minecraft:dragon_head' },
                     { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'betterendforge:eternal_crystal' },
-                    { item: 'betterendforge:eternal_crystal' },
-                    { tag: 'atum:godshards' },
-                    { tag: 'atum:godshards' },
-                    { tag: 'atum:godshards' },
-                    { tag: 'atum:godshards' }
+                    { item: 'occultism:spirit_attuned_crystal' }
                 ],
-                result: { item: 'occultism:storage_stabilizer_tier4' },
+                result: {
+                    item: 'occultism:storage_stabilizer_tier4'
+                },
                 id: 'occultism:ritual/craft_stabilizer_tier4'
             },
             {
@@ -254,11 +228,13 @@ onEvent('recipes', (event) => {
                 ingredients: [
                     { item: 'occultism:magic_lamp_empty' },
                     { item: 'occultism:iesnium_pickaxe' },
-                    { item: 'atum:ptah_godforged_block' },
+                    { tag: 'forge:ores/gold' },
                     { tag: 'forge:storage_blocks/iesnium' },
                     { item: 'occultism:spirit_attuned_crystal' }
                 ],
-                result: { item: 'occultism:miner_djinni_ores' },
+                result: {
+                    item: 'occultism:miner_djinni_ores'
+                },
                 id: 'occultism:ritual/craft_miner_djinni_ores'
             },
             {
@@ -275,10 +251,12 @@ onEvent('recipes', (event) => {
                 ingredients: [
                     { item: 'occultism:magic_lamp_empty' },
                     { item: 'occultism:iesnium_pickaxe' },
-                    { tag: 'atum:relic_non_dirty/brooch' },
-                    { item: 'atum:limestone_gravel' }
+                    { tag: 'forge:ores/iron' },
+                    { item: 'minecraft:gravel' }
                 ],
-                result: { item: 'occultism:miner_foliot_unspecialized' },
+                result: {
+                    item: 'occultism:miner_foliot_unspecialized'
+                },
                 id: 'occultism:ritual/craft_miner_foliot_unspecialized'
             },
             {
@@ -297,12 +275,13 @@ onEvent('recipes', (event) => {
                     { item: 'occultism:otherstone' },
                     { item: 'occultism:otherstone' },
                     { item: 'occultism:otherstone' },
-                    { item: 'atum:scarab' },
+                    { tag: 'forge:ingots/gold' },
                     { tag: 'forge:storage_blocks/iesnium' },
-                    { item: 'occultism:spirit_attuned_crystal' },
-                    { item: 'atum:scarab' }
+                    { item: 'occultism:spirit_attuned_crystal' }
                 ],
-                result: { item: 'occultism:dimensional_mineshaft' },
+                result: {
+                    item: 'occultism:dimensional_mineshaft'
+                },
                 id: 'occultism:ritual/craft_dimensional_mineshaft'
             },
             {
@@ -318,11 +297,14 @@ onEvent('recipes', (event) => {
                 },
                 ingredients: [
                     { item: 'occultism:soul_gem' },
-                    { item: 'eidolon:gold_inlay' },
-                    { tag: 'atum:relic_non_dirty/ring' },
-                    { item: 'eidolon:gold_inlay' }
+                    { tag: 'forge:ingots/gold' },
+                    { tag: 'forge:ingots/gold' },
+                    { tag: 'forge:ingots/silver' },
+                    { tag: 'forge:ingots/silver' }
                 ],
-                result: { item: 'occultism:familiar_ring' },
+                result: {
+                    item: 'occultism:familiar_ring'
+                },
                 id: 'occultism:ritual/craft_familiar_ring'
             },
             {
@@ -338,12 +320,13 @@ onEvent('recipes', (event) => {
                 },
                 ingredients: [
                     { item: 'occultism:otherstone_pedestal' },
-                    { item: 'eidolon:gold_inlay' },
-                    { tag: 'forge:ingots/nebu' },
-                    { item: 'eidolon:gold_inlay' },
-                    { item: 'botania:corporea_spark_master' }
+                    { tag: 'forge:ingots/gold' },
+                    { tag: 'forge:ingots/gold' },
+                    { tag: 'forge:ingots/gold' }
                 ],
-                result: { item: 'occultism:storage_controller_base' },
+                result: {
+                    item: 'occultism:storage_controller_base'
+                },
                 id: 'occultism:ritual/craft_storage_controller_base'
             },
             {
@@ -359,11 +342,13 @@ onEvent('recipes', (event) => {
                 },
                 ingredients: [
                     { item: 'occultism:wormhole_frame' },
-                    { item: 'botania:corporea_spark' },
-                    { item: 'botania:corporea_funnel' },
-                    { item: 'botania:corporea_spark' }
+                    { tag: 'forge:ender_pearls' },
+                    { tag: 'forge:gems/quartz' },
+                    { tag: 'forge:gems/quartz' }
                 ],
-                result: { item: 'occultism:stable_wormhole' },
+                result: {
+                    item: 'occultism:stable_wormhole'
+                },
                 id: 'occultism:ritual/craft_stable_wormhole'
             },
             {
@@ -379,11 +364,13 @@ onEvent('recipes', (event) => {
                 },
                 ingredients: [
                     { item: 'occultism:storage_remote_inert' },
-                    { item: 'botania:corporea_spark' },
-                    { item: 'atum:scarab' },
-                    { item: 'botania:corporea_spark' }
+                    { tag: 'forge:ender_pearls' },
+                    { tag: 'forge:ender_pearls' },
+                    { tag: 'forge:gems/quartz' }
                 ],
-                result: { item: 'occultism:storage_remote' },
+                result: {
+                    item: 'occultism:storage_remote'
+                },
                 id: 'occultism:ritual/craft_storage_remote'
             },
             {
@@ -398,11 +385,11 @@ onEvent('recipes', (event) => {
                     item: 'occultism:ritual_dummy/craft_satchel'
                 },
                 ingredients: [
-                    { item: 'ironchest:silver_chest' },
-                    { item: 'ars_nouveau:end_fiber' },
-                    { item: 'alexsmobs:kangaroo_hide' },
-                    { item: 'ars_nouveau:end_fiber' },
-                    { tag: 'forge:ingots/infused_iron' }
+                    { tag: 'forge:chests/wooden' },
+                    { tag: 'forge:leather' },
+                    { tag: 'forge:leather' },
+                    { tag: 'forge:string' },
+                    { tag: 'forge:ingots/silver' }
                 ],
                 result: {
                     item: 'occultism:satchel'


### PR DESCRIPTION
Brings in all current rituals into scripts. Bit overkill, but the main reason was to reduce the craft time of rituals, some of which took a pretty long time.

Most rituals have been made roughly 10x faster. So a ritual that previously took 240 ticks per item, now takes 24 per item.

Also fixes Wild Hunt and Afrit summoning being broken.