### PR TITLE
Fixes missing valid apiary tags 

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/resourcefulbees/valid_apiary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/blocks/resourcefulbees/valid_apiary.js
@@ -1,3 +1,3 @@
 onEvent('block.tags', (event) => {
-    event.get('resourcefulbees:valid_apiary').removeAll().add(validApiaryBlocks);
+    event.get('resourcefulbees:valid_apiary').add(validApiaryBlocks);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/resourcefulbees/valid_apiary.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/resourcefulbees/valid_apiary.js
@@ -1,3 +1,3 @@
 onEvent('item.tags', (event) => {
-    event.get('resourcefulbees:valid_apiary').removeAll().add(validApiaryBlocks);
+    event.get('resourcefulbees:valid_apiary').add(validApiaryBlocks);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
@@ -7,7 +7,7 @@ const validApiaryBlocks = [
     'glassential:glass_dark_ethereal',
     'glassential:glass_ethereal',
     'glassential:glass_light',
-    'glassential:glass_redstone',
+    'glassential:glass_redstone'
 ];
 
 const honeyVarieties = [

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/resourcefulbees.js
@@ -3,22 +3,11 @@
 // Items added here will get the 'valid_apiary' tag, and be usable as Apiary multiblock walls.
 // This is in addition to all blocks that have collision.
 const validApiaryBlocks = [
-    'botania:bifrost_pane',
-    'botania:bifrost_perm',
-    'botania:elf_glass_pane',
-    'botania:mana_glass_pane',
-    'botania:elf_glass',
-    'botania:mana_glass',
-
     'glassential:glass_dark',
     'glassential:glass_dark_ethereal',
     'glassential:glass_ethereal',
     'glassential:glass_light',
     'glassential:glass_redstone',
-
-    /mcwwindows:/,
-
-    /elevatorid/
 ];
 
 const honeyVarieties = [


### PR DESCRIPTION
fixes #3384 

left the glassential blocks in as they are still not registered by RB's collision test

removed the `removeAll()` from the block and item tag scripts

tested in game and all seems to be working as it should