### PR TITLE
Merge (the 5) congealed slime blocks in ultimine

### DIFF
--- a/defaultconfigs/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine-server.snbt
@@ -11,5 +11,5 @@
 	
 	# These tags will be considered the same block when checking for blocks to Ultimine
 	# Default: ["minecraft:base_stone_overworld"]
-	merge_tags: ["minecraft:base_stone_overworld", "ftbultimine:menril_logs"]
+	merge_tags: ["minecraft:base_stone_overworld", "ftbultimine:menril_logs", "tconstruct:congealed_slime"]
 }


### PR DESCRIPTION
This would allow for the looting of a slime island with basically one swing due to the blocks alternating constantly:

![2021-10-21_17 18 51](https://user-images.githubusercontent.com/3179271/138308055-1bb251eb-0fb1-456b-89ae-0582e4cfa865.png)

Leaving this one open for discussion, perhaps it makes it _too_ easy/convenient? should the hopping slimes pose danger?