### PR TITLE
[Expert] Preliminary restrictions setup 

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -1088,5 +1088,15 @@
 				}
 			}]
 		}
+		{
+			x: -2.0d
+			y: 7.5d
+			id: "1D1BD002FC8614E1"
+			tasks: [{
+				id: "36390A183BB6011C"
+				type: "item"
+				item: "eidolon:soul_enchanter"
+			}]
+		}
 	]
 }

--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -1091,6 +1091,7 @@
 		{
 			x: -2.0d
 			y: 7.5d
+			dependencies: ["2ECA82ED72DA6D61"]
 			id: "1D1BD002FC8614E1"
 			tasks: [{
 				id: "36390A183BB6011C"

--- a/config/ftbquests/quests/chapters/hidden_quests.snbt
+++ b/config/ftbquests/quests/chapters/hidden_quests.snbt
@@ -77,5 +77,61 @@
 				stage: "impossible"
 			}]
 		}
+		{
+			x: -10.0d
+			y: -5.0d
+			id: "28619E49157C73FE"
+			tasks: [{
+				id: "124102D88E74BB65"
+				type: "item"
+				item: "bloodmagic:masterbloodorb"
+			}]
+			rewards: [{
+				id: "0917A808DE276817"
+				type: "gamestage"
+				title: "Master Blood Orb"
+				auto: "invisible"
+				stage: "master_blood_orb"
+			}]
+		}
+		{
+			x: -8.5d
+			y: -5.0d
+			id: "38F3D549DAFF2CD0"
+			tasks: [{
+				id: "5B43BCA2F385EE07"
+				type: "item"
+				item: "bloodmagic:soulforge"
+			}]
+			rewards: [{
+				id: "6D36A253466E98C9"
+				type: "gamestage"
+				title: "Hellfire Forge"
+				auto: "invisible"
+				stage: "hellfire_forge"
+			}]
+		}
+		{
+			x: -7.0d
+			y: -5.0d
+			id: "7F501A95E6E9C7A6"
+			tasks: [{
+				id: "1F386E8BDBE651FF"
+				type: "item"
+				item: {
+					id: "occultism:chalk_red"
+					Count: 1b
+					tag: {
+						Damage: 0
+					}
+				}
+			}]
+			rewards: [{
+				id: "5D12D220379855E1"
+				type: "gamestage"
+				auto: "invisible"
+				stage: "red_chalk"
+			}]
+		}
 	]
 }

