### PR TITLE
Fix oil in neromantic prime. Fix recipe loop for expert mana spreader

### DIFF
--- a/defaultconfigs/astralsorcery.toml
+++ b/defaultconfigs/astralsorcery.toml
@@ -675,7 +675,7 @@
 
 	[registries.fluid_rarities]
 		#Defines fluid-rarities and amounts for the evershifting fountain's neromantic prime. The lower the relative rarity, the more rare the fluid. Format: <FluidName>;<guaranteedMbAmount>;<additionalRandomMbAmount>;<rarity>
-		fluid_rarities = ["minecraft:water;2147483647;2147483647;14000", "minecraft:lava;4000000;1000000;7500","immersivepetroleum:oil;2500000;1000000;5000","mekanismgenerators:flowing_fusion_fuel;1000000;500000;100","industrialforegoing:sewage_fluid;10000000;5000000;250","bloodmagic:life_essence_fluid_flowing;5000000;2500000;250","industrialforegoing:sludge_fluid;1000000;1000000;200","immersivepetroleum:napalm;500000;500000;100","industrialforegoing:essence_fluid;500000;100000;300", "mekanism:flowing_heavy_water;10000000;2000000;2500"]
+		fluid_rarities = ["minecraft:water;2147483647;2147483647;14000", "minecraft:lava;4000000;1000000;7500","pneumaticcraft:oil;2500000;1000000;5000","mekanismgenerators:flowing_fusion_fuel;1000000;500000;100","industrialforegoing:sewage_fluid;10000000;5000000;250","bloodmagic:life_essence_fluid_flowing;5000000;2500000;250","industrialforegoing:sludge_fluid;1000000;1000000;200","immersivepetroleum:napalm;500000;500000;100","industrialforegoing:essence_fluid;500000;100000;300", "mekanism:flowing_heavy_water;10000000;2000000;2500"]
 
 	[registries.technical_entities]
 		#Defines entities whose purpose is mostly technical and less gameplay impactful. Those will be excluded from effects that manipulate entities. Add entities by their entity type name.Format: <EntityTypeName>

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
@@ -12,7 +12,7 @@ onEvent('recipes', (event) => {
     }
     const id_prefix = 'enigmatica:expert/astralsorcery/altar/';
     const recipes = [
-        /// Luminous Crafting Table REcipes
+        /// Luminous Crafting Table Recipes
         {
             output: Item.of('astralsorcery:well'),
             pattern: ['_____', '_B_B_', '_CDC_', '_ABA_', '_____'],
@@ -126,7 +126,7 @@ onEvent('recipes', (event) => {
                 B: { item: 'botania:glimmering_livingwood' },
                 C: { tag: 'forge:ingots/infused_iron' },
                 D: { item: 'botania:spark' },
-                E: { item: 'astralsorcery:glass_lens' }
+                E: { item: 'atum:crystal_glass_pane' }
             },
             altar_type: 0,
             duration: 100,


### PR DESCRIPTION
Fix oil in neromantic prime. All other sources of oil give PNC oil. This was missed in the unification. Fixes: #3393


Fix recipe loop for expert mana spreader. Mana spreader needed Astral lens, which needed resonating gems... which need mana.... which need mana spreader. >.<