### PR TITLE
Remove Powah 'starter' tier from tags to prevent them being shown in quests

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/powah/powah.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/items/powah/powah.js
@@ -1,7 +1,9 @@
 onEvent('item.tags', (event) => {
     powahTiers.forEach(function (tier) {
         powahBlocks.forEach(function (block) {
-            event.get('powah:' + block).add('powah:' + block + '_' + tier);
+            if (tier != 'starter') {
+                event.get('powah:' + block).add('powah:' + block + '_' + tier);
+            }
         });
     });
 });


### PR DESCRIPTION
Resolves: #3682