### PR TITLE
Update the default ultimine config to merge `forge:ores/*`

### DIFF
--- a/defaultconfigs/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine-server.snbt
@@ -1,15 +1,23 @@
+# Server-specific configuration for FTB Ultimine
+# This file is meant for server administrators to control user behaviour.
+# Changes in this file currently require a server restart to take effect
+
 {
 	# Hunger multiplied for each block mined with ultimine
 	# Default: 20.0
 	# Range: 0.0 ~ 10000.0
-	exhaustion_per_block: 25.0d
+	exhaustion_per_block: 20.0d
 	
 	# Max amount of blocks that can be ultimined at once
 	# Default: 64
 	# Range: 0 ~ 32768
-	max_blocks: 128
+	max_blocks: 64
 	
 	# These tags will be considered the same block when checking for blocks to Ultimine
-	# Default: ["minecraft:base_stone_overworld"]
-	merge_tags: ["minecraft:base_stone_overworld", "ftbultimine:menril_logs"]
+	# Default: ["minecraft:base_stone_overworld", "c:*_ores", "forge:ores/*"]
+	merge_tags: [
+		"minecraft:base_stone_overworld"
+		"c:*_ores"
+		"forge:ores/*"
+	]
 }

--- a/defaultconfigs/ftbultimine-server.snbt
+++ b/defaultconfigs/ftbultimine-server.snbt
@@ -6,18 +6,18 @@
 	# Hunger multiplied for each block mined with ultimine
 	# Default: 20.0
 	# Range: 0.0 ~ 10000.0
-	exhaustion_per_block: 20.0d
+	exhaustion_per_block: 25.0d
 	
 	# Max amount of blocks that can be ultimined at once
 	# Default: 64
 	# Range: 0 ~ 32768
-	max_blocks: 64
+	max_blocks: 128
 	
 	# These tags will be considered the same block when checking for blocks to Ultimine
 	# Default: ["minecraft:base_stone_overworld", "c:*_ores", "forge:ores/*"]
 	merge_tags: [
 		"minecraft:base_stone_overworld"
-		"c:*_ores"
+		"ftbultimine:menril_logs"
 		"forge:ores/*"
 	]
 }


### PR DESCRIPTION
> fixes #3514

after updating [ultimine](https://www.curseforge.com/minecraft/mc-mods/ftb-ultimine-forge) to at least `1605.3.1-build.40` this should be merged (without merging it would crash on `*`'s!)

this pull request updates the generated config & includes the new `forge:ores/*`, but strips out the fabric namespace.

![2021-11-05_15 07 59](https://user-images.githubusercontent.com/3179271/140523466-8f2ac954-bce7-4f47-a17b-2ef8d306c15c.png)

