### PR TITLE
[Expert + Normal] Occultism Ritual update

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -28,12 +28,12 @@
 
     "ritual.enigmatica.occultism/ritual/magical_feathers.started": "The Binding of the Ender Dragon has begun.",
     "ritual.enigmatica.occultism/ritual/magical_feathers.finished": "The Ender Dragon has beem bound successfully ",
-    "ritual.enigmatica.occultism/ritual/magical_feathers.interrupted": "Ritual Interrupted.",
+    "ritual.enigmatica.occultism/ritual/magical_feathers.interrupted": "Binding of the Ender Dragon Ritual Interrupted.",
     "ritual.enigmatica.occultism/ritual/magical_feathers.conditions": "Not all requirements for this ritual are met.",
 
     "ritual.enigmatica.occultism/ritual/magicfeather.started": "The Ritual of Flight has begun.",
     "ritual.enigmatica.occultism/ritual/magicfeather.finished": "The Ritual of Flight has finished successfully.",
-    "ritual.enigmatica.occultism/ritual/magicfeather.interrupted": "Ritual Interrupted.",
+    "ritual.enigmatica.occultism/ritual/magicfeather.interrupted": "Ritual of Flight Interrupted.",
     "ritual.enigmatica.occultism/ritual/magicfeather.conditions": "Not all requirements for this ritual are met.",
 
     "ritual.enigmatica.occultism/ritual/pharaoh.started": "Started summoning Pharaoh.",

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -25,15 +25,21 @@
     "ritual.occultism.sacrifice.cephalopods": "Cephalopod",
     "ritual.occultism.sacrifice.thrashers": "Thrasher",
     "ritual.occultism.sacrifice.dragons": "Ender Dragon",
+
     "ritual.enigmatica.occultism/ritual/magical_feathers.started": "The Binding of the Ender Dragon has begun.",
     "ritual.enigmatica.occultism/ritual/magical_feathers.finished": "The Ender Dragon has beem bound successfully ",
-    "ritual.enigmatica.occultism/ritual/magical_feathers.interrupted": "Ritual Interrupted",
+    "ritual.enigmatica.occultism/ritual/magical_feathers.interrupted": "Ritual Interrupted.",
     "ritual.enigmatica.occultism/ritual/magical_feathers.conditions": "Not all requirements for this ritual are met.",
 
     "ritual.enigmatica.occultism/ritual/magicfeather.started": "The Ritual of Flight has begun.",
     "ritual.enigmatica.occultism/ritual/magicfeather.finished": "The Ritual of Flight has finished successfully.",
-    "ritual.enigmatica.occultism/ritual/magicfeather.interrupted": "Ritual Interrupted",
+    "ritual.enigmatica.occultism/ritual/magicfeather.interrupted": "Ritual Interrupted.",
     "ritual.enigmatica.occultism/ritual/magicfeather.conditions": "Not all requirements for this ritual are met.",
+
+    "ritual.enigmatica.occultism/ritual/pharaoh.started": "Started summoning Pharaoh.",
+    "ritual.enigmatica.occultism/ritual/pharaoh.finished": "Summoned Pharaoh successfully.",
+    "ritual.enigmatica.occultism/ritual/pharaoh.interrupted": "Summoning of Pharaoh interrupted.",
+    "ritual.enigmatica.occultism/ritual/pharaoh.conditions": "Not all requirements for this ritual are met.",
 
     "item.kubejs.suffused_aluminum": "Mana Suffused Aluminum Chunk",
     "item.kubejs.suffused_cloggrum": "Mana Suffused Cloggrum Chunk",

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -22,6 +22,8 @@
     "item.kubejs.quintuple_alfsteel_ingot": "Quintuple Alfsteel Ingot",
 
     "ritual.occultism.sacrifice.deer": "Deer",
