### PR TITLE
[Expert] Extended Initial Compressed Iron Recipe

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -107,6 +107,11 @@
     "item.kubejs.basic_circuit_package": "Basic Control Circuit Assembly Package",
     "item.kubejs.basic_circuit_assembly": "Unpacked Basic Control Circuit Assembly Package",
 
+    "item.kubejs.superheated_steel_ingot": "Superheated Steel Ingot",
+    "block.kubejs.superheated_steel_block": "Superheated Block of Steel",
+    "item.kubejs.hot_compressed_iron_ingot": "Hot Compressed Iron Ingot",
+    "block.kubejs.hot_compressed_iron_block": "Hot Compressed Iron Block",
+
     "item.kubejs.basic_lenses_package": "Basic Lens Assembly Package",
 
     "item.kubejs.direhouse": "DireHouse",

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -110,7 +110,7 @@
     "item.kubejs.superheated_steel_ingot": "Superheated Steel Ingot",
     "block.kubejs.superheated_steel_block": "Superheated Block of Steel",
     "item.kubejs.hot_compressed_iron_ingot": "Hot Compressed Iron Ingot",
-    "block.kubejs.hot_compressed_iron_block": "Hot Compressed Iron Block",
+    "block.kubejs.hot_compressed_iron_block": "Hot Block of Compressed Iron",
 
     "item.kubejs.basic_lenses_package": "Basic Lens Assembly Package",
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -30,7 +30,9 @@ onEvent('recipes', (event) => {
         'darkutils:crafting/rune_damage_player',
         /emendatusenigmatica:alloy_dust/,
         'thermal:compat/refinedstorage/smelter_refinedstorage_alloy_quartz_enriched_iron',
-        'refinedstorage:quartz_enriched_iron'
+        'refinedstorage:quartz_enriched_iron',
+        'pneumaticcraft:explosion_crafting/compressed_iron_ingot',
+        'pneumaticcraft:explosion_crafting/compressed_iron_block'
     ];
 
     const outputRemovals = ['tiab:timeinabottle'];

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_explode.js
@@ -30,27 +30,27 @@ onEvent('recipes', (event) => {
             inputs: [
                 { tag: 'forge:ingots/steel', count: 2 },
                 { tag: 'forge:tar', count: 2 },
-                { tag: 'forge:obsidian', count: 1 }
+                { tag: 'forge:obsidian', count: 2 }
             ],
             output: {
-                entries: [{ result: { item: 'pneumaticcraft:ingot_iron_compressed', count: 4 }, weight: 1 }],
+                entries: [{ result: { item: 'kubejs:superheated_steel_ingot', count: 4 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
             },
-            id: 'pneumaticcraft:explosion_crafting/compressed_iron_ingot'
+            id: 'enigmatica:expert/interactio/superheated_steel_ingot'
         },
         {
             inputs: [
                 { tag: 'forge:storage_blocks/steel', count: 2 },
                 { tag: 'forge:tar', count: 18 },
-                { tag: 'forge:obsidian', count: 9 }
+                { tag: 'forge:obsidian', count: 18 }
             ],
             output: {
-                entries: [{ result: { item: 'pneumaticcraft:compressed_iron_block', count: 4 }, weight: 1 }],
+                entries: [{ result: { item: 'kubejs:superheated_steel_block', count: 4 }, weight: 1 }],
                 empty_weight: 0,
                 rolls: 1
             },
-            id: 'pneumaticcraft:explosion_crafting/compressed_iron_block'
+            id: 'enigmatica:expert/interactio/superheated_steel_block'
         },
         {
             inputs: [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_fluid_transform.js
@@ -68,6 +68,32 @@ onEvent('recipes', (event) => {
             },
             consume_fluid: 1.0,
             id: 'meetyourfight:spectres_eye'
+        },
+        {
+            inputs: [
+                { item: 'kubejs:hot_compressed_iron_ingot', count: 1 }
+            ],
+            fluid: { fluid: 'water' },
+            output: {
+                entries: [{ result: { item: 'pneumaticcraft:ingot_iron_compressed', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            },
+            consume_fluid: 0.2,
+            id: 'enigmatica:expert/interactio/ingot_iron_compressed'
+        },
+        {
+            inputs: [
+                { item: 'kubejs:hot_compressed_iron_block', count: 1 }
+            ],
+            fluid: { fluid: 'water' },
+            output: {
+                entries: [{ result: { item: 'pneumaticcraft:compressed_iron_block', count: 1 }, weight: 1 }],
+                empty_weight: 0,
+                rolls: 1
+            },
+            consume_fluid: 1.0,
+            id: 'enigmatica:expert/interactio/compressed_iron_block'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/press.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/machine/press.js
@@ -1,0 +1,32 @@
+onEvent('recipes', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            inputs: [
+                Item.of('4x kubejs:superheated_steel_ingot'),
+                Ingredient.of('#thermal:crafting/dies/packing_2x2')
+            ],
+            outputs: Item.of('2x kubejs:hot_compressed_iron_ingot'),
+            energy: 1000,
+            id: 'enigmatica:expert/thermal/hot_compressed_iron_ingot'
+        },
+        {
+            inputs: [
+                Item.of('4x kubejs:superheated_steel_block'),
+                Ingredient.of('#thermal:crafting/dies/packing_2x2')
+            ],
+            outputs: Item.of('2x kubejs:hot_compressed_iron_block'),
+            energy: 9000,
+            id: 'enigmatica:expert/thermal/hot_compressed_iron_block'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        recipe.id
+            ? event.recipes.thermal.press(recipe.outputs, recipe.inputs).energy(recipe.energy).id(recipe.id)
+            : event.recipes.thermal.press(recipe.outputs, recipe.inputs).energy(recipe.energy);
+    });
+});

--- a/kubejs/startup_scripts/block_registry.js
+++ b/kubejs/startup_scripts/block_registry.js
@@ -1,5 +1,9 @@
 onEvent('block.registry', (event) => {
-    const blocks = [{ name: 'firmament', material: 'rock', hardness: 2 }];
+    const blocks = [
+        { name: 'firmament', material: 'rock', hardness: 2 },
+        { name: 'superheated_steel_block', material: 'iron', hardness: 5 },
+        { name: 'hot_compressed_iron_block', material: 'iron', hardness: 5 }
+    ];
 
     blocks.forEach((block) => {
         event.create(block.name).material(block.material).hardness(block.hardness);

--- a/kubejs/startup_scripts/item_registry.js
+++ b/kubejs/startup_scripts/item_registry.js
@@ -21,7 +21,9 @@ onEvent('item.registry', (event) => {
         'cutting_essence',
         'rftools_machine_frame_parts',
         'unassembled_rftools_machine_frame_top',
-        'unassembled_rftools_machine_frame'
+        'unassembled_rftools_machine_frame',
+        'superheated_steel_ingot',
+        'hot_compressed_iron_ingot'
     ];
 
     const assemblyTableItems = [


### PR DESCRIPTION
Modifies Compressed Iron Ingot and Block gating. Rather than explosion crafting directly creating Compressed Iron, it produces Superheated Steel:

<img width="608" alt="image" src="https://user-images.githubusercontent.com/13169307/131272691-fd9ab530-517c-4e44-9125-a97278d0582f.png">
<img width="630" alt="image" src="https://user-images.githubusercontent.com/13169307/131272720-915737eb-42a1-4db9-b92d-55ede094a8fc.png">

Superheated Steel can be packed in a Thermal Multiservo Press into Hot Compressed Iron:

<img width="554" alt="image" src="https://user-images.githubusercontent.com/13169307/131272840-cf4afa11-9131-43de-9965-1139e464b139.png">
<img width="573" alt="image" src="https://user-images.githubusercontent.com/13169307/131272853-fb8d1ff7-02ec-48e5-b492-8920c3f3933f.png">

Which can be cooled into Compressed Iron:

<img width="596" alt="image" src="https://user-images.githubusercontent.com/13169307/131272938-2bbca5dc-377e-4ed5-a50f-87ff7f8256eb.png">
<img width="638" alt="image" src="https://user-images.githubusercontent.com/13169307/131272923-6a544674-44f3-412f-a88f-e55f4d05a718.png">

I'm not including any texture assets (despite the screenshots above), and will instead be begging Rid for art as usual!

This will be bypassed via the Pressure Chamber once it's constructed, which currently directly creates Compressed Iron. But... what if it didn't? I'm thinking that we have the pressure chamber convert Superheated Steel to Compressed Iron, maybe with packed or blue ice, at a better ratio than the initial gate - this would get the player a better production ratio & skip the multiservo press/water cooling steps.

Added bonus if we go this route - add a later Create Mixing superheated recipe to produce Superheated Steel. This would be much easier to automate than explosion crafting, and I would again give this a better production ratio than explosion crafting.