### PR TITLE
[Expert] Pink Wither Summon

### DIFF
--- a/config/ftbquests/quests/chapters/natures_aura.snbt
+++ b/config/ftbquests/quests/chapters/natures_aura.snbt
@@ -303,7 +303,7 @@
 			x: 1.5d
 			y: -14.0d
 			subtitle: "In Wrong, There Is Some Right"
-			description: ["Gold makes an excellent receptacle for the souls of the departed."]
+			description: ["An excellent receptacle for the souls of the departed."]
 			dependencies: ["00000000000002B5"]
 			id: "00000000000002B9"
 			tasks: [{
@@ -348,7 +348,7 @@
 			x: 3.0d
 			y: -13.5d
 			subtitle: "In Darkness, Some Light"
-			description: ["Iron makes an excellent receptacle for the essence of life. "]
+			description: ["An excellent receptacle for the essence of life. "]
 			dependencies: ["00000000000002B5"]
 			id: "00000000000002BD"
 			tasks: [{
@@ -578,6 +578,8 @@
 				"A portable source of Aura that can be be put to good use with a variety of tools. "
 				""
 				"Refer to the Book of Natural Aura's section on Natural Tools for potential uses."
+				""
+				"Note: These may not fill completely when worn. To get a full charge, or to even automate filling them, they may be placed in a Natural Altar to their maximum capacity."
 			]
 			dependencies: ["00000000000002BD"]
 			id: "00000000000002CD"
@@ -659,6 +661,8 @@
 				"Higher capacity than the Aura Cache."
 				""
 				"Refer to the Book of Natural Aura's section on Natural Tools for potential uses."
+				""
+				"Note: These may not fill completely when worn. To get a full charge, or to even automate filling them, they may be placed in a Natural Altar to their maximum capacity."
 			]
 			dependencies: ["00000000000002E9"]
 			id: "00000000000002EE"

--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -57,6 +57,7 @@
     "ritual.occultism.sacrifice.dropbears": "Dropbear",
     "ritual.occultism.sacrifice.gaia_guardian": "Guardian of Gaia",
     "ritual.occultism.sacrifice.pharaohs": "Pharaoh of Atum",
+    "ritual.occultism.sacrifice.wither": "The Wither",
 
     "item.kubejs.craft_magical_feathers": "Ritual: Craft Magical Feathers.",
     "item.kubejs.craft_magical_feathers.tooltip": "Binds the Spirit of the Ender Dragon to grant Creative Flight.",
@@ -78,6 +79,13 @@
     "ritual.enigmatica.occultism/ritual/pharaoh.finished": "Summoned Pharaoh successfully.",
     "ritual.enigmatica.occultism/ritual/pharaoh.interrupted": "Summoning of Pharaoh interrupted.",
     "ritual.enigmatica.occultism/ritual/pharaoh.conditions": "Not all requirements for this ritual are met.",
+
+    "item.kubejs.summon_pink_wither": "Ritual: Summon Pink Wither.",
+    "item.kubejs.summon_pink_wither.tooltip": "I'm comin' up so you better get this party started.",
+    "ritual.enigmatica.occultism/ritual/pink_wither.started": "I'm comin' up, I'm comin'.",
+    "ritual.enigmatica.occultism/ritual/pink_wither.finished": "Makin' my connection as I enter the room.",
+    "ritual.enigmatica.occultism/ritual/pink_wither.interrupted": "I'll be burnin' rubber, you'll be kissin' my ...",
+    "ritual.enigmatica.occultism/ritual/pink_wither.conditions": "Not all requirements for this ritual are met.",
 
     "item.kubejs.craft_spirit_heat_exchanger": "Ritual: Craft Maxwellian Heat Exchanger",
     "item.kubejs.craft_spirit_heat_exchanger.tooltip": "Fission, brought to you by the Spirits of the Otherworld.",

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/enigmatica/wither.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/enigmatica/wither.js
@@ -1,0 +1,3 @@
+onEvent('entity_type.tags', (event) => {
+    event.get('enigmatica:wither').add('minecraft:wither');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/general.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/general.js
@@ -68,28 +68,5 @@ const createStoneTypes = [
     'natural_scoria'
 ];
 
-/* 
-    The Aura Cache and Aura Trove, when charged on a player, fill to a random amount somewhere shy of their max. 
-    Otherwise it would need to be charged in an altar to get to full. This lets any nearly full cache be used for crafting.
-    */
-const aura_trove_astral_recipes = [],
-    aura_cache_astral_recipes = [];
-
-for (let i = 0; i <= 2000; i++) {
-    aura_trove_astral_recipes.push({
-        type: 'forge:nbt',
-        item: 'naturesaura:aura_trove',
-        count: 1,
-        nbt: `{aura:${1200000 - i}}`
-    });
-
-    aura_cache_astral_recipes.push({
-        type: 'forge:nbt',
-        item: 'naturesaura:aura_cache',
-        count: 1,
-        nbt: `{aura:${400000 - i}}`
-    });
-}
-
 const normalMode = global.packmode == 'normal';
 const expertMode = global.packmode == 'expert';

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_0_luminous.js
@@ -105,7 +105,12 @@ onEvent('recipes', (event) => {
                 A: { item: 'botania:livingrock' },
                 B: { item: 'minecraft:conduit' },
                 C: { tag: 'forge:ingots/infused_iron' },
-                D: aura_cache_astral_recipes
+                D: {
+                    type: 'forge:nbt',
+                    item: 'naturesaura:aura_cache',
+                    count: 1,
+                    nbt: '{aura:400000}'
+                }
             },
             altar_type: 0,
             duration: 100,

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_1_starlight.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/astralsorcery/altar/altar_1_starlight.js
@@ -173,7 +173,12 @@ onEvent('recipes', (event) => {
                 C: { item: 'supplementaries:faucet' },
                 D: { tag: 'botania:runes/mana' },
                 E: { item: 'naturesaura:spring' },
-                F: aura_trove_astral_recipes,
+                F: {
+                    type: 'forge:nbt',
+                    item: 'naturesaura:aura_trove',
+                    count: 1,
+                    nbt: '{aura:1200000}'
+                },
                 G: { item: 'minecraft:terracotta' }
             },
             effects: [

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/occultism/ritual.js
@@ -865,6 +865,44 @@ onEvent('recipes', (event) => {
             ],
             result: { item: 'integrateddynamics:logic_director' },
             id: `${id_prefix}logic_director`
+        },
+        {
+            ritual_type: 'occultism:summon',
+            activation_item: { item: 'botania:goddess_charm' },
+            pentacle_id: 'occultism:summon_wild_afrit',
+            duration: 6,
+            entity_to_sacrifice: {
+                tag: 'enigmatica:wither',
+                display_name: 'ritual.occultism.sacrifice.wither'
+            },
+            entity_to_summon: 'botania:pink_wither',
+            ritual_dummy: { item: 'kubejs:summon_pink_wither' },
+            ingredients: [
+                { item: 'minecraft:brain_coral_block' },
+                { tag: 'forge:storage_blocks/fairy' },
+                { item: 'tconstruct:silky_cloth' },
+                { tag: 'forge:storage_blocks/fairy' },
+
+                { item: 'minecraft:brain_coral_block' },
+                { item: 'atum:anubis_godshard' },
+                {
+                    type: 'forge:nbt',
+                    item: 'minecraft:potion',
+                    nbt: '{Potion:"upgrade_aquatic:vibing"}'
+                },
+                { item: 'quark:pink_rune' },
+
+                { item: 'minecraft:brain_coral_block' },
+                { item: 'quark:pink_rune' },
+                {
+                    type: 'forge:nbt',
+                    item: 'minecraft:potion',
+                    nbt: '{Potion:"upgrade_aquatic:vibing"}'
+                },
+                { item: 'atum:anubis_godshard' }
+            ],
+            result: { item: 'occultism:jei_dummy/none' },
+            id: `${id_prefix}pink_wither`
         }
     ];
 

--- a/kubejs/startup_scripts/item_registry.js
+++ b/kubejs/startup_scripts/item_registry.js
@@ -36,8 +36,9 @@ onEvent('item.registry', (event) => {
     ];
 
     const ritualDummies = [
-        'craft_spirit_heat_exchanger',
+        'summon_pink_wither',
         'summon_pharaoh',
+        'craft_spirit_heat_exchanger',
         'craft_magical_feathers',
         'craft_magicfeather',
         'craft_soulsword',


### PR DESCRIPTION
Implement Pink Wither Summon

![image](https://user-images.githubusercontent.com/9543430/137825403-11916913-0b69-4745-a0e5-b68b4c939734.png)


Also reverts the previous Aura Trove and Cache ingredients in Astral recipes. These will now require a fully charged Cache or Trove, which can be obtained by charging the item in a Natural Altar. Quest text updated to mention this.