--- a/config/gamestages/known_stages.json
+++ b/config/gamestages/known_stages.json
@@ -1,0 +1,1 @@
+["hellfire_forge", "undergarden:undergarden", "red_chalk"]

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
@@ -1,0 +1,76 @@
+onEvent('server.datapack.high_priority', (event) => {
+    if (global.isExpertMode == false) {
+        return;
+    }
+
+    let restrictions = [
+        // Soul Enchanter only usable in the nether after crafting a Hellfire Forge
+        {
+            type: 'and',
+            name: 'eidolon:soul_enchanter',
+            block: true,
+            first: {
+                type: 'dimension',
+                dimension: 'minecraft:the_nether'
+            },
+            second: {
+                type: 'gamestage',
+                stage: 'hellfire_forge'
+            }
+        }
+    ];
+
+    let restrictedBloodMagicBlocks = [
+        'bloodmagic:altar',
+        'bloodmagic:alchemytable',
+        'bloodmagic:demoncrucible',
+        'bloodmagic:demoncrystallizer',
+        'bloodmagic:alchemytable',
+        'bloodmagic:soulforge',
+        'bloodmagic:alchemicalreactionchamber',
+        'bloodmagic:incensealtar'
+    ];
+    // Requires creation Master Blood Orb to place outside of Undergarden
+    restrictedBloodMagicBlocks.forEach((item) => {
+        restrictions.push({
+            type: 'or',
+            name: item,
+            block: true,
+            first: {
+                type: 'dimension',
+                dimension: 'undergarden:undergarden'
+            },
+            second: {
+                type: 'gamestage',
+                stage: 'master_blood_orb'
+            }
+        });
+    });
+
+    let restrictedOccultismItems = [
+        'occultism:chalk_white',
+        'occultism:chalk_gold',
+        'occultism:chalk_purple',
+        'occultism:chalk_red',
+        'occultism:golden_sacrificial_bowl'
+    ];
+    // Requires creation of Red Chalk to place outside of Atum
+    restrictedOccultismItems.forEach((item) => {
+        restrictions.push({
+            type: 'or',
+            name: item,
+            block: true,
+            item: true,
+            first: {
+                type: 'dimension',
+                dimension: 'atum:atum'
+            },
+            second: {
+                type: 'gamestage',
+                stage: 'red_chalk'
+            }
+        });
+    });
+
+    event.addJson(`restriction:restrictions/expert.json`, restrictions);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
@@ -17,7 +17,22 @@ onEvent('server.datapack.high_priority', (event) => {
                 type: 'gamestage',
                 stage: 'hellfire_forge'
             }
-        }
+        },
+        // Requires creation of Red Chalk to place outside of Atum
+        {
+            restrictions.push({
+                type: 'or',
+                name: 'occultism:golden_sacrificial_bowl',
+                block: true,
+                first: {
+                    type: 'dimension',
+                    dimension: 'atum:atum'
+                },
+                second: {
+                    type: 'gamestage',
+                    stage: 'red_chalk'
+                }
+            })
     ];
 
     let restrictedBloodMagicBlocks = [
@@ -31,10 +46,10 @@ onEvent('server.datapack.high_priority', (event) => {
         'bloodmagic:incensealtar'
     ];
     // Requires creation Master Blood Orb to place outside of Undergarden
-    restrictedBloodMagicBlocks.forEach((item) => {
+    restrictedBloodMagicBlocks.forEach((block) => {
         restrictions.push({
             type: 'or',
-            name: item,
+            name: block,
             block: true,
             first: {
                 type: 'dimension',
@@ -43,31 +58,6 @@ onEvent('server.datapack.high_priority', (event) => {
             second: {
                 type: 'gamestage',
                 stage: 'master_blood_orb'
-            }
-        });
-    });
-
-    let restrictedOccultismItems = [
-        'occultism:chalk_white',
-        'occultism:chalk_gold',
-        'occultism:chalk_purple',
-        'occultism:chalk_red',
-        'occultism:golden_sacrificial_bowl'
-    ];
-    // Requires creation of Red Chalk to place outside of Atum
-    restrictedOccultismItems.forEach((item) => {
-        restrictions.push({
-            type: 'or',
-            name: item,
-            block: true,
-            item: true,
-            first: {
-                type: 'dimension',
-                dimension: 'atum:atum'
-            },
-            second: {
-                type: 'gamestage',
-                stage: 'red_chalk'
             }
         });
     });

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
@@ -19,7 +19,6 @@ onEvent('server.datapack.high_priority', (event) => {
             }
         },
         // Requires creation of Red Chalk to place outside of Atum
-
         {
             type: 'or',
             name: 'occultism:golden_sacrificial_bowl',

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/restrictions/restrictions.js
@@ -19,20 +19,20 @@ onEvent('server.datapack.high_priority', (event) => {
             }
         },
         // Requires creation of Red Chalk to place outside of Atum
+
         {
-            restrictions.push({
-                type: 'or',
-                name: 'occultism:golden_sacrificial_bowl',
-                block: true,
-                first: {
-                    type: 'dimension',
-                    dimension: 'atum:atum'
-                },
-                second: {
-                    type: 'gamestage',
-                    stage: 'red_chalk'
-                }
-            })
+            type: 'or',
+            name: 'occultism:golden_sacrificial_bowl',
+            block: true,
+            first: {
+                type: 'dimension',
+                dimension: 'atum:atum'
+            },
+            second: {
+                type: 'gamestage',
+                stage: 'red_chalk'
+            }
+        }
     ];
 
     let restrictedBloodMagicBlocks = [


### PR DESCRIPTION
Restrict soul forge to the nether. Can only be used once the hellfire forge has been crafted.

Key Blood Magic blocks restricted to Undergarden until they've crafted a master blood orb.