### PR TITLE
[Expert] Fix for PNC Progression

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/sequenced_assembly.js
@@ -220,6 +220,25 @@ onEvent('recipes', (event) => {
                 }
             ],
             id: `${id_prefix}logic_cable`
+        },
+        {
+            input: 'immersiveengineering:insulating_glass',
+            outputs: ['immersiveengineering:circuit_board'],
+            transitionalItem: 'immersiveengineering:insulating_glass',
+            loops: 1,
+            sequence: [
+                {
+                    type: 'deploying',
+                    input: ['immersiveengineering:insulating_glass', '#forge:plates/copper'],
+                    output: 'immersiveengineering:insulating_glass'
+                },
+                {
+                    type: 'deploying',
+                    input: ['immersiveengineering:insulating_glass', 'powah:dielectric_paste'],
+                    output: 'immersiveengineering:insulating_glass'
+                }
+            ],
+            id: `${id_prefix}backplane_alternate`
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/immersiveengineering/shaped.js
@@ -70,6 +70,18 @@ onEvent('recipes', (event) => {
                 D: 'thermal:redstone_servo'
             },
             id: 'immersiveengineering:crafting/conveyor_basic'
+        },
+        {
+            output: 'immersiveengineering:circuit_table',
+            pattern: [' AB', 'CCC', 'D E'],
+            key: {
+                A: 'thermal:diving_fabric',
+                B: 'immersiveengineering:screwdriver',
+                C: '#forge:treated_wood_slab',
+                D: 'immersiveengineering:craftingtable',
+                E: 'thermal:energy_cell'
+            },
+            id: 'immersiveengineering:crafting/circuit_table'
         }
     ];
 


### PR DESCRIPTION
Currently the first compressor requires a circuit made manually in the Circuit Bench. However, the backplane for that circuit, as well as the bench itself, requires components made from the component blueprint... which requires PNC upgrade matrix. Crafting loop. 

Move Circuit bench moved earlier. No longer needs any blueprint items
![image](https://user-images.githubusercontent.com/9543430/140560984-eb87b483-daf5-443b-94aa-a513b84bb102.png)

Backplane alternate recipe. Makes it available prior to the blueprint, but slightly more expensive. 
![image](https://user-images.githubusercontent.com/9543430/140561263-f6ea38f5-c01a-4445-9258-faa6f8f7ca74.png)
