### PR TITLE
[Expert] Blood Magic Updates

### DIFF
--- a/config/configswapper/expert/occultism.txt
+++ b/config/configswapper/expert/occultism.txt
@@ -1,0 +1,6 @@
+$occultism.server.spirit_job {
+    spirit_job.tier1CrusherOutputMultiplier = 0.5
+    spirit_job.tier2CrusherOutputMultiplier = 1.0
+    spirit_job.tier3CrusherOutputMultiplier = 1.5
+    spirit_job.tier4CrusherOutputMultiplier = 2.0
+}

--- a/config/configswapper/normal/occultism.txt
+++ b/config/configswapper/normal/occultism.txt
@@ -1,0 +1,6 @@
+$occultism.server.spirit_job {
+    spirit_job.tier1CrusherOutputMultiplier = 1.0
+    spirit_job.tier2CrusherOutputMultiplier = 1.5
+    spirit_job.tier3CrusherOutputMultiplier = 2.0
+    spirit_job.tier4CrusherOutputMultiplier = 3.0
+}

--- a/kubejs/client_scripts/expert/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/expert/item_modifiers/tooltips.js
@@ -26,7 +26,7 @@ onEvent('item.tooltip', (event) => {
     const recipes = [
         {
             items: ['bloodmagic:soulpickaxe'],
-            text: ['Capable of mining Iesnium.']
+            text: [Text.of('Capable of mining Iesnium.').color('#7e24b3')]
         },
         {
             items: ['tconstruct:seared_melter'],

--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -310,6 +310,18 @@ onEvent('jei.information', (event) => {
             description: [
                 `Mungus may be summoned through the Altar of Birthing, while Crimson Mosquitos may be created by bringing a Fly into the Nether.`
             ]
+        },
+        {
+            items: ['bloodmagic:weak_tau'],
+            description: [`Found in chests within the Demon Realm.`]
+        },
+        {
+            items: ['bloodmagic:strong_tau'],
+            description: [`Produced by growing Tau near mobs.`]
+        },
+        {
+            items: ['eidolon:unholy_symbol'],
+            description: [`Produced by chanting the Touch of Darkness at Pewter Inlay dropped on the ground.`]
         }
     ];
 

--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -92,40 +92,44 @@ onEvent('item.tooltip', (event) => {
             text: [Text.of('Shield Projections are immune to the Wither').color('#4F0D75')]
         },
         {
-            items: ['bloodmagic:quick_draw_anointment'],
+            items: [/bloodmagic:quick_draw_anointment/],
             text: [Text.of('Grants Quick-Draw on Bows and Crossbows').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:fortune_anointment'],
+            items: [/bloodmagic:fortune_anointment/],
             text: [Text.of('Grants additional Fortune on Tools').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:holy_water_anointment'],
+            items: [/bloodmagic:holy_water_anointment/],
             text: [Text.of('Grants bonus Smite damage on Melee Attacks.').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:melee_anointment'],
+            items: [/bloodmagic:melee_anointment/],
             text: [Text.of('Grants bonus damage on Melee Attacks').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:bow_power_anointment'],
+            items: [/bloodmagic:bow_power_anointment/],
             text: [Text.of('Grants bonus damage on Bows and Crossbows').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:silk_touch_anointment'],
+            items: [/bloodmagic:silk_touch_anointment/],
             text: [Text.of('Grants Silk Touch').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:hidden_knowledge_anointment'],
+            items: [/bloodmagic:hidden_knowledge_anointment/],
             text: [Text.of('Grants bonus Experience from block harvests.').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:smelting_anointment'],
+            items: [/bloodmagic:smelting_anointment/],
             text: [Text.of('Grants Auto Smelt').color('#7e24b3')]
         },
         {
-            items: ['bloodmagic:looting_anointment'],
+            items: [/bloodmagic:looting_anointment/],
             text: [Text.of('Grants additional Looting on Weapons').color('#7e24b3')]
+        },
+        {
+            items: [/bloodmagic:bow_velocity_anointment/],
+            text: [Text.of('Grants additional projectile velocity on Bows and Crossbows').color('#7e24b3')]
         },
         {
             items: ['#enigmatica:burning_hot'],

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/bloodmagic/alchemytable.js
@@ -1,252 +1,244 @@
 onEvent('recipes', (event) => {
     const id_prefix = 'enigmatica:base/bloodmagic/alchemytable/';
-    data = {
-        recipes: [
-            {
-                inputs: ['minecraft:gravel', 'minecraft:gravel', 'minecraft:gravel'],
-                output: 'minecraft:flint',
-                count: 3,
-                syphon: 50,
-                ticks: 20,
-                orbLevel: 0,
-                id: 'bloodmagic:alchemytable/flint_from_gravel'
-            },
-            {
-                inputs: ['#forge:crops/potato', '#forge:crops/potato', '#forge:crops/potato', 'minecraft:bone_meal'],
-                output: 'bloodmagic:plantoil',
-                count: 1,
-                syphon: 100,
-                ticks: 100,
-                orbLevel: 1,
-                id: 'bloodmagic:alchemytable/plantoil_from_taters'
-            },
-            {
-                inputs: ['#forge:crops', '#forge:crops', '#forge:crops', 'minecraft:bone_meal'],
-                output: 'bloodmagic:plantoil',
-                count: 1,
-                syphon: 100,
-                ticks: 100,
-                orbLevel: 1,
-                id: 'bloodmagic:alchemytable/plantoil_from_wheat'
-            },
-            {
-                inputs: ['minecraft:coal', 'minecraft:coal'],
-                output: 'emendatusenigmatica:coal_dust',
-                count: 2,
-                syphon: 400,
-                ticks: 200,
-                orbLevel: 1,
-                id: 'bloodmagic:alchemytable/sand_coal'
-            },
-            {
-                inputs: ['#minecraft:wool'],
-                output: 'minecraft:string',
-                count: 4,
-                syphon: 100,
-                ticks: 100,
-                orbLevel: 0,
-                id: 'bloodmagic:alchemytable/string'
-            },
-            {
-                inputs: ['#forge:sand', '#forge:sand', 'minecraft:water_bucket'],
-                output: 'minecraft:clay',
-                count: 2,
-                syphon: 50,
-                ticks: 100,
-                orbLevel: 2,
-                id: 'bloodmagic:alchemytable/clay_from_sand'
-            },
-            {
-                inputs: ['#forge:rods/blaze'],
-                output: 'minecraft:blaze_powder',
-                count: 4,
-                syphon: 50,
-                ticks: 20,
-                orbLevel: 1,
-                id: `${id_prefix}blaze_powder`
-            },
-            {
-                inputs: ['#forge:rods/basalz'],
-                output: 'thermal:basalz_powder',
-                count: 4,
-                syphon: 50,
-                ticks: 20,
-                orbLevel: 1,
-                id: `${id_prefix}basalz_powder`
-            },
-            {
-                inputs: ['#forge:rods/blizz'],
-                output: 'thermal:blizz_powder',
-                count: 4,
-                syphon: 50,
-                ticks: 20,
-                orbLevel: 1,
-                id: `${id_prefix}blizz_powder`
-            },
-            {
-                inputs: ['#forge:rods/blitz'],
-                output: 'thermal:blitz_powder',
-                count: 4,
-                syphon: 50,
-                ticks: 20,
-                orbLevel: 1,
-                id: `${id_prefix}blitz_powder`
-            },
-            {
-                inputs: ['minecraft:dirt', 'minecraft:bone_meal', '#forge:mushrooms'],
-                output: 'minecraft:mycelium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}mycelium`
-            },
-            {
-                inputs: ['minecraft:dirt', 'minecraft:bone_meal', '#minecraft:leaves'],
-                output: 'minecraft:podzol',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}podzol`
-            },
-            {
-                inputs: ['byg:quartzite_sand', 'byg:quartzite_sand', 'byg:quartzite_sand'],
-                output: 'minecraft:quartz',
-                count: 3,
-                syphon: 50,
-                ticks: 20,
-                orbLevel: 0,
-                id: `${id_prefix}quartz`
-            },
-            {
-                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:bulbis_sprouts'],
-                output: 'byg:bulbis_phycelium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}bulbis_phycelium`
-            },
-            {
-                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:imparius_vine'],
-                output: 'byg:imparius_phylium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}imparius_phylium`
-            },
-            {
-                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:shulkren_moss_blanket'],
-                output: 'byg:shulkren_phylium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}shulkren_phylium`
-            },
-            {
-                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:nightshade_sprouts'],
-                output: 'byg:nightshade_phylium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}nightshade_phylium`
-            },
-            {
-                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:ivis_sprout'],
-                output: 'byg:ivis_phylium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}ivis_phylium`
-            },
-            {
-                inputs: ['byg:ether_soil', 'minecraft:bone_meal', 'byg:ether_foliage'],
-                output: 'byg:ether_phylium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}ether_phylium`
-            },
-            {
-                inputs: ['minecraft:dirt', 'minecraft:bone_meal', 'byg:ether_foliage'],
-                output: 'byg:ether_soil',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}ether_soil`
-            },
-            {
-                inputs: ['byg:ether_stone', 'minecraft:bone_meal', 'byg:vermilion_sculk_growth'],
-                output: 'byg:vermilion_sculk',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}vermilion_sculk`
-            },
-            {
-                inputs: ['minecraft:netherrack', 'minecraft:bone_meal', '#forge:mushrooms'],
-                output: 'byg:mycelium_netherrack',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}mycelium_netherrack`
-            },
-            {
-                inputs: ['#forge:dusts/sulfur', 'industrialforegoing:dryrubber', 'industrialforegoing:dryrubber'],
-                output: 'thermal:cured_rubber',
-                count: 2,
-                syphon: 400,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}cured_rubber`
-            },
-            {
-                inputs: ['minecraft:end_stone', 'minecraft:bone_meal', '#forge:mushrooms'],
-                output: 'betterendforge:end_mycelium',
-                count: 1,
-                syphon: 200,
-                ticks: 200,
-                orbLevel: 1,
-                id: `${id_prefix}end_mycelium`
-            },
-            {
-                inputs: ['minecraft:nether_wart_block'],
-                output: 'minecraft:nether_wart',
-                count: 4,
-                syphon: 50,
-                ticks: 40,
-                orbLevel: 0,
-                id: 'bloodmagic:alchemytable/nether_wart_from_block'
-            },
-            {
-                inputs: [
-                    'bloodmagic:tauoil',
-                    '#forge:dusts/glowstone',
-                    'minecraft:gunpowder',
-                    'minecraft:sugar',
-                    '#forge:dusts/sulfur',
-                    Item.of('minecraft:potion', '{Potion:"minecraft:water"}')
-                ],
-                output: 'bloodmagic:intermediatecuttingfluid',
-                count: 1,
-                syphon: 2000,
-                ticks: 200,
-                orbLevel: 3,
-                id: 'bloodmagic:alchemytable/intermediate_cutting_fluid'
-            }
-        ]
-    };
 
-    data.recipes.forEach((recipe) => {
+    recipes = [
+        {
+            inputs: ['minecraft:gravel', 'minecraft:gravel', 'minecraft:gravel'],
+            output: 'minecraft:flint',
+            count: 3,
+            syphon: 50,
+            ticks: 20,
+            orbLevel: 0,
+            id: 'bloodmagic:alchemytable/flint_from_gravel'
+        },
+        {
+            inputs: ['#forge:crops/potato', '#forge:crops/potato', '#forge:crops/potato', 'minecraft:bone_meal'],
+            output: 'bloodmagic:plantoil',
+            count: 1,
+            syphon: 100,
+            ticks: 100,
+            orbLevel: 1,
+            id: 'bloodmagic:alchemytable/plantoil_from_taters'
+        },
+        {
+            inputs: ['#forge:crops', '#forge:crops', '#forge:crops', 'minecraft:bone_meal'],
+            output: 'bloodmagic:plantoil',
+            count: 1,
+            syphon: 100,
+            ticks: 100,
+            orbLevel: 1,
+            id: 'bloodmagic:alchemytable/plantoil_from_wheat'
+        },
+        {
+            inputs: ['minecraft:coal', 'minecraft:coal'],
+            output: 'emendatusenigmatica:coal_dust',
+            count: 2,
+            syphon: 400,
+            ticks: 200,
+            orbLevel: 1,
+            id: 'bloodmagic:alchemytable/sand_coal'
+        },
+        {
+            inputs: ['#minecraft:wool'],
+            output: 'minecraft:string',
+            count: 4,
+            syphon: 100,
+            ticks: 100,
+            orbLevel: 0,
+            id: 'bloodmagic:alchemytable/string'
+        },
+        {
+            inputs: ['#forge:sand', '#forge:sand', 'minecraft:water_bucket'],
+            output: 'minecraft:clay',
+            count: 2,
+            syphon: 50,
+            ticks: 100,
+            orbLevel: 2,
+            id: 'bloodmagic:alchemytable/clay_from_sand'
+        },
+        {
+            inputs: ['#forge:sand', '#forge:sand', 'bloodmagic:watersigil'],
+            output: 'minecraft:clay',
+            count: 2,
+            syphon: 150,
+            ticks: 100,
+            orbLevel: 2,
+            id: `${id_prefix}clay_from_sand_sigil`
+        },
+        {
+            inputs: ['#forge:rods/blaze'],
+            output: 'minecraft:blaze_powder',
+            count: 4,
+            syphon: 50,
+            ticks: 20,
+            orbLevel: 1,
+            id: `${id_prefix}blaze_powder`
+        },
+        {
+            inputs: ['#forge:rods/basalz'],
+            output: 'thermal:basalz_powder',
+            count: 4,
+            syphon: 50,
+            ticks: 20,
+            orbLevel: 1,
+            id: `${id_prefix}basalz_powder`
+        },
+        {
+            inputs: ['#forge:rods/blizz'],
+            output: 'thermal:blizz_powder',
+            count: 4,
+            syphon: 50,
+            ticks: 20,
+            orbLevel: 1,
+            id: `${id_prefix}blizz_powder`
+        },
+        {
+            inputs: ['#forge:rods/blitz'],
+            output: 'thermal:blitz_powder',
+            count: 4,
+            syphon: 50,
+            ticks: 20,
+            orbLevel: 1,
+            id: `${id_prefix}blitz_powder`
+        },
+        {
+            inputs: ['minecraft:dirt', 'minecraft:bone_meal', '#forge:mushrooms'],
+            output: 'minecraft:mycelium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}mycelium`
+        },
+        {
+            inputs: ['minecraft:dirt', 'minecraft:bone_meal', '#minecraft:leaves'],
+            output: 'minecraft:podzol',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}podzol`
+        },
+        {
+            inputs: ['byg:quartzite_sand', 'byg:quartzite_sand', 'byg:quartzite_sand'],
+            output: 'minecraft:quartz',
+            count: 3,
+            syphon: 50,
+            ticks: 20,
+            orbLevel: 0,
+            id: `${id_prefix}quartz`
+        },
+        {
+            inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:bulbis_sprouts'],
+            output: 'byg:bulbis_phycelium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}bulbis_phycelium`
+        },
+        {
+            inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:imparius_vine'],
+            output: 'byg:imparius_phylium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}imparius_phylium`
+        },
+        {
+            inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:shulkren_moss_blanket'],
+            output: 'byg:shulkren_phylium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}shulkren_phylium`
+        },
+        {
+            inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:nightshade_sprouts'],
+            output: 'byg:nightshade_phylium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}nightshade_phylium`
+        },
+        {
+            inputs: ['minecraft:end_stone', 'minecraft:bone_meal', 'byg:ivis_sprout'],
+            output: 'byg:ivis_phylium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}ivis_phylium`
+        },
+        {
+            inputs: ['byg:ether_soil', 'minecraft:bone_meal', 'byg:ether_foliage'],
+            output: 'byg:ether_phylium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}ether_phylium`
+        },
+        {
+            inputs: ['minecraft:dirt', 'minecraft:bone_meal', 'byg:ether_foliage'],
+            output: 'byg:ether_soil',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}ether_soil`
+        },
+        {
+            inputs: ['byg:ether_stone', 'minecraft:bone_meal', 'byg:vermilion_sculk_growth'],
+            output: 'byg:vermilion_sculk',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}vermilion_sculk`
+        },
+        {
+            inputs: ['minecraft:netherrack', 'minecraft:bone_meal', '#forge:mushrooms'],
+            output: 'byg:mycelium_netherrack',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}mycelium_netherrack`
+        },
+        {
+            inputs: ['#forge:dusts/sulfur', 'industrialforegoing:dryrubber', 'industrialforegoing:dryrubber'],
+            output: 'thermal:cured_rubber',
+            count: 2,
+            syphon: 400,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}cured_rubber`
+        },
+        {
+            inputs: ['minecraft:end_stone', 'minecraft:bone_meal', '#forge:mushrooms'],
+            output: 'betterendforge:end_mycelium',
+            count: 1,
+            syphon: 200,
+            ticks: 200,
+            orbLevel: 1,
+            id: `${id_prefix}end_mycelium`
+        },
+        {
+            inputs: ['minecraft:nether_wart_block'],
+            output: 'minecraft:nether_wart',
+            count: 4,
+            syphon: 50,
+            ticks: 40,
+            orbLevel: 0,
+            id: 'bloodmagic:alchemytable/nether_wart_from_block'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
         event.recipes.bloodmagic
             .alchemytable(Item.of(recipe.output, recipe.count), recipe.inputs)
             .syphon(recipe.syphon)

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -20,6 +20,9 @@ onEvent('recipes', (event) => {
 
         'betterendforge:leather_to_stripes',
 
+        'bloodmagic:arc/weakbloodshard_tau',
+        /bloodmagic:alchemytable\/melee_damage_anointment/,
+
         'botania:mana_infusion/mana_diamond_block',
 
         /create:pressing\/\w*_ingot/,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -76,7 +76,7 @@ onEvent('recipes', (event) => {
         /emendatusenigmatica:alloy_dust/
     ];
 
-    const outputRemovals = ['tiab:timeinabottle', 'minecraft:nautilus_shell'];
+    const outputRemovals = ['tiab:timeinabottle', 'minecraft:nautilus_shell', 'bloodmagic:intermediatecuttingfluid'];
 
     const patchouli_safe_removals = [
         { output: 'apotheosis:hellshelf', id: 'apotheosis:hellshelf' },

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -213,7 +213,7 @@ onEvent('recipes', (event) => {
             syphon: 20000,
             ticks: 200,
             orbLevel: 3,
-            id: 'bloodmagic:arc/weakbloodshard'
+            id: `${id_prefix}weakbloodshard`
         },
         {
             inputs: [
@@ -392,7 +392,7 @@ onEvent('recipes', (event) => {
                 'bloodmagic:slate_vial',
                 Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
                 '#forge:nuggets/aluminum',
-                'undergarden:gloomper_leg'
+                'undergarden:raw_gloomper_leg'
             ],
             output: 'bloodmagic:quick_draw_anointment',
             count: 1,
@@ -400,6 +400,20 @@ onEvent('recipes', (event) => {
             ticks: 100,
             orbLevel: 1,
             id: 'bloodmagic:alchemytable/quick_draw_anointment'
+        },
+        {
+            inputs: [
+                'bloodmagic:slate_vial',
+                Item.of('naturesaura:aura_bottle', '{stored_type:"naturesaura:overworld"}'),
+                'undergarden:utheric_shard',
+                'undergarden:raw_gwibling'
+            ],
+            output: 'bloodmagic:bow_velocity_anointment',
+            count: 1,
+            syphon: 500,
+            ticks: 100,
+            orbLevel: 1,
+            id: 'bloodmagic:alchemytable/bow_velocity_anointment'
         },
         {
             inputs: [
@@ -532,8 +546,46 @@ onEvent('recipes', (event) => {
             id: 'bloodmagic:alchemytable/basic_cutting_fluid_sigil'
         }
     ];
+
+    let anointmentTypes = [
+        'holy_water_anointment',
+        'looting_anointment',
+        'melee_anointment',
+        'hidden_knowledge_anointment',
+        'fortune_anointment',
+        'bow_power_anointment',
+        'smelting_anointment',
+        'silk_touch_anointment',
+        'quick_draw_anointment',
+        'bow_velocity_anointment'
+    ];
+
+    anointmentTypes.forEach((anointmentType) => {
+        recipes.push({
+            inputs: [`bloodmagic:${anointmentType}`, 'bloodmagic:tauoil'],
+            output: `bloodmagic:${anointmentType}_l`,
+            count: 1,
+            syphon: 1000,
+            ticks: 100,
+            orbLevel: 3,
+            id: `bloodmagic:alchemytable/${anointmentType}_l`
+        });
+        if (anointmentType !== 'smelting_anointment' && anointmentType !== 'silk_touch_anointment') {
+            recipes.push({
+                inputs: [`bloodmagic:${anointmentType}`, 'bloodmagic:strong_tau'],
+                output: `bloodmagic:${anointmentType}_2`,
+                count: 1,
+                syphon: 1000,
+                ticks: 100,
+                orbLevel: 3,
+                id: `bloodmagic:alchemytable/${anointmentType}_2`
+            });
+        }
+    });
+
     recipes.forEach((recipe) => {
-        const re = event.recipes.bloodmagic
+        console.log(`Adding Recipe for ${recipe.output}`);
+        event.recipes.bloodmagic
             .alchemytable(Item.of(recipe.output, recipe.count), recipe.inputs)
             .syphon(recipe.syphon)
             .ticks(recipe.ticks)

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/bloodmagic/alchemytable.js
@@ -534,6 +534,15 @@ onEvent('recipes', (event) => {
             orbLevel: 1,
             id: `${id_prefix}light_gray_rune`
         },
+        {
+            inputs: ['bloodmagic:basiccuttingfluid', 'bloodmagic:tauoil', 'bloodmagic:lavasigil'],
+            output: 'bloodmagic:intermediatecuttingfluid',
+            count: 2,
+            syphon: 2100,
+            ticks: 200,
+            orbLevel: 3,
+            id: `${id_prefix}intermediatecuttingfluid`
+        },
 
         /// Patchouli Removals
         {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/shaped.js
@@ -99,10 +99,10 @@ onEvent('recipes', (event) => {
             output: 'botania:knockback_belt',
             pattern: ['B  ', ' C ', 'D A'],
             key: {
-                A: { tag: 'botania:runes/earth' },
-                B: { tag: 'botania:runes/fire' },
-                C: { item: 'eidolon:basic_belt' },
-                D: { tag: 'forge:ingots/manasteel' }
+                A: '#botania:runes/earth',
+                B: '#botania:runes/fire',
+                C: 'eidolon:basic_belt',
+                D: '#forge:ingots/manasteel'
             },
             id: 'botania:knockback_belt'
         },
@@ -110,10 +110,10 @@ onEvent('recipes', (event) => {
             output: 'botania:travel_belt',
             pattern: ['B  ', ' C ', 'D A'],
             key: {
-                A: { tag: 'botania:runes/air' },
-                B: { tag: 'botania:runes/earth' },
-                C: { item: 'eidolon:basic_belt' },
-                D: { tag: 'forge:ingots/manasteel' }
+                A: '#botania:runes/air',
+                B: '#botania:runes/earth',
+                C: 'eidolon:basic_belt',
+                D: '#forge:ingots/manasteel'
             },
             id: 'botania:travel_belt'
         },
@@ -121,19 +121,25 @@ onEvent('recipes', (event) => {
             output: 'botania:crafting_halo',
             pattern: [' A ', 'BCB', ' B '],
             key: {
-                A: { item: 'botania:corporea_spark' },
-                B: { item: 'ars_nouveau:marvelous_clay' },
-                C: { item: 'ars_nouveau:glyph_craft' }
+                A: 'botania:corporea_spark',
+                B: 'ars_nouveau:marvelous_clay',
+                C: 'ars_nouveau:glyph_craft'
             },
             id: 'botania:crafting_halo'
+        },
+        {
+            output: 'botania:glass_pickaxe',
+            pattern: ['ABA', ' C ', ' C '],
+            key: {
+                A: 'glassential:glass_ghostly',
+                B: '#forge:gems/mana',
+                C: 'naturesaura:ancient_stick'
+            },
+            id: 'botania:glass_pickaxe'
         }
     ];
 
     newRecipes.forEach((recipe) => {
-        if (recipe.id) {
-            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
-        } else {
-            event.shaped(recipe.output, recipe.pattern, recipe.key);
-        }
+        event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
     });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/bloodmagic/alchemytable.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/normal/recipetypes/bloodmagic/alchemytable.js
@@ -1,0 +1,34 @@
+onEvent('recipes', (event) => {
+    if (global.isNormalMode == false) {
+        return;
+    }
+    const id_prefix = 'enigmatica:normal/bloodmagic/alchemytable/';
+
+    recipes = [
+        {
+            inputs: [
+                'bloodmagic:tauoil',
+                '#forge:dusts/glowstone',
+                'minecraft:gunpowder',
+                'minecraft:sugar',
+                '#forge:dusts/sulfur',
+                Item.of('minecraft:potion', '{Potion:"minecraft:water"}')
+            ],
+            output: 'bloodmagic:intermediatecuttingfluid',
+            count: 1,
+            syphon: 2000,
+            ticks: 200,
+            orbLevel: 3,
+            id: 'bloodmagic:alchemytable/intermediate_cutting_fluid'
+        }
+    ];
+
+    recipes.forEach((recipe) => {
+        event.recipes.bloodmagic
+            .alchemytable(Item.of(recipe.output, recipe.count), recipe.inputs)
+            .syphon(recipe.syphon)
+            .ticks(recipe.ticks)
+            .upgradeLevel(recipe.orbLevel)
+            .id(recipe.id);
+    });
+});


### PR DESCRIPTION
Drop Occultism crusher outputs for expert to 1x, 2x, 3x, and 4x

More BM tooltips added and other helper text

Update recipes for new anointments. Made enhanced versions cheaper to promote use.
New Archer's Polish
![image](https://user-images.githubusercontent.com/9543430/135195927-12b8d324-b53b-413e-aa77-f19ac348b0d7.png)

Upgrades follow similar format of tau oil for the extended duration and saturated tau for the improved power
![image](https://user-images.githubusercontent.com/9543430/135195999-547cbdc9-0750-48de-ae30-9082e0cd01b2.png)

Removed new default blood shard recipe in expert

Vitreous Pickaxe brought forward a bit.
![image](https://user-images.githubusercontent.com/9543430/135198918-7547b5b4-e11e-4edd-8ac8-b7cfe3e9753a.png)
