### PR TITLE
Blacklist powah from mekanism cardboard

### DIFF
--- a/config/Mekanism/general.toml
+++ b/config/Mekanism/general.toml
@@ -7,7 +7,7 @@
 	#Peak processing rate for the Solar Neutron Activator. Note: It can go higher than this value in some extreme environments.
 	maxSolarNeutronActivatorRate = 64
 	#Any mod ids added to this list will not be able to have any of their blocks, picked up by the cardboard box. For example: ["mekanism"]
-	cardboardModBlacklist = ["refinedstorage", "tetra", "storagedrawers", "lootr", "extrastorage", "astralsorcery", "waystones"]
+	cardboardModBlacklist = ["refinedstorage", "tetra", "storagedrawers", "lootr", "extrastorage", "astralsorcery", "waystones", "powah"]
 	#Disable to make the anchor upgrade not do anything.
 	allowChunkloading = true
 	#How much heat energy is created from one Joule of regular energy in the Resistive Heater.


### PR DESCRIPTION
Started to look into it when someone on my server tried to move a player transmitter with cardboard and lost it:

- the reactor just straight up vanishes when you cardboard one block of it (furnator, a single block, seems to be unscaved)
![2021-10-17_19 27 26](https://user-images.githubusercontent.com/3179271/137638381-5ea5226c-03e8-4037-a25d-dc3b6c04bea3.png)

- since the transmitter also consists of 2 "actual" blocks it can get derpy as well (top and bottom can both be cardboarded)
![2021-10-17_19 27 58](https://user-images.githubusercontent.com/3179271/137638407-bf63b945-770b-4527-bf11-4a2597722e05.png)

- and energizing rods pop off without dropping if their cable is cardboarded (the cable itself does stay intact & reconnects)
![2021-10-17_19 29 43](https://user-images.githubusercontent.com/3179271/137638425-da2e9f25-69a8-4022-affc-79f5a56c4147.png)

i suppose this is enough to qualify for the entire mod being blacklisted for cardboard instead of just a few blocks 🤔 

