### PR TITLE
Vanilla Beehive Recipe Adjustment

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -969,6 +969,15 @@ onEvent('recipes', (event) => {
                 A: 'atum:sand',
                 B: 'minecraft:clay'
             }
+        },
+        {
+            output: 'minecraft:beehive',
+            pattern: ['AAA','BBB','AAA'],
+            key: {
+                A: '#minecraft:planks',
+                B: '#resourcefulbees:resourceful_honeycomb'
+            },
+            id: 'minecraft:beehive'
         }
     ];
 


### PR DESCRIPTION
Changes out `minecraft:honeycomb` for `#resourcefulbees:resourceful_honeycomb` in `minecraft:beehive` recipe. Fixes #3120.