+    "ritual.occultism.sacrifice.cephalopods": "Cephalopod",
+    "ritual.occultism.sacrifice.thrashers": "Thrasher",
     "ritual.occultism.sacrifice.dragons": "Ender Dragon",
     "ritual.enigmatica.occultism/ritual/magical_feathers.started": "The Binding of the Ender Dragon has begun.",
     "ritual.enigmatica.occultism/ritual/magical_feathers.finished": "The Ender Dragon has beem bound successfully ",

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/enigmatica/cephalopods.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/enigmatica/cephalopods.js
@@ -1,0 +1,9 @@
+onEvent('entity_type.tags', (event) => {
+    let entities = [
+        'minecraft:squid',
+        'upgrade_aquatic:glow_squid',
+        'upgrade_aquatic:nautilus',
+        'alexsmobs:mimic_octopus'
+    ];
+    event.get('enigmatica:cephalopods').add(entities);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/enigmatica/thrashers.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/enigmatica/thrashers.js
@@ -1,0 +1,4 @@
+onEvent('entity_type.tags', (event) => {
+    let entities = ['upgrade_aquatic:great_thrasher', 'upgrade_aquatic:thrasher'];
+    event.get('enigmatica:thrashers').add(entities);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/forge/villagers.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/forge/villagers.js
@@ -1,0 +1,4 @@
+onEvent('entity_type.tags', (event) => {
+    let entities = ['atum:villager_male', 'atum:villager_female', 'undergarden:stoneborn'];
+    event.get('forge:villagers').add(entities);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/forge/zombies.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/forge/zombies.js
@@ -1,0 +1,4 @@
+onEvent('entity_type.tags', (event) => {
+    let entities = ['eidolon:zombie_brute', 'minecraft:zombified_piglin', 'atum:mummy'];
+    event.get('forge:zombies').add(entities);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/occultism/wild_hunt_sacrifices.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/occultism/wild_hunt_sacrifices.js
@@ -1,0 +1,4 @@
+onEvent('entity_type.tags', (event) => {
+    let entities = ['atum:villager_male', 'atum:villager_female', 'undergarden:stoneborn'];
+    event.get('occultism:wild_hunt_sacrifices').add(entities);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -657,6 +657,37 @@ onEvent('recipes', (event) => {
                 },
                 id: 'occultism:ritual/familiar_deer'
             },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:familiar',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_djinni',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'enigmatica:thrashers',
+                    display_name: 'ritual.occultism.sacrifice.thrashers'
+                },
+                entity_to_summon: 'occultism:cthulhu_familiar',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_cthulhu'
+                },
+                ingredients: [
+                    { item: 'quark:gold_bars' },
+                    { item: 'quark:gold_bars' },
+                    { item: 'quark:gold_bars' },
+                    { item: 'quark:gold_bars' },
+                    { item: 'aquaculture:neptunium_helmet' },
+                    { tag: 'forge:heads' },
+                    { item: 'sushigocrafting:shrimp_nigiri' },
+                    { item: 'sushigocrafting:shrimp_nigiri' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_cthulhu'
+            },
 
             /// Custom Rituals
             {
@@ -714,6 +745,35 @@ onEvent('recipes', (event) => {
                 ],
                 result: { item: 'losttrinkets:magical_feathers' },
                 id: `${id_prefix}magical_feathers`
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:summon',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_afrit'
+                },
+                pentacle_id: 'occultism:summon_wild_afrit',
+                duration: 6,
+                entity_to_sacrifice: {
+                    tag: 'occultism:wild_hunt_sacrifices',
+                    display_name: 'ritual.occultism.sacrifice.villagers_or_players'
+                },
+                entity_to_summon: 'atum:pharaoh',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/custom_ritual'
+                },
+                ingredients: [
+                    { tag: 'atum:godshards' },
+                    { item: 'atum:golden_date_enchanted' },
+                    { tag: 'forge:storage_blocks/nebu' },
+                    { tag: 'forge:heads' },
+                    { tag: 'atum:godshards' },
+                    { tag: 'atum:godshards' },
+                    { item: 'atum:crystal_glass' },
+                    { item: 'atum:crystal_glass' }
+                ],
+                result: { item: 'occultism:jei_dummy/none' },
+                id: `${id_prefix}pharaoh`
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/occultism/ritual.js
@@ -607,6 +607,37 @@ onEvent('recipes', (event) => {
                     item: 'occultism:jei_dummy/none'
                 },
                 id: 'occultism:ritual/familiar_deer'
+            },
+            {
+                type: 'occultism:ritual',
+                ritual_type: 'occultism:familiar',
+                activation_item: {
+                    item: 'occultism:book_of_binding_bound_djinni'
+                },
+                pentacle_id: 'occultism:possess_djinni',
+                duration: 3,
+                entity_to_sacrifice: {
+                    tag: 'enigmatica:cephalopod',
+                    display_name: 'ritual.occultism.sacrifice.cephalopod'
+                },
+                entity_to_summon: 'occultism:cthulhu_familiar',
+                ritual_dummy: {
+                    item: 'occultism:ritual_dummy/familiar_cthulhu'
+                },
+                ingredients: [
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' },
+                    { tag: 'minecraft:fishes' }
+                ],
+                result: {
+                    item: 'occultism:jei_dummy/none'
+                },
+                id: 'occultism:ritual/familiar_cthulhu'
             }
         ]
     };


### PR DESCRIPTION
Updates Occultism rituals.

Normal mode: Reduces summoning time for Cthulhu and expands the required sacrifice to any cephalopod instead of just MC squid.

Expert mode: New recipe
![image](https://user-images.githubusercontent.com/9543430/132368524-481ea305-ccb5-4ce8-be75-7c09abba79c7.png)

Add zombie brutes, mummies, and zombified piglins to the `forge:zombies` tag

Add Atum villagers and Undergarden Villagers to `forge:villagers` and `occultism:wild_hunt_sacrifices` tags

Pharaoh Summon:
![image](https://user-images.githubusercontent.com/9543430/132379792-c0ebd763-dafe-44a6-adfa-238ef785caaf.png)

Needs work still. Missing feature that would allow creating the dummy ritual item properly. Klikli is looking into that to see if anything can be done.

The idea here is that automating godshards, while doable without this, is not at all obvious. It can be done manually in big batches thanks to ultimine, but that's not ideal either. This would make for an extra expensive, but very clearly automatable recipe to summon more pharaohs to get relics to smelt down to godshards.