### PR TITLE
Allow for thermal latex processing inside IF questline

### DIFF
--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -54,11 +54,6 @@
 						}
 					}
 				}
-				{
-					id: "0B47FFE60566FFBB"
-					type: "item"
-					item: "thermal:device_tree_extractor"
-				}
 			]
 			rewards: [
 				{


### PR DESCRIPTION
On our current playthrough we went the thermal expansion route of producing latex, but we still "had" to craft the industrial foregoing variants of the two to in order to unlock the quests gated by it.

There are other cross mod quest bypasses in this pack, but i won't be pr-ing any of those just yet, this one serves as a pilot to see what the response is to adding other mod's items to mod specific quest lines.

Unfortunately there does not seem to be a way in `ftbquests` or `item-filters` to "hide" (or at least stop the valid item carousel) the alternative items that should also trigger it to unlock:

![Screen Shot 2021-10-26 at 10 57 19](https://user-images.githubusercontent.com/3179271/138847953-41dd48ed-31fd-4386-ae46-23bed155ab4e.png)

(whilst this is a proof of concept, its not in draft mode since the code for it is finalized & stable should it get accepted)

