### PR TITLE
Tag `create:copper_backtank` as `forge:armor/chest`

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/armor/chests.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/armor/chests.js
@@ -13,7 +13,8 @@ onEvent('item.tags', (event) => {
         'naturesaura:sky_chest',
         'astralsorcery:mantle',
         'bloodmagic:livingplate',
-        'eidolon:warlock_cloak'
+        'eidolon:warlock_cloak',
+        'create:copper_backtank'
     ];
 
     var exceptions = [


### PR DESCRIPTION
unlike the [diving boots](https://github.com/NillerMedDild/Enigmatica6/blob/ca669fad5587aa58c29027932ec55e9d0ef2caf3/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/armor/boots.js#L26) and [diving helmet](https://github.com/NillerMedDild/Enigmatica6/blob/ca669fad5587aa58c29027932ec55e9d0ef2caf3/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/armor/helms.js#L28) the copper backtank did not get added since it name does not end with [_chestplate](https://github.com/NillerMedDild/Enigmatica6/blob/ca669fad5587aa58c29027932ec55e9d0ef2caf3/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/armor/chests.js#L32)

![Screen Shot 2021-10-18 at 16 44 58](https://user-images.githubusercontent.com/3179271/137754046-9acffb09-0efe-4b83-bf2b-a26574c39920.png)


