### PR TITLE
Re-disables supplementaries items, un-hides items we have since enabled

### DIFF
--- a/config/supplementaries-registry.toml
+++ b/config/supplementaries-registry.toml
@@ -18,7 +18,7 @@
 	[initialization.blocks]
 		clock_block = true
 		speaker_block = true
-		sack = true
+		sack = false
 		#WIP
 		laser_block = false
 		bellows = true
@@ -38,9 +38,9 @@
 		checker_block = true
 		slingshot = true
 		wattle_and_daub = true
-		stone_lamp = true
+		stone_lamp = false
 		cog_block = true
-		crank = true
+		crank = false
 		copper_lantern = true
 		pancake = true
 		statue = true
@@ -59,8 +59,8 @@
 		#WIP
 		present = true
 		sign_post = true
-		pedestal = true
-		blackboard = true
+		pedestal = false
+		blackboard = false
 		netherite_door = true
 		candle_holder = true
 		flint_block = true
@@ -74,7 +74,7 @@
 		planter = true
 		wind_vane = true
 		item_shelf = true
-		turn_table = true
+		turn_table = false
 		faucet = true
 		daub = true
 		blackstone_lamp = true

--- a/kubejs/client_scripts/constants.js
+++ b/kubejs/client_scripts/constants.js
@@ -264,10 +264,7 @@ const itemsToHide = [
 
     'supplementaries:pedestal',
     'supplementaries:crank',
-    'supplementaries:cog_block',
-    'supplementaries:redstone_illuminator',
     'supplementaries:turn_table',
-    'supplementaries:firefly_jar',
     'supplementaries:stone_lamp',
     'supplementaries:sack',
     'supplementaries:blackboard',


### PR DESCRIPTION
left cog blocks(rid likes these, and they would look great in a create themed build), redstone illuminator enabled, removed those from hide list

also removed firefly jar from hide list as we have had the other jars enabled for some time now and we have fireflies to catch!