### PR TITLE
Intermediate Cutting Fluid now requires water bottle instead of any potion bottle

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
@@ -226,6 +226,22 @@ onEvent('recipes', (event) => {
                 ticks: 40,
                 orbLevel: 0,
                 id: 'bloodmagic:alchemytable/nether_wart_from_block'
+            },
+            {
+                inputs: [
+                    'bloodmagic:tauoil',
+                    '#forge:dusts/glowstone',
+                    'minecraft:gunpowder',
+                    'minecraft:sugar',
+                    '#forge:dusts/sulfur',
+                    Item.of('minecraft:potion', '{Potion:"minecraft:water"}')
+                ],
+                output: 'bloodmagic:intermediatecuttingfluid',
+                count: 1,
+                syphon: 2000,
+                ticks: 200,
+                orbLevel: 3,
+                id: 'bloodmagic:alchemytable/intermediate_cutting_fluid'
             }
         ]
     };


### PR DESCRIPTION
quick fix to intermediate cutting fluid. it's accepting any potion instead of a water bottle specifically