### PR TITLE
[Expert] Update theme to BM recipes, expertify ore processing, and more

### DIFF
--- a/config/naturesaura-common.toml
+++ b/config/naturesaura-common.toml
@@ -11,7 +11,7 @@
 	#Additional blocks that are recognized as generatable ores for the passive ore generation effect. Each entry needs to be formatted as tag_name->oreWeight->dimension where a higher weight makes the ore more likely to spawn with 5000 being the weight of coal, the default ore with the highest weight, and dimension being any of overworld and nether
 	additionalOres = ["forge:ores/nether/gold->1000->nether", "forge:ores/netherite_scrap->1->nether", "forge:ores/bitumen->1000->overworld", "forge:ores/fluorite->50->overworld", "forge:ores/potassium_nitrate->500->overworld", "forge:ores/mana->500->overworld", "forge:ores/sulfur->300->overworld"]
 	#Additional dimensions that map to Aura types that should be present in them. This is useful if you have a modpack with custom dimensions that should have Aura act similarly to an existing dimension in them. Each entry needs to be formatted as dimension_name->aura_type, where aura_type can be any of naturesaura:overworld, naturesaura:nether and naturesaura:end.
-	auraTypeOverrides = []
+	auraTypeOverrides = ["undergarden:undergarden->naturesaura:end", "atum:atum->naturesaura:overworld"]
 	#The amount of blocks that can be between two Aura Field Creators for them to be connectable and work together
 	fieldCreatorRange = 10
 	#The maximum amount of animals that can be around the powder of fertility before it stops working

