### PR TITLE
Allow pneumaticcraft gasoline in motor boats and portable generators

### DIFF
--- a/defaultconfigs/immersivepetroleum-server.toml
+++ b/defaultconfigs/immersivepetroleum-server.toml
@@ -27,11 +27,11 @@
 
 [Generation]
 	#List of Portable Generator fuels. Format: fluid_name, mb_used_per_tick, flux_produced_per_tick
-	fuels = ["immersivepetroleum:gasoline, 5, 256", "pneumaticcraft:gasoline, 5, 256"]
+	fuels = ["immersivepetroleum:gasoline, 5, 256", "pneumaticcraft:gasoline, 5, 256", "thermal:refined_fuel, 5, 256"]
 
 [Miscellaneous]
 	#List of Motorboat fuels. Format: fluid_name, mb_used_per_tick
-	boat_fuels = ["immersivepetroleum:gasoline, 1", "pneumaticcraft:gasoline, 1"]
+	boat_fuels = ["immersivepetroleum:gasoline, 1", "pneumaticcraft:gasoline, 1", "thermal:refined_fuel, 1"]
 	#Automatically unlock IP recipes for new players, default=true
 	autounlock_recipes = true
 	#Set to false to disable the asphalt block boosting player speed, default=true


### PR DESCRIPTION
they seem to work in cross-mod recipes, so i figured it only made sense if they were usable in these 2 thingies as well:

![2021-10-25_10 45 24](https://user-images.githubusercontent.com/3179271/138664074-3b4143e3-06f6-4cf9-9661-cf6ba1c711ad.png)

![2021-10-25_10 45 57](https://user-images.githubusercontent.com/3179271/138664170-654df514-d914-4348-b9c9-cce7a542fda6.png)

brought to my attention by one of the players on my server: `the_red_soul`