### PR TITLE
Change Artifact Infinity Tools to accept Weak NBT instead of Strong

### DIFF
--- a/config/ftbquests/quests/chapters/challenges.snbt
+++ b/config/ftbquests/quests/chapters/challenges.snbt
@@ -884,7 +884,7 @@
 				{
 					id: "4801DE27B925DA50"
 					type: "item"
-					title: "Infinity Drill: Artififact Tier"
+					title: "Infinity Drill: Artifact Tier"
 					icon: {
 						id: "industrialforegoing:infinity_drill"
 						Count: 1b
@@ -910,8 +910,8 @@
 									tag: {
 										CanCharge: 1b
 										Special: 0b
-										Selected: "ARTIFACT"
-										Energy: 9223372036854775807L
+										Selected: "POOR"
+										Energy: 0L
 										Fluid: {
 											FluidName: "biofuel"
 											Amount: 0
@@ -919,18 +919,11 @@
 									}
 								}
 								{
-									id: "itemfilters:strong_nbt"
+									id: "itemfilters:weak_nbt"
 									Count: 1b
 									tag: {
 										value: {
-											CanCharge: 1b
-											Special: 0b
 											Selected: "ARTIFACT"
-											Energy: 9223372036854775807L
-											Fluid: {
-												FluidName: "biofuel"
-												Amount: 0
-											}
 										}
 									}
 								}
@@ -941,7 +934,7 @@
 				{
 					id: "7FD0249142690FBD"
 					type: "item"
-					title: "Infinity Hammer: Artififact Tier"
+					title: "Infinity Hammer: Artifact Tier"
 					icon: {
 						id: "industrialforegoing:infinity_hammer"
 						Count: 1b
@@ -963,35 +956,27 @@
 						tag: {
 							items: [
 								{
+									id: "itemfilters:weak_nbt"
+									Count: 1b
+									tag: {
+										value: {
+											Selected: "ARTIFACT"
+										}
+									}
+								}
+								{
 									id: "industrialforegoing:infinity_hammer"
 									Count: 1b
 									tag: {
-										CanCharge: 1b
+										CanCharge: 1
 										Energy: 9223372036854775807L
 										Fluid: {
 											FluidName: "biofuel"
 											Amount: 0
 										}
-										Special: 0b
+										Special: 0
 										Selected: "ARTIFACT"
 										Beheading: 0
-									}
-								}
-								{
-									id: "itemfilters:strong_nbt"
-									Count: 1b
-									tag: {
-										value: {
-											CanCharge: 1b
-											Energy: 9223372036854775807L
-											Fluid: {
-												FluidName: "biofuel"
-												Amount: 0
-											}
-											Special: 0b
-											Selected: "ARTIFACT"
-											Beheading: 0
-										}
 									}
 								}
 							]
@@ -1001,7 +986,7 @@
 				{
 					id: "625720B1A137C6DF"
 					type: "item"
-					title: "Infinity Trident: Artififact Tier"
+					title: "Infinity Trident: Artifact Tier"
 					icon: {
 						id: "industrialforegoing:infinity_trident"
 						Count: 1b
@@ -1025,39 +1010,29 @@
 						tag: {
 							items: [
 								{
+									id: "itemfilters:weak_nbt"
+									Count: 1b
+									tag: {
+										value: {
+											Selected: "ARTIFACT"
+										}
+									}
+								}
+								{
 									id: "industrialforegoing:infinity_trident"
 									Count: 1b
 									tag: {
-										CanCharge: 1b
+										CanCharge: 1
 										Riptide: 0
-										Channeling: 0b
+										Channeling: 0
 										Energy: 9223372036854775807L
 										Fluid: {
 											FluidName: "biofuel"
 											Amount: 0
 										}
-										Special: 0b
+										Special: 0
 										Selected: "ARTIFACT"
 										Loyalty: 0
-									}
-								}
-								{
-									id: "itemfilters:strong_nbt"
-									Count: 1b
-									tag: {
-										value: {
-											CanCharge: 1b
-											Riptide: 0
-											Channeling: 0b
-											Energy: 9223372036854775807L
-											Fluid: {
-												FluidName: "biofuel"
-												Amount: 0
-											}
-											Special: 0b
-											Selected: "ARTIFACT"
-											Loyalty: 0
-										}
 									}
 								}
 							]
@@ -1067,7 +1042,7 @@
 				{
 					id: "314182BBA59CFDD8"
 					type: "item"
-					title: "Infinity Saw: Artififact Tier"
+					title: "Infinity Saw: Artifact Tier"
 					icon: {
 						id: "industrialforegoing:infinity_saw"
 						Count: 1b
@@ -1088,32 +1063,25 @@
 						tag: {
 							items: [
 								{
+									id: "itemfilters:weak_nbt"
+									Count: 1b
+									tag: {
+										value: {
+											Selected: "ARTIFACT"
+										}
+									}
+								}
+								{
 									id: "industrialforegoing:infinity_saw"
 									Count: 1b
 									tag: {
-										CanCharge: 1b
-										Special: 0b
+										CanCharge: 1
+										Special: 0
 										Selected: "ARTIFACT"
 										Energy: 9223372036854775807L
 										Fluid: {
 											FluidName: "biofuel"
 											Amount: 0
-										}
-									}
-								}
-								{
-									id: "itemfilters:strong_nbt"
-									Count: 1b
-									tag: {
-										value: {
-											CanCharge: 1b
-											Special: 0b
-											Selected: "ARTIFACT"
-											Energy: 9223372036854775807L
-											Fluid: {
-												FluidName: "biofuel"
-												Amount: 0
-											}
 										}
 									}
 								}
@@ -1124,7 +1092,7 @@
 				{
 					id: "09A7BEA11BB1C9B1"
 					type: "item"
-					title: "Infinity Backpack: Artififact Tier"
+					title: "Infinity Backpack: Artifact Tier"
 					icon: {
 						id: "industrialforegoing:infinity_backpack"
 						Count: 1b
@@ -1141,25 +1109,22 @@
 						tag: {
 							items: [
 								{
-									id: "industrialforegoing:infinity_backpack"
-									Count: 1b
-									tag: {
-										CanCharge: 1b
-										Special: 0b
-										Selected: "ARTIFACT"
-										Energy: 9223372036854775807L
-									}
-								}
-								{
-									id: "itemfilters:strong_nbt"
+									id: "itemfilters:weak_nbt"
 									Count: 1b
 									tag: {
 										value: {
-											CanCharge: 1b
-											Special: 0b
 											Selected: "ARTIFACT"
-											Energy: 9223372036854775807L
 										}
+									}
+								}
+								{
+									id: "industrialforegoing:infinity_backpack"
+									Count: 1b
+									tag: {
+										CanCharge: 1
+										Special: 0
+										Selected: "ARTIFACT"
+										Energy: 9223372036854775807L
 									}
 								}
 							]
@@ -1170,7 +1135,7 @@
 					id: "1C420C2B58ADD9F4"
 					type: "item"
 					title: "Infinity Nuke: Artifact Tier"
-					item: {
+					icon: {
 						id: "industrialforegoing:infinity_nuke"
 						Count: 1b
 						tag: {
@@ -1184,12 +1149,43 @@
 							}
 						}
 					}
+					item: {
+						id: "itemfilters:and"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "itemfilters:weak_nbt"
+									Count: 1b
+									tag: {
+										value: {
+											Selected: "ARTIFACT"
+										}
+									}
+								}
+								{
+									id: "industrialforegoing:infinity_nuke"
+									Count: 1b
+									tag: {
+										CanCharge: 1
+										Special: 0
+										Selected: "ARTIFACT"
+										Energy: 9223372036854775807L
+										Fluid: {
+											FluidName: "biofuel"
+											Amount: 0
+										}
+									}
+								}
+							]
+						}
+					}
 				}
 				{
 					id: "50D6D2760038E934"
 					type: "item"
 					title: "Infinity Launcher: Artifact Tier"
-					item: {
+					icon: {
 						id: "industrialforegoing:infinity_launcher"
 						Count: 1b
 						tag: {
@@ -1202,6 +1198,38 @@
 							Special: 0
 							Selected: "ARTIFACT"
 							Plunger: 0
+						}
+					}
+					item: {
+						id: "itemfilters:and"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "itemfilters:weak_nbt"
+									Count: 1b
+									tag: {
+										value: {
+											Selected: "ARTIFACT"
+										}
+									}
+								}
+								{
+									id: "industrialforegoing:infinity_launcher"
+									Count: 1b
+									tag: {
+										CanCharge: 1
+										Energy: 9223372036854775807L
+										Fluid: {
+											FluidName: "biofuel"
+											Amount: 0
+										}
+										Special: 0
+										Selected: "ARTIFACT"
+										Plunger: 0
+									}
+								}
+							]
 						}
 					}
 				}

--- a/config/ftbquests/quests/chapters/challenges.snbt
+++ b/config/ftbquests/quests/chapters/challenges.snbt
@@ -910,8 +910,8 @@
 									tag: {
 										CanCharge: 1b
 										Special: 0b
-										Selected: "POOR"
-										Energy: 0L
+										Selected: "ARTIFACT"
+										Energy: 9223372036854775807L
 										Fluid: {
 											FluidName: "biofuel"
 											Amount: 0


### PR DESCRIPTION
Change Artifact Infinity Tools to accept Weak NBT instead of Strong
Some people are reporting they aren't getting credit for a few of these. Normalized them all on weak NBT filters. As long as they have `{Selected: "ARTIFACT"}` now, they're good to go.

Tests seem positive.  Quest is not completing for lower tiers and completes fine when I pull the items out of JEI or from crafting them.