### PR TITLE
Add "Tier" indicator to Bee Lore

### DIFF
--- a/config/resourcefulbees/bees/alloy/Brass.json
+++ b/config/resourcefulbees/bees/alloy/Brass.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Bronze.json
+++ b/config/resourcefulbees/bees/alloy/Bronze.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Constantan.json
+++ b/config/resourcefulbees/bees/alloy/Constantan.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Electrum.json
+++ b/config/resourcefulbees/bees/alloy/Electrum.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Enderium.json
+++ b/config/resourcefulbees/bees/alloy/Enderium.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Invar.json
+++ b/config/resourcefulbees/bees/alloy/Invar.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Lumium.json
+++ b/config/resourcefulbees/bees/alloy/Lumium.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Signalum.json
+++ b/config/resourcefulbees/bees/alloy/Signalum.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/alloy/Steel.json
+++ b/config/resourcefulbees/bees/alloy/Steel.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Within the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
+    "lore": "Tier 3:\nWithin the heart of many metal blocks lies an Alloy Bee\negg; the proper bee can mutate the block, releasing it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/gem/Diamond.json
+++ b/config/resourcefulbees/bees/gem/Diamond.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "The Diamond Bee's parentage makes it clear that a\ndiamond is really just Quartz, stained blue.",
+    "lore": "Tier 3:\nThe Diamond Bee's parentage makes it clear that a\ndiamond is really just Quartz, stained blue.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/gem/Emerald.json
+++ b/config/resourcefulbees/bees/gem/Emerald.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Dying a Diamond green (and slimy) apparently yields an Emerald.",
+    "lore": "Tier 3:\nDying a Diamond green (and slimy) apparently yields an Emerald.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/gem/Lapis.json
+++ b/config/resourcefulbees/bees/gem/Lapis.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Deep down, Coal just wants to be blue. Wash it with\nWater and you'll find Lapis inside.",
+    "lore": "Tier 2:\nDeep down, Coal just wants to be blue. Wash it with\nWater and you'll find Lapis inside.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/gem/Redstone.json
+++ b/config/resourcefulbees/bees/gem/Redstone.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Coal + Rainbows = Redstone? Makes sense.",
+    "lore": "Tier 2:\nCoal + Rainbows = Redstone? Makes sense.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/material/Clay.json
+++ b/config/resourcefulbees/bees/material/Clay.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "The temperment of the Rocky Bee can be\nsoftened by the Slimy Bee, yeilding Clay.",
+    "lore": "Tier 2:\nThe temperment of the Rocky Bee can be\nsoftened by the Slimy Bee, yeilding Clay.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/material/Gravel.json
+++ b/config/resourcefulbees/bees/material/Gravel.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Gravel seems like the Rocky version of Sand, right?",
+    "lore": "Tier 2:\nGravel seems like the Rocky version of Sand, right?",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/metal/Aluminum.json
+++ b/config/resourcefulbees/bees/metal/Aluminum.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Copper.json
+++ b/config/resourcefulbees/bees/metal/Copper.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Gold.json
+++ b/config/resourcefulbees/bees/metal/Gold.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Iron.json
+++ b/config/resourcefulbees/bees/metal/Iron.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Lead.json
+++ b/config/resourcefulbees/bees/metal/Lead.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Nickel.json
+++ b/config/resourcefulbees/bees/metal/Nickel.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Osmium.json
+++ b/config/resourcefulbees/bees/metal/Osmium.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Silver.json
+++ b/config/resourcefulbees/bees/metal/Silver.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Tin.json
+++ b/config/resourcefulbees/bees/metal/Tin.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Uranium.json
+++ b/config/resourcefulbees/bees/metal/Uranium.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/metal/Zinc.json
+++ b/config/resourcefulbees/bees/metal/Zinc.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Metal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
+    "lore": "Tier 2:\nMetal Bees have a grand breeding heirarchy, starting with\nthe bees found in nature as a base.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 3600,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Coal.json
+++ b/config/resourcefulbees/bees/natural/Coal.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Sooty Bees are common in the Overworld, found close to sea level.",
+    "lore": "Tier 1:\nSooty Bees are common in the Overworld, found close to sea level.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Creeper.json
+++ b/config/resourcefulbees/bees/natural/Creeper.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Beepers skulk in the dark, in wasted surrounds and mesa's highlands.",
+    "lore": "Tier 1:\nBeepers skulk in the dark, in wasted surrounds and mesa's highlands.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Ender.json
+++ b/config/resourcefulbees/bees/natural/Ender.json
@@ -1,6 +1,6 @@
 {
     "flower": "minecraft:chorus_flower",
-    "lore": "The Ender Bee, as it name suggests, hails\nfrom the same lands as the Enderman.",
+    "lore": "Tier 1:\nThe Ender Bee, as it name suggests, hails\nfrom the same lands as the Enderman.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Forest.json
+++ b/config/resourcefulbees/bees/natural/Forest.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Forest Bees prefer to stick to the woods & clearings of their birth.",
+    "lore": "Tier 1:\nForest Bees prefer to stick to the woods & clearings of their birth.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Glowstone.json
+++ b/config/resourcefulbees/bees/natural/Glowstone.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Glowstone Bees are found in the same\nhellscape their produce typically resides.",
+    "lore": "Tier 1:\nGlowstone Bees are found in the same\nhellscape their produce typically resides.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Icy.json
+++ b/config/resourcefulbees/bees/natural/Icy.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Why are you here mister Winter Bee?\nYou're not where you're supposed to be.\nThe Sun is gone, you're all alone.\nSo why are you here mister Winter Bee?",
+    "lore": "Tier 1:\nWhy are you here mister Winter Bee?\nYou're not where you're supposed to be.\nThe Sun is gone, you're all alone.\nSo why are you here mister Winter Bee?",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Obsidian.json
+++ b/config/resourcefulbees/bees/natural/Obsidian.json
@@ -1,6 +1,6 @@
 {
     "flower": "minecraft:chorus_flower",
-    "lore": "Obsidian Bees, surprising some, hail from the End.\nMaybe it's the obsidian pillars.",
+    "lore": "Tier 1:\nObsidian Bees, surprising some, hail from the End.\nMaybe it's the obsidian pillars.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Pigman.json
+++ b/config/resourcefulbees/bees/natural/Pigman.json
@@ -1,6 +1,6 @@
 {
     "flower": "tag:forge:mushrooms",
-    "lore": "Hellish Zombees prefer similar enviorns to thier Piglin bretheren.",
+    "lore": "Tier 1:\nHellish Zombees prefer similar enviorns to thier Piglin bretheren.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/RGBee.json
+++ b/config/resourcefulbees/bees/natural/RGBee.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "RGBees fly wide open areas, using their\ncolors to blend in with the flowers.",
+    "lore": "Tier 1:\nRGBees fly wide open areas, using their\ncolors to blend in with the flowers.",
     "loreColor": "rainbow",
     "maxTimeInHive": 2400,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Rocky.json
+++ b/config/resourcefulbees/bees/natural/Rocky.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Mountains and hills are monuments to\nthe stone Rocky Bees represent.",
+    "lore": "Tier 1:\nMountains and hills are monuments to\nthe stone Rocky Bees represent.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Sand.json
+++ b/config/resourcefulbees/bees/natural/Sand.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "The Sandy Bee can be found, unsurprisingly, in the sand.",
+    "lore": "Tier 1:\nThe Sandy Bee can be found, unsurprisingly, in the sand.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 2400,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Skeleton.json
+++ b/config/resourcefulbees/bees/natural/Skeleton.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "The Skeleton Bee can be found haunting spooky, dead places.",
+    "lore": "Tier 1:\nThe Skeleton Bee can be found haunting spooky, dead places.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Slimy.json
+++ b/config/resourcefulbees/bees/natural/Slimy.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Slimy Bees can be found squishing around in the same\nswampy areas as their terrestrial relatives.",
+    "lore": "Tier 1:\nSlimy Bees can be found squishing around in the same\nswampy areas as their terrestrial relatives.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/natural/Water.json
+++ b/config/resourcefulbees/bees/natural/Water.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Water Bees prefer to stay hydrated, but\nalways stick to fresh water.",
+    "lore": "Tier 1:\nWater Bees prefer to stay hydrated, but\nalways stick to fresh water.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 0.75,

--- a/config/resourcefulbees/bees/natural/Zombie.json
+++ b/config/resourcefulbees/bees/natural/Zombie.json
@@ -1,6 +1,6 @@
 {
     "flower": "ALL",
-    "lore": "Zombees are spooky and dead. Look for them in similar environments.",
+    "lore": "Tier 1:\nZombees are spooky and dead. Look for them in similar environments.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/nether/Blaze.json
+++ b/config/resourcefulbees/bees/nether/Blaze.json
@@ -1,6 +1,6 @@
 {
     "flower": "tconstruct:magma_cake",
-    "lore": "The Coal Bee has a latent gene that, when\nsparked, will ignite with a Blaze.",
+    "lore": "Tier 3:\nThe Coal Bee has a latent gene that, when\nsparked, will ignite with a Blaze.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1.0,

--- a/config/resourcefulbees/bees/nether/Ghast.json
+++ b/config/resourcefulbees/bees/nether/Ghast.json
@@ -1,6 +1,6 @@
 {
     "flower": "minecraft:crimson_fungus",
-    "lore": "The Creeper Bee's explosive force can be mutated by\nthe Blaze Bee, forming a creature of the Nether.",
+    "lore": "Tier 3:\nThe Creeper Bee's explosive force can be mutated by\nthe Blaze Bee, forming a creature of the Nether.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/nether/Netherite.json
+++ b/config/resourcefulbees/bees/nether/Netherite.json
@@ -1,6 +1,6 @@
 {
     "flower": "minecraft:wither_rose",
-    "lore": "The heart of the Diamond Bee is ancient - this ageless \n relic can be transformed by the Ghast Bee.",
+    "lore": "Tier 3:\nThe heart of the Diamond Bee is ancient - this ageless \n relic can be transformed by the Ghast Bee.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 7200,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/nether/Wither.json
+++ b/config/resourcefulbees/bees/nether/Wither.json
@@ -1,6 +1,6 @@
 {
     "flower": "minecraft:wither_rose",
-    "lore": "The Wither Bee is not of this world; the Netherite Bee can bring\nit forth at the cost of its cousin the Ender Bee.",
+    "lore": "Tier 3:\nThe Wither Bee is not of this world; the Netherite Bee can bring\nit forth at the cost of its cousin the Ender Bee.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,

--- a/config/resourcefulbees/bees/nether/nether_quartz.json
+++ b/config/resourcefulbees/bees/nether/nether_quartz.json
@@ -1,6 +1,6 @@
 {
     "flower": "minecraft:warped_fungus",
-    "lore": "Within the I-C-Bee's crystaline form lies dormant potential;\nthe Hellish Zombee can release it.",
+    "lore": "Tier 3:\nWithin the I-C-Bee's crystaline form lies dormant potential;\nthe Hellish Zombee can release it.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 0.75,


### PR DESCRIPTION
Adds a "Tier" line to Naturally spawning/bred/mutated bees, in line with the quests. Diamond & Emerald are a little tricky - I've made them Tier 3 as they depend on mutated bees for breeding. Does not label "crafted" bees - those get to be a little bit mysterious.