### PR TITLE
Allow ftb ultimine to harvest entire menril tree (excl. leaves)

### DIFF
--- a/defaultconfigs/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine-server.snbt
@@ -11,5 +11,5 @@
 	
 	# These tags will be considered the same block when checking for blocks to Ultimine
 	# Default: ["minecraft:base_stone_overworld"]
-	merge_tags: ["minecraft:base_stone_overworld"]
+	merge_tags: ["minecraft:base_stone_overworld", "ftbultimine:menril_logs"]
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/ftbultimine/menril_logs.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/ftbultimine/menril_logs.js
@@ -1,0 +1,3 @@
+onEvent('block.tags', (event) => {
+    event.add('ftbultimine:menril_logs', ['integrateddynamics:menril_log', 'integrateddynamics:menril_log_filled']);
+});


### PR DESCRIPTION
> implements https://github.com/NillerMedDild/Enigmatica6/issues/3271

my attempt at trying to be helpful, went with the `ftbultimine:` tag namespace instead of `integrateddynamics:menril_tree` as to not confuse people where the tag originates, and to allow for future ultimine grouping to happen in the same place 🤔 

![2021-09-18_17 50 01](https://user-images.githubusercontent.com/3179271/133894660-ccdddb3b-0a99-48a2-9d7a-c4e7b905b988.png)


