### PR TITLE
Fixed sorting in backpacks with stack upgrade

### DIFF
--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -29,6 +29,10 @@
 	#Out-of-bound slots are ignored
 	#Omit sortRange to leave as default
 	[[sorting.containerOverrides]]
+		containerClass = "net.p3pp3rf1y.sophisticatedbackpacks.common.gui.BackpackContainer"
+		sortRange = ""
+		
+	[[sorting.containerOverrides]]
 		containerClass = "com.tfar.craftingstation.CraftingStationContainer"
 		sortRange = ""
 


### PR DESCRIPTION
Sophisticated backpacks have its own sort keybind, witch conflict with Inv Tweaks.
When backpack with installed stack upgrade sorted with Inv Tweaks sorting is not working and spam big stacktrace in server log.