### PR TITLE
Mineral Update - Add Fluorite to the Excavator

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/minerals.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/immersiveengineering/minerals.js
@@ -16,8 +16,8 @@ onEvent('recipes', (event) => {
             },
             {
                 ores: [
-                    { chance: 0.6, output: { tag: 'forge:chunks/quartz' } },
-                    { chance: 0.3, output: { tag: 'forge:chunks/quartz' } },
+                    { chance: 0.5, output: { tag: 'forge:chunks/quartz' } },
+                    { chance: 0.3, output: { tag: 'forge:chunks/fluorite' } },
                     { chance: 0.1, output: { tag: 'forge:chunks/gold' } },
                     { chance: 0.1, output: { tag: 'forge:dusts/sulfur' } }
                 ],


### PR DESCRIPTION
Adds a low chance to get fluorite from Kimberlite nodes:
![image](https://user-images.githubusercontent.com/9543430/137048848-c395e122-5741-400d-a84a-799b44630c60.png)

and a much higher chance to get it from Mephitic Quarzite nodes:
![image](https://user-images.githubusercontent.com/9543430/137049072-ee53e284-75ed-49ef-ba55-209cdbd3d129.png)

Resolves #3420
