### PR TITLE
Remove Starmetal dupe loop from smeltery

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -135,6 +135,8 @@ onEvent('recipes', (event) => {
 
         'immersivepetroleum:distillationtower/oilcracking',
 
+        'materialis:smeltery/melting/metal/starmetal/dust',
+
         'mekanism:crushing/stone/to_cobblestone',
         'mekanism:enriching/enriched/tin',
         'mekanism:processing/bronze/dust/from_infusing',


### PR DESCRIPTION
One ingot breaks into multiple dusts, 1 dust smelts into 1 ingot via tinkers.