### PR TITLE
Fix missing NBT on SushiGo Wasabee tobiko craft

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/shaped.js
@@ -117,7 +117,7 @@ onEvent('recipes', (event) => {
             id: 'enigmatica:base/minecraft/salmon_combs'
         },
         {
-            output: Item.of('sushigocrafting:tobiko', 3),
+            output: Item.of('sushigocrafting:tobiko', '{Amount:15}'),
             pattern: ['A', 'C', 'B'],
             key: {
                 A: 'resourcefulbees:wasabee_honeycomb',


### PR DESCRIPTION
Add NBT to the Tobiko craft using wasabee combs
In relation with PR #3169
Resolving issue #3093