### PR TITLE
Fixes the sawmill quest using the wrong steel scaffolding variant

### DIFF
--- a/config/ftbquests/quests/chapters/immersive_engineering.snbt
+++ b/config/ftbquests/quests/chapters/immersive_engineering.snbt
@@ -652,7 +652,7 @@
 				{
 					id: "000000000000005B"
 					type: "item"
-					item: "immersiveengineering:steel_scaffolding_grate_top"
+					item: "immersiveengineering:steel_scaffolding_standard"
 					count: 8L
 				}
 				{


### PR DESCRIPTION
Switched the quest requirements to the standard/craftable steel scaffolding:

![Screen Shot 2021-10-16 at 10 22 27](https://user-images.githubusercontent.com/3179271/137580347-6b9ee27f-aca1-463f-9e45-1906244ecef5.png)

Checked the multiblock visually to ensure it does not require that specific grated variant:
![Screen Shot 2021-10-16 at 10 24 09](https://user-images.githubusercontent.com/3179271/137580383-b79f1a1a-0efa-475b-a6a0-881a46348092.png)


