### PR TITLE
Allow Ultimine to break Filled and Regular Menril logs

### DIFF
--- a/defaultconfigs/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine-server.snbt
@@ -11,5 +11,5 @@
 	
 	# These tags will be considered the same block when checking for blocks to Ultimine
 	# Default: ["minecraft:base_stone_overworld"]
-	merge_tags: ["minecraft:base_stone_overworld"]
+	merge_tags: ["minecraft:base_stone_overworld", "integrateddynamics:menril_logs"]
 }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/integrateddynamics/menril_logs.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/integrateddynamics/menril_logs.js
@@ -1,0 +1,3 @@
+onEvent('block.tags', (event) => {
+    event.get('integrateddynamics:menril_logs').add('integrateddynamics:menril_log_filled');
+});


### PR DESCRIPTION
Allow Ultimine to break Filled and Regular Menril logs. Allows chopping a whole menril tree at once like any other tree
![2021-09-18_12 00 27](https://user-images.githubusercontent.com/9543430/133895050-c072db39-2707-46ea-8762-be0fd5a60808.png)
.