### PR TITLE
[Expert] Fix for PNC Refinery Progression issue

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mekanism/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/mekanism/shaped.js
@@ -135,7 +135,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'pneumaticcraft:heat_sink',
                 B: 'pneumaticcraft:heat_pipe',
-                C: 'mekanism:steel_casing',
+                C: 'immersiveengineering:alloybrick',
                 D: 'immersiveengineering:coil_mv'
             },
             id: 'mekanism:superheating_element'


### PR DESCRIPTION
Superheating elements required steel casings, which needed Infused Alloy... which need circuits and therefore plastic from the Refinery. 

This could be gotten around by doing biodiesel, but that's a bit rough I think and wasn't intended. 

Changed Superheating Element to use Kiln Bricks instead.

![image](https://user-images.githubusercontent.com/9543430/140633347-de561e05-8211-4944-b5a2-703342524c2b.png)