--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -110,6 +110,8 @@ var itemsToHide = [
     'bloodmagic:coalsand',
     'bloodmagic:saltpeter',
     'bloodmagic:sulfur',
+    'bloodmagic:ironsand',
+    'bloodmagic:goldsand',
 
     'byg:budding_ametrine_ore',
     'byg:anthracite_ore',

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -199,13 +199,13 @@ onEvent('jei.information', (event) => {
         {
             items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:overworld' })],
             description: [
-                'Obtained by Right-Clicking a Bottle and Cork in the air in the Overworld. This action removes Aura from the area.'
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the Overworld or Atum. This action removes Aura from the area.'
             ]
         },
         {
             items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:end' })],
             description: [
-                'Obtained by Right-Clicking a Bottle and Cork in the air in the End. This action removes Aura from the area.'
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the End or The Undergarden. This action removes Aura from the area.'
             ]
         },
         {

--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -94,6 +94,42 @@ onEvent('item.tooltip', (event) => {
         {
             items: ['kubejs:basic_circuit_package'],
             text: [Text.of('Requires 64 Buckets of Memory Essence in the Memory Stick').aqua()]
+        },
+        {
+            items: ['bloodmagic:quick_draw_anointment'],
+            text: [Text.of('Grants Quick-Draw on Bows and Crossbows').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:fortune_anointment'],
+            text: [Text.of('Grants additional Fortune on Tools').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:holy_water_anointment'],
+            text: [Text.of('Grants bonus Smite damage on Melee Attacks.').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:melee_anointment'],
+            text: [Text.of('Grants bonus damage on Melee Attacks').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:bow_power_anointment'],
+            text: [Text.of('Grants bonus damage on Bows and Crossbows').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:silk_touch_anointment'],
+            text: [Text.of('Grants Silk Touch').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:hidden_knowledge_anointment'],
+            text: [Text.of('Grants bonus Experience from block harvests.').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:smelting_anointment'],
+            text: [Text.of('Grants Auto Smelt').color('#7e24b3')]
+        },
+        {
+            items: ['bloodmagic:looting_anointment'],
+            text: [Text.of('Grants additional Looting on Weapons').color('#7e24b3')]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/shaped.js
@@ -972,12 +972,85 @@ onEvent('recipes', (event) => {
         },
         {
             output: 'minecraft:beehive',
-            pattern: ['AAA','BBB','AAA'],
+            pattern: ['AAA', 'BBB', 'AAA'],
             key: {
                 A: '#minecraft:planks',
                 B: '#resourcefulbees:resourceful_honeycomb'
             },
             id: 'minecraft:beehive'
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_polished', 4),
+            pattern: ['AA', 'AA'],
+            key: {
+                A: 'bloodmagic:dungeon_stone'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_brick1', 4),
+            pattern: ['AA', 'AA'],
+            key: {
+                A: 'bloodmagic:dungeon_polished'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_polished_stairs', 4),
+            pattern: ['A', 'AA', 'AAA'],
+            key: {
+                A: 'bloodmagic:dungeon_polished'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_brick_stairs', 4),
+            pattern: ['A', 'AA', 'AAA'],
+            key: {
+                A: 'bloodmagic:dungeon_brick1'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_pillar_center', 2),
+            pattern: ['A', 'A'],
+            key: {
+                A: 'bloodmagic:dungeon_stone'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_eye', 1),
+            pattern: [' B ', 'BAB', ' B '],
+            key: {
+                A: 'bloodmagic:dungeon_stone',
+                B: '#bloodmagic:crystals/demon'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_polished_wall', 6),
+            pattern: ['AAA', 'AAA'],
+            key: {
+                A: 'bloodmagic:dungeon_polished'
+            }
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_brick_wall', 6),
+            pattern: ['AAA', 'AAA'],
+            key: {
+                A: 'bloodmagic:dungeon_brick1'
+            }
+        },
+        {
+            output: 'bloodmagic:dungeon_polished_gate',
+            pattern: ['BAB', 'BAB'],
+            key: {
+                A: 'bloodmagic:dungeon_polished',
+                B: 'minecraft:stick'
+            }
+        },
+        {
+            output: 'bloodmagic:dungeon_brick_gate',
+            pattern: ['BAB', 'BAB'],
+            key: {
+                A: 'bloodmagic:dungeon_brick1',
+                B: 'minecraft:stick'
+            }
         }
     ];
 
@@ -1636,7 +1709,7 @@ onEvent('recipes', (event) => {
         }
     });
 
-    //Generate one RGBee Comb recipe for each dye, usting the appropriate flowers from dyeSources
+    //Generate one RGBee Comb recipe for each dye, using the appropriate flowers from dyeSources
     colors.forEach((color) => {
         let flowers = dyeSources.filter((dyeSource) => dyeSource.primary == `minecraft:${color}_dye`);
         let ingredients = flowers.map((flower) => flower.input);

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/occultism/ritual.js
@@ -229,31 +229,6 @@ onEvent('recipes', (event) => {
                     item: 'occultism:book_of_binding_bound_afrit'
                 },
                 pentacle_id: 'occultism:summon_afrit',
-                duration: 12,
-                spirit_max_age: -1,
-                spirit_job_type: 'occultism:crush_tier3',
-                entity_to_summon: 'occultism:afrit',
-                ritual_dummy: {
-                    item: 'occultism:ritual_dummy/summon_afrit_crusher'
-                },
-                ingredients: [
-                    { tag: 'forge:gems/diamond' },
-                    { tag: 'forge:dusts/iesnium' },
-                    { tag: 'forge:dusts/iesnium' },
-                    { tag: 'forge:gems/emerald' }
-                ],
-                result: {
-                    item: 'occultism:jei_dummy/none'
-                },
-                id: 'occultism:ritual/summon_afrit_crusher'
-            },
-            {
-                type: 'occultism:ritual',
-                ritual_type: 'occultism:summon_spirit_with_job',
-                activation_item: {
-                    item: 'occultism:book_of_binding_bound_afrit'
-                },
-                pentacle_id: 'occultism:summon_afrit',
                 duration: 6,
                 spirit_max_age: 120,
                 spirit_job_type: 'occultism:rain_weather',
@@ -329,31 +304,6 @@ onEvent('recipes', (event) => {
                     item: 'occultism:jei_dummy/none'
                 },
                 id: 'occultism:ritual/summon_djinni_clear_weather'
-            },
-            {
-                type: 'occultism:ritual',
-                ritual_type: 'occultism:summon_spirit_with_job',
-                activation_item: {
-                    item: 'occultism:book_of_binding_bound_djinni'
-                },
-                pentacle_id: 'occultism:summon_djinni',
-                duration: 9,
-                spirit_max_age: -1,
-                spirit_job_type: 'occultism:crush_tier2',
-                entity_to_summon: 'occultism:djinni',
-                ritual_dummy: {
-                    item: 'occultism:ritual_dummy/summon_djinni_crusher'
-                },
-                ingredients: [
-                    { tag: 'forge:dusts/iron' },
-                    { tag: 'forge:dusts/gold' },
-                    { tag: 'forge:dusts/copper' },
-                    { tag: 'forge:dusts/silver' }
-                ],
-                result: {
-                    item: 'occultism:jei_dummy/none'
-                },
-                id: 'occultism:ritual/summon_djinni_crusher'
             },
             {
                 type: 'occultism:ritual',
@@ -464,31 +414,6 @@ onEvent('recipes', (event) => {
                 pentacle_id: 'occultism:summon_foliot',
                 duration: 6,
                 spirit_max_age: -1,
-                spirit_job_type: 'occultism:crush_tier1',
-                entity_to_summon: 'occultism:foliot',
-                ritual_dummy: {
-                    item: 'occultism:ritual_dummy/summon_foliot_crusher'
-                },
-                ingredients: [
-                    { tag: 'forge:ores/iron' },
-                    { tag: 'forge:ores/gold' },
-                    { tag: 'forge:ores/copper' },
-                    { tag: 'forge:ores/silver' }
-                ],
-                result: {
-                    item: 'occultism:jei_dummy/none'
-                },
-                id: 'occultism:ritual/summon_foliot_crusher'
-            },
-            {
-                type: 'occultism:ritual',
-                ritual_type: 'occultism:summon_spirit_with_job',
-                activation_item: {
-                    item: 'occultism:book_of_binding_bound_foliot'
-                },
-                pentacle_id: 'occultism:summon_foliot',
-                duration: 6,
-                spirit_max_age: -1,
                 spirit_job_type: 'occultism:lumberjack',
                 entity_to_summon: 'occultism:foliot',
                 ritual_dummy: {
@@ -580,31 +505,6 @@ onEvent('recipes', (event) => {
                     item: 'occultism:book_of_calling_foliot_transport_items'
                 },
                 id: 'occultism:ritual/summon_foliot_transport_items'
-            },
-            {
-                type: 'occultism:ritual',
-                ritual_type: 'occultism:summon_spirit_with_job',
-                activation_item: {
-                    item: 'occultism:book_of_binding_bound_marid'
-                },
-                pentacle_id: 'occultism:summon_marid',
-                duration: 3,
-                spirit_max_age: -1,
-                spirit_job_type: 'occultism:crush_tier4',
-                entity_to_summon: 'occultism:marid',
-                ritual_dummy: {
-                    item: 'occultism:ritual_dummy/summon_marid_crusher'
-                },
-                ingredients: [
-                    { tag: 'forge:storage_blocks/diamond' },
-                    { item: 'minecraft:ghast_tear' },
-                    { tag: 'forge:storage_blocks/iesnium' },
-                    { tag: 'forge:storage_blocks/emerald' }
-                ],
-                result: {
-                    item: 'occultism:jei_dummy/none'
-                },
-                id: 'occultism:ritual/summon_marid_crusher'
             },
             {
                 type: 'occultism:ritual',

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -1711,6 +1711,30 @@ const stonecuttables = [
         ],
         onlyAsOutput: [],
         onlyAsInput: []
+    },
+    {
+        name: 'demon_brick',
+        stones: [
+            'bloodmagic:dungeon_smallbrick',
+            'bloodmagic:dungeon_tilespecial',
+            'bloodmagic:dungeon_tile',
+            'bloodmagic:dungeon_brick_assorted',
+            'bloodmagic:dungeon_brick3',
+            'bloodmagic:dungeon_brick2',
+            'bloodmagic:dungeon_brick1'
+        ],
+        onlyAsOutput: [],
+        onlyAsInput: []
+    },
+    {
+        name: 'demon_pillar',
+        stones: [
+            'bloodmagic:dungeon_pillar_cap',
+            'bloodmagic:dungeon_pillar_special',
+            'bloodmagic:dungeon_pillar_center'
+        ],
+        onlyAsOutput: [],
+        onlyAsInput: []
     }
 ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -32,7 +32,7 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'upgrade_aquatic:glowing_ink_sac',
+                    'undergarden:glowing_kelp',
                     '#forge:dusts/regalium',
                     '#forge:dusts/regalium',
                     '#forge:dusts/regalium',
@@ -47,7 +47,7 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'occultism:purified_ink',
+                    'undergarden:ink_mushroom',
                     '#forge:dusts/obsidian',
                     '#forge:dusts/obsidian',
                     'astralsorcery:illumination_powder'
@@ -228,8 +228,8 @@ onEvent('recipes', (event) => {
             {
                 inputs: [
                     'eidolon:zombie_heart',
-                    'minecraft:rotten_flesh',
-                    '#forge:dusts/charcoal',
+                    'undergarden:raw_dweller_meat',
+                    'undergarden:ditchbulb',
                     'projectvibrantjourneys:charred_bones',
                     'undergarden:ink_mushroom'
                 ],
@@ -267,6 +267,188 @@ onEvent('recipes', (event) => {
                 syphon: 1000,
                 ticks: 200,
                 orbLevel: 2
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/silver',
+                    'undergarden:shimmerweed'
+                ],
+                output: 'bloodmagic:holy_water_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/holy_water_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/regalium',
+                    'undergarden:underbeans'
+                ],
+                output: 'bloodmagic:looting_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/looting_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/froststeel',
+                    'undergarden:dweller_steak'
+                ],
+                output: 'bloodmagic:melee_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/melee_damage_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/cloggrum',
+                    'undergarden:veil_mushroom'
+                ],
+                output: 'bloodmagic:hidden_knowledge_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/hidden_knowledge_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/regalium',
+                    'undergarden:indigo_mushroom'
+                ],
+                output: 'bloodmagic:fortune_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/fortune_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/iron',
+                    'undergarden:depthrock_pebble'
+                ],
+                output: 'bloodmagic:bow_power_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/bow_power_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/uranium',
+                    'undergarden:ditchbulb'
+                ],
+                output: 'bloodmagic:smelting_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/smelting_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/cloggrum',
+                    'undergarden:goo_ball'
+                ],
+                output: 'bloodmagic:silk_touch_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/silk_touch_anointment'
+            },
+            {
+                inputs: [
+                    'bloodmagic:slate_vial',
+                    Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                    '#forge:nuggets/aluminum',
+                    'undergarden:gloomper_leg'
+                ],
+                output: 'bloodmagic:quick_draw_anointment',
+                count: 1,
+                syphon: 500,
+                ticks: 100,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/quick_draw_anointment'
+            },
+            {
+                inputs: [
+                    'undergarden:glowing_kelp',
+                    'glassential:glass_ghostly',
+                    'glassential:glass_ghostly',
+                    'bloodmagic:divinationsigil'
+                ],
+                output: 'bloodmagic:reagentsight',
+                count: 1,
+                syphon: 500,
+                ticks: 200,
+                orbLevel: 1,
+                id: 'bloodmagic:alchemytable/reagent_sight'
+            },
+            {
+                inputs: [
+                    'undergarden:cloggrum_pickaxe',
+                    'undergarden:cloggrum_axe',
+                    'undergarden:cloggrum_shovel',
+                    'undergarden:blisterberry'
+                ],
+                output: 'bloodmagic:reagentfastminer',
+                count: 1,
+                syphon: 2000,
+                ticks: 200,
+                orbLevel: 2,
+                id: 'bloodmagic:alchemytable/reagent_fastminer'
+            },
+            {
+                inputs: [
+                    'undergarden:glowing_kelp',
+                    'undergarden:droopvine_item',
+                    'undergarden:droopvine_item',
+                    'undergarden:shard_torch'
+                ],
+                output: 'bloodmagic:reagentbloodlight',
+                count: 1,
+                syphon: 1000,
+                ticks: 200,
+                orbLevel: 3,
+                id: 'bloodmagic:alchemytable/reagent_blood_light'
+            },
+            {
+                inputs: [
+                    '#forge:ingots/utherium',
+                    'undergarden:blood_mushroom',
+                    'undergarden:goo_ball',
+                    '#forge:nuggets/regalium'
+                ],
+                output: 'bloodmagic:reagentbinding',
+                count: 1,
+                syphon: 1000,
+                ticks: 200,
+                orbLevel: 3,
+                id: 'bloodmagic:alchemytable/reagent_binding'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/shaped.js
@@ -211,6 +211,26 @@ onEvent('recipes', (event) => {
                 C: 'architects_palette:abyssaline'
             },
             id: 'bloodmagic:ritual_stone_master'
+        },
+        {
+            output: Item.of('bloodmagic:dungeon_stone', 8),
+            pattern: ['AAA', 'ABA', 'AAA'],
+            key: {
+                A: 'naturesaura:infused_stone',
+                B: '#bloodmagic:crystals/demon'
+            }
+        },
+        {
+            output: 'bloodmagic:alchemicalreactionchamber',
+            pattern: ['AAA', 'BCB', 'DED'],
+            key: {
+                A: 'bloodmagic:dungeon_stone',
+                B: 'bloodmagic:infusedslate',
+                C: { type: 'bloodmagic:bloodorb', orb_tier: 3 },
+                D: '#forge:storage_blocks/blazing',
+                E: 'minecraft:blast_furnace'
+            },
+            id: 'bloodmagic:arc'
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/soulforge.js
@@ -175,7 +175,7 @@ onEvent('recipes', (event) => {
             },
             {
                 inputs: [
-                    'naturesaura:infused_stone',
+                    'bloodmagic:dungeon_stone',
                     '#forge:ingots/tainted_gold',
                     '#forge:gems/nitro',
                     '#forge:gems/nitro'

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -408,6 +408,129 @@ onEvent('recipes', (event) => {
                     item: 'occultism:satchel'
                 },
                 id: 'occultism:ritual/craft_satchel'
+            },
+
+            // 2x Ore Processing
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier1',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_crusher'
+                },
+                ingredients: [
+                    { item: 'naturesaura:crushing_catalyst' },
+                    { tag: 'forge:ingots/nebu' },
+                    { item: 'atum:nebu_hammer' },
+                    { tag: 'forge:ingots/nebu' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/water' },
+                    { tag: 'botania:runes/water' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_foliot_crusher'
+            },
+
+            // 3x Ore Processing
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 9,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier2',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_crusher'
+                },
+                ingredients: [
+                    { item: 'naturesaura:crushing_catalyst' },
+                    { tag: 'forge:ingots/sky' },
+                    { item: 'naturesaura:sky_pickaxe' },
+                    { tag: 'forge:ingots/sky' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/water' },
+                    { tag: 'botania:runes/water' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_djinni_crusher'
+            },
+            // 4x Ore Processing
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_afrit'
+                },
+                pentacle_id: 'occultism:summon_afrit',
+                duration: 12,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier3',
+                entity_to_summon: 'occultism:afrit',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_afrit_crusher'
+                },
+                ingredients: [
+                    { item: 'naturesaura:crushing_catalyst' },
+                    { tag: 'botania:runes/joetunheim' },
+                    { item: 'botania:terra_pick' },
+                    { tag: 'botania:runes/joetunheim' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/water' },
+                    { tag: 'botania:runes/water' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_afrit_crusher'
+            },
+
+            // 6x Ore Processing
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_marid'
+                },
+                pentacle_id: 'occultism:summon_marid',
+                duration: 3,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier4',
+                entity_to_summon: 'occultism:marid',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_marid_crusher'
+                },
+                ingredients: [
+                    { item: 'naturesaura:crushing_catalyst' },
+                    { tag: 'botania:runes/vanaheim' },
+                    { item: 'mythicbotany:alfsteel_pick' },
+                    { tag: 'botania:runes/vanaheim' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/earth' },
+                    { tag: 'botania:runes/water' },
+                    { tag: 'botania:runes/water' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_marid_crusher'
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/bloodmagic/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/bloodmagic/shaped.js
@@ -1,0 +1,24 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+
+    const recipes = [
+        {
+            output: Item.of('bloodmagic:dungeon_stone', 8),
+            pattern: ['AAA', 'ABA', 'AAA'],
+            key: {
+                A: '#forge:stone',
+                B: '#bloodmagic:crystals/demon'
+            }
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        if (recipe.id) {
+            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+        } else {
+            event.shaped(recipe.output, recipe.pattern, recipe.key);
+        }
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/ritual.js
@@ -395,6 +395,106 @@ onEvent('recipes', (event) => {
                     item: 'occultism:satchel'
                 },
                 id: 'occultism:ritual/craft_satchel'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_foliot'
+                },
+                pentacle_id: 'occultism:summon_foliot',
+                duration: 6,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier1',
+                entity_to_summon: 'occultism:foliot',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_foliot_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:ores/iron' },
+                    { tag: 'forge:ores/gold' },
+                    { tag: 'forge:ores/copper' },
+                    { tag: 'forge:ores/silver' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_foliot_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:summon_djinni',
+                duration: 9,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier2',
+                entity_to_summon: 'occultism:djinni',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_djinni_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:dusts/iron' },
+                    { tag: 'forge:dusts/gold' },
+                    { tag: 'forge:dusts/copper' },
+                    { tag: 'forge:dusts/silver' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_djinni_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_afrit'
+                },
+                pentacle_id: 'occultism:summon_afrit',
+                duration: 12,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier3',
+                entity_to_summon: 'occultism:afrit',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_afrit_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:gems/diamond' },
+                    { tag: 'forge:dusts/iesnium' },
+                    { tag: 'forge:dusts/iesnium' },
+                    { tag: 'forge:gems/emerald' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_afrit_crusher'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon_spirit_with_job',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_marid'
+                },
+                pentacle_id: 'occultism:summon_marid',
+                duration: 3,
+                spirit_max_age: -1,
+                spirit_job_type: 'occultism:crush_tier4',
+                entity_to_summon: 'occultism:marid',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/summon_marid_crusher'
+                },
+                ingredients: [
+                    { tag: 'forge:storage_blocks/diamond' },
+                    { item: 'minecraft:ghast_tear' },
+                    { tag: 'forge:storage_blocks/iesnium' },
+                    { tag: 'forge:storage_blocks/emerald' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/summon_marid_crusher'
             }
         ]
     };


### PR DESCRIPTION
Since Blood Magic is initially bound to Undergarden, it seemed fitting to theme some more of the recipes around that.

Alchemy Table Anointments all now follow a pattern of Bottled Sunlight, a nugget of some sort, and an item specific to Undergarden, thus creating something by melding items from two worlds.

Honing:
![image](https://user-images.githubusercontent.com/9543430/132016311-30c9ed48-c2bc-413d-a5a6-599feccc7b56.png)

Soft Coating:
![image](https://user-images.githubusercontent.com/9543430/132016357-fd46a118-3795-4e03-b3de-4d9855a9d07d.png)

Fortuna:
![image](https://user-images.githubusercontent.com/9543430/132016394-3a5bbb83-414c-4794-b45a-e3e8a7cefe2a.png)

Holy Water:
![image](https://user-images.githubusercontent.com/9543430/132016430-08de47f5-9696-4637-80d5-78b9301d4e31.png)

Miner's Secrets:
![image](https://user-images.githubusercontent.com/9543430/132016469-a7dff012-f2d7-423c-91ce-93b64896bc5d.png)

Dexterity Alkahest:
![image](https://user-images.githubusercontent.com/9543430/132016518-0f1a9f28-b3cb-4bb1-8273-8fc75863ab5e.png)

Plunderer's Glint:
![image](https://user-images.githubusercontent.com/9543430/132016579-b0dc5214-dd55-4d80-b51b-030182201599.png)

Iron Tip:
![image](https://user-images.githubusercontent.com/9543430/132016612-43e384ac-647e-4b78-86a1-0f9b5121c06f.png)

Slow-Burning Oil:
![image](https://user-images.githubusercontent.com/9543430/132016669-5725140c-ba68-4753-9270-ee735f305937.png)

Each also has a new tooltip attached to help people discover their uses. They're covered in the BM book, but it seemed like they could use a little help.

![image](https://user-images.githubusercontent.com/9543430/132016852-1d28c53f-66c5-4ddb-8a1b-e7ccd2317dd7.png)

Nocturnal Powder now uses ink mushrooms
![image](https://user-images.githubusercontent.com/9543430/132019792-364744ca-e4d9-4de3-823e-17fdcfdb70ad.png)

Illumination Powder using glitter kelp instead of glow squid ink
![image](https://user-images.githubusercontent.com/9543430/132020814-171458b6-19ee-4331-b8a3-d94ff34d2a39.png)

Mining Reagent:
![image](https://user-images.githubusercontent.com/9543430/132021536-d6dd075a-7cc0-4233-aa58-dca7e5876a33.png)

Blood Lamp Reagent:
![image](https://user-images.githubusercontent.com/9543430/132021570-5108eb2e-eee6-41b9-8b19-b07963586524.png)

Binding Reagent:
![image](https://user-images.githubusercontent.com/9543430/132029366-0e467df7-50aa-4fbb-bcf2-5e4833889910.png)

Essence of Death:
![image](https://user-images.githubusercontent.com/9543430/132020350-e96a847b-e1dd-4a91-8886-6e67c967915a.png)

Makes Demon Stone/Bricks craftable in all modes. Expert uses Infused stone for base while normal uses `#forge:stone`
![image](https://user-images.githubusercontent.com/9543430/132025707-1d37f840-ea22-44e7-9414-ebb95bcd128b.png)

Variants available through stonecutting.

Updated Crystalline Resonator to use Demon Stone instead.
![image](https://user-images.githubusercontent.com/9543430/132026103-f4626453-486b-4285-91ae-b5c9fa7773ea.png)

ARC
![image](https://user-images.githubusercontent.com/9543430/132027858-41e7beba-afb3-4f27-ab5c-ea674b09af66.png)

Ore Processing update:

Occultism Crusher Spirits getting more appropriate recipes compared to their power
Foliot (2x Ore)
![image](https://user-images.githubusercontent.com/9543430/132036557-556c110b-4f36-4841-8440-52a8e02ead8e.png)

Djinni (3x Ore)
![image](https://user-images.githubusercontent.com/9543430/132036773-aa3a3d76-a81f-4e53-999b-e9da1f6ecdab.png)

Afrit (4x Ore)
![image](https://user-images.githubusercontent.com/9543430/132038671-dfa73e43-25c0-4171-b845-7866c6bdde6a.png)

Marid (6x Ore)
![image](https://user-images.githubusercontent.com/9543430/132038749-693d364b-9dd9-41fe-88cc-8cfbf20f6a66.png)

Also add NA aura to Atum and Undergarden as alternate places to set those up.