### PR TITLE
Remove Ender Slime as sap output for Green slime saplings. Moved to Pythandron logs instead. 

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/trees.js
@@ -638,7 +638,7 @@ const treeRegistry = [
                 trunk: 'betterendforge:pythadendron_log',
                 leaf: 'betterendforge:pythadendron_leaves',
                 substrate: 'chorus_nylium',
-                sap: 'integrateddynamics:liquid_chorus',
+                sap: 'tconstruct:ender_slime',
                 rate: { living: 25, dead: 4 }
             },
             {
@@ -839,7 +839,7 @@ const treeRegistry = [
                 leaf: 'tconstruct:ender_slime_leaves',
                 fruit: 'tconstruct:ender_slime_ball',
                 substrate: 'slimy_dirt',
-                sap: 'tconstruct:ender_slime',
+                sap: 'tconstruct:earth_slime',
                 rate: { living: 25, dead: 4 }
             },
             {


### PR DESCRIPTION
Since both the purple and green tree use the same logs, this script was resulting in end slime from both trees. Defaulting to regular slime instead. Moved ender slime over to the pythandron tree instead.