### PR TITLE
Remove powah cables from quest rewards

### DIFF
--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -160,6 +160,7 @@
 				"Let’s try them out!"
 			]
 			dependencies: ["0000000000000174"]
+			optional: true
 			id: "000000000000017C"
 			tasks: [{
 				id: "000000000000017D"

--- a/config/ftbquests/quests/chapters/thermal_series.snbt
+++ b/config/ftbquests/quests/chapters/thermal_series.snbt
@@ -72,7 +72,7 @@
 					id: "00000000000004EC"
 					type: "item"
 					title: "Energy Cable (Basic)"
-					item: "powah:energy_cable_basic"
+					item: "mekanism:basic_universal_cable"
 					count: 8
 				}
 				{

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_powah_loot.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_powah_loot.json
@@ -88,11 +88,11 @@
                 {
                     "type": "minecraft:item",
                     "weight": 150,
-                    "name": "powah:energy_cable_hardened",
+                    "name": "mekanism:basic_universal_cable",
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": 16
+                            "count": 8
                         }
                     ]
                 },


### PR DESCRIPTION
Makes powah cable quest optional. Might consider removing?

removes powah cables from quest rewards. replaced with basic universal