### PR TITLE
remove all chance to return from lightning crafting

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/interactio/item_lightning.js
@@ -8,7 +8,7 @@ onEvent('recipes', (event) => {
             inputs: [
                 { item: 'minecraft:snowball', count: 16 },
                 { item: 'quark:bottled_cloud', count: 1 },
-                { tag: 'forge:dusts/fluorite', count: 1, return_chance: 0.75 }
+                { tag: 'forge:dusts/fluorite', count: 1 }
             ],
             output: {
                 entries: [{ result: { item: 'powah:charged_snowball', count: 1 }, weight: 7 }],


### PR DESCRIPTION
I'll just yoink them all out for now. if max ever has the time to fix this we can revert, but for now it's just too confusing.