### PR TITLE
@Chipped Glowstone + Planks are missing stonecutter recipes.

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
@@ -59,4 +59,5 @@ onEvent('item.tags', (event) => {
     event.add(storageBlocks + '/glowstone', ['#chisel:glowstone']);
     event.add(storageBlocks + '/redstone', ['#chisel:redstone']);
     event.add(storageBlocks + '/coal', ['#chisel:coal']);
+	event.add(storageBlocks + '/glowstone', ['#chipped:glowstone']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/forge/storage_blocks.js
@@ -59,5 +59,5 @@ onEvent('item.tags', (event) => {
     event.add(storageBlocks + '/glowstone', ['#chisel:glowstone']);
     event.add(storageBlocks + '/redstone', ['#chisel:redstone']);
     event.add(storageBlocks + '/coal', ['#chisel:coal']);
-	event.add(storageBlocks + '/glowstone', ['#chipped:glowstone']);
+    event.add(storageBlocks + '/glowstone', ['#chipped:glowstone']);
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -2457,8 +2457,9 @@ chiselPlankVariants = [
     'braid',
     'log_cabin'
 ];
+
+const numberChippedVariants = 18;
 plankTypes.forEach((plankType) => {
-	const numberChippedVariants = 18;
     let stones = [`minecraft:${plankType}_planks`];
 	if(! chippedOnlyPlankTypes.includes(plankType) ) {
 		chiselPlankVariants.forEach((chiselPlankVariant) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -2438,6 +2438,8 @@ colors.forEach((color) => {
 
 // @Chisel Planks
 chiselPlankTypes = ['oak', 'spruce', 'birch', 'acacia', 'jungle', 'dark_oak'];
+chippedOnlyPlankTypes = ['warped','crimson'];
+plankTypes = chiselPlankTypes.concat(chippedOnlyPlankTypes);
 chiselPlankVariants = [
     'large_planks',
     'crude_horizontal_planks',
@@ -2455,13 +2457,19 @@ chiselPlankVariants = [
     'braid',
     'log_cabin'
 ];
-chiselPlankTypes.forEach((chiselPlankType) => {
-    let stones = [`minecraft:${chiselPlankType}_planks`];
-    chiselPlankVariants.forEach((chiselPlankVariant) => {
-        stones.push(`chisel:planks/${chiselPlankType}/${chiselPlankVariant}`);
-    });
+plankTypes.forEach((plankType) => {
+	const numberChippedVariants = 18;
+    let stones = [`minecraft:${plankType}_planks`];
+	if(! chippedOnlyPlankTypes.includes(plankType) ) {
+		chiselPlankVariants.forEach((chiselPlankVariant) => {
+			stones.push(`chisel:planks/${plankType}/${chiselPlankVariant}`);
+		});
+	}
+	for (i = 1; i <= numberChippedVariants; i++) {
+        stones.push(`chipped:${plankType}_planks_${i}`);
+    }
     stonecuttables.push({
-        name: `${chiselPlankType}`,
+        name: `${plankType}`,
         stones: stones,
         onlyAsOutput: [],
         onlyAsInput: []


### PR DESCRIPTION
Fixes #3673 

This might not be the right approach, or it might be broken! Though I've double-checked, it wouldn't be the first time something slips by.

It adds a stonecutter recipe for Chipped's glowstone by adding the forge:storage_blocks/glowstone tag to it.
It adds the planks to stonecuttables.js.