### PR TITLE
Update to magical ore processing

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -203,19 +203,25 @@ onEvent('jei.information', (event) => {
         {
             items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:overworld' })],
             description: [
-                'Obtained by Right-Clicking a Bottle and Cork in the air in the Overworld or Atum. This action removes Aura from the area.'
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the Overworld or Atum. This action removes Aura from the area.',
+                ' ',
+                `Can be automated using a Dispenser.`
             ]
         },
         {
             items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:end' })],
             description: [
-                'Obtained by Right-Clicking a Bottle and Cork in the air in the End or The Undergarden. This action removes Aura from the area.'
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the End or The Undergarden. This action removes Aura from the area.',
+                ' ',
+                `Can be automated using a Dispenser.`
             ]
         },
         {
             items: [Item.of('naturesaura:aura_bottle', { stored_type: 'naturesaura:nether' })],
             description: [
-                'Obtained by Right-Clicking a Bottle and Cork in the air in the Nether. This action removes Aura from the area.'
+                'Obtained by Right-Clicking a Bottle and Cork in the air in the Nether. This action removes Aura from the area.',
+                ' ',
+                `Can be automated using a Dispenser.`
             ]
         },
         {

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/botania/terra_plate.js
@@ -2,15 +2,26 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+    const id_prefix = 'enigmatica:expert/botania/terra_plate/';
     const recipes = [
         {
             inputs: [
-                Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson(),
+                Item.of('resourcefulbees:bee_jar', {
+                    Entity: 'resourcefulbees:mana_bee',
+                    BeeType: 'mana',
+                    Color: '#4c97ff'
+                })
+                    .weakNBT()
+                    .toJson(),
                 { item: 'botania:mana_pearl' },
                 { item: 'botania:mana_diamond' },
                 { item: 'botania:quartz_mana' }
             ],
-            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrestrial_bee", BeeType: "terrestrial", Color: "#5bf23d"}).toJson(),
+            output: Item.of('resourcefulbees:bee_jar', {
+                Entity: 'resourcefulbees:terrestrial_bee',
+                BeeType: 'terrestrial',
+                Color: '#5bf23d'
+            }).toJson(),
             mana: 2000000,
             id: 'botania:terra_plate/terrestrial_bee_plate'
         },
@@ -39,6 +50,19 @@ onEvent('recipes', (event) => {
             output: { item: 'botania:terrasteel_ingot' },
             mana: 500000,
             id: 'botania:terra_plate/terrasteel_ingot'
+        },
+        {
+            inputs: [
+                { item: 'botania:forest_eye' },
+                { item: 'naturesaura:token_euphoria' },
+                { item: 'naturesaura:token_rage' },
+                { item: 'atum:ptah_godshard' },
+                { item: 'naturesaura:token_grief' },
+                { item: 'naturesaura:token_terror' }
+            ],
+            output: { item: 'naturesaura:generator_limit_remover' },
+            mana: 2000000,
+            id: `${id_prefix}generator_limit_remover`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mythicbotany/infusion.js
@@ -2,15 +2,26 @@ onEvent('recipes', (event) => {
     if (global.isExpertMode == false) {
         return;
     }
+    const id_prefix = 'enigmatica:expert/mythicbotany/infusion/';
     const recipes = [
         {
             inputs: [
-                Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:mana_bee", BeeType: "mana", Color: "#4c97ff"}).weakNBT().toJson(),
+                Item.of('resourcefulbees:bee_jar', {
+                    Entity: 'resourcefulbees:mana_bee',
+                    BeeType: 'mana',
+                    Color: '#4c97ff'
+                })
+                    .weakNBT()
+                    .toJson(),
                 { item: 'botania:mana_pearl' },
                 { item: 'botania:mana_diamond' },
                 { item: 'botania:quartz_mana' }
             ],
-            output: Item.of('resourcefulbees:bee_jar', {Entity: "resourcefulbees:terrestrial_bee", BeeType: "terrestrial", Color: "#5bf23d"}).toJson(),
+            output: Item.of('resourcefulbees:bee_jar', {
+                Entity: 'resourcefulbees:terrestrial_bee',
+                BeeType: 'terrestrial',
+                Color: '#5bf23d'
+            }).toJson(),
             mana: 2000000,
             fromColor: parseInt('0xFFFFFF'),
             toColor: parseInt('0x00FF00'),
@@ -77,17 +88,18 @@ onEvent('recipes', (event) => {
         },
         {
             inputs: [
-                { item: 'naturesaura:infused_stone' },
+                { item: 'botania:forest_eye' },
                 { item: 'naturesaura:token_euphoria' },
                 { item: 'naturesaura:token_rage' },
-                { tag: 'forge:ingots/infused_iron' },
+                { item: 'atum:ptah_godshard' },
                 { item: 'naturesaura:token_grief' },
                 { item: 'naturesaura:token_terror' }
             ],
             output: { item: 'naturesaura:generator_limit_remover' },
             mana: 2000000,
             fromColor: parseInt('0xFF9900'),
-            toColor: parseInt('0x00FF1A')
+            toColor: parseInt('0x00FF1A'),
+            id: `${id_prefix}generator_limit_remover`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/unification/unify_materials.js
@@ -167,7 +167,7 @@ onEvent('recipes', (event) => {
 
         event.shapeless(Item.of(output, 2), [plate, plate, wireCutters]).id(`kubejs:shaped_crafting_${material}_wire`);
     }
-    //Mock-up. Real process would use new assets to avoid mix ups with Mek processing.
+
     function magical_ore_processing(
         event,
         material,
@@ -212,23 +212,20 @@ onEvent('recipes', (event) => {
             input: Ingredient.of(infusing_input).toJson(),
             output: { item: mana_cluster, count: 1 },
             catalyst: { type: 'block', block: 'naturesaura:generator_limit_remover' },
-            mana: 25000
+            mana: 10000
         });
 
         // Step Two: Zap!
         event.custom({
             type: 'interactio:item_lightning',
-            inputs: [
-                Ingredient.of(zapping_input).toJson(),
-                { tag: 'botania:runes/asgard', count: 1, return_chance: 0.5 }
-            ],
+            inputs: [Ingredient.of(zapping_input).toJson()],
             output: {
                 entries: [
                     { result: { item: fulminated_cluster, count: 1 }, weight: 10 },
                     { result: { item: secondary_fulminated_cluster, count: 1 }, weight: 5 },
-                    { result: { item: 'thermal:slag', count: 1 }, weight: 85 } // would prefer something like tiny slag here
+                    { result: { item: 'thermal:slag', count: 1 }, weight: 35 }
                 ],
-                empty_weight: 0,
+                empty_weight: 50,
                 rolls: 20
             }
         });
@@ -249,18 +246,18 @@ onEvent('recipes', (event) => {
             type: 'interactio:item_fluid_transform',
             inputs: [
                 Ingredient.of(freezing_input).toJson(),
-                { tag: 'botania:runes/winter', count: 1, return_chance: 0.95 }
+                { tag: 'botania:runes/winter', count: 1, return_chance: 1.0 }
             ],
             output: {
                 entries: [
                     { result: Ingredient.of(crystalline_sliver).toJson(), weight: 75 },
-                    { result: Ingredient.of('bloodmagic:corrupted_tinydust').toJson(), weight: 25 } //placeholder item. Could be a handy place to put a byproduct required for high tier crafts
+                    { result: Ingredient.of('bloodmagic:corrupted_tinydust').toJson(), weight: 25 }
                 ],
                 empty_weight: 0,
                 rolls: 20
             },
             fluid: { fluid: 'astralsorcery:liquid_starlight' },
-            consume_fluid: 0.75
+            consume_fluid: 0.15
         });
 
         // Step Five: Fuse!
@@ -278,8 +275,8 @@ onEvent('recipes', (event) => {
                 Ingredient.of(fusing_input).toJson(),
                 Ingredient.of(fusing_input).toJson(),
                 Ingredient.of(fusing_input).toJson(),
-                Ingredient.of('eidolon:ender_calx').toJson(),
-                Ingredient.of(`#botania:runes/muspelheim`).toJson()
+                Ingredient.of('#forge:dusts/mana').toJson(),
+                Ingredient.of(`#botania:runes/nidavellir`).toJson()
             ]
         });
     }


### PR DESCRIPTION
Reduced mana cost of first step

Removed Rune from Lightning step of magical 5x ore processing. Now you just zap it.

Moved creational Catalyst to terra plate instead of only the mythic botany infuser
![image](https://user-images.githubusercontent.com/9543430/135738125-459061ae-21fe-4dc3-9897-5d4efe2e4386.png)

Guaranteed return of Winter rune from crystallization step. Reduced consumption rate of liquid starlight

Final step now uses mana powder of ender calx.