### PR TITLE
[Expert] PNC Lithium Fix

### DIFF
--- a/kubejs/assets/enigmatica/lang/en_us.json
+++ b/kubejs/assets/enigmatica/lang/en_us.json
@@ -8,6 +8,11 @@
 
     "block.tetra.hammer_head": "Hammer head",
 
+    "block.mekanism.steam": "Dense Steam",
+    "fluid.mekanism.flowing_steam": "Flowing Dense Steam",
+    "fluid.mekanism.steam": "Dense Steam",
+    "item.mekanism.steam_bucket": "Dense Steam Bucket",
+
     "curios.identifier.goggles": "Goggles",
 
     "entity.minecraft.villager.beekeeper": "Beekeeper",

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/refinery.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/pneumaticcraft/refinery.js
@@ -8,17 +8,17 @@ onEvent('recipes', (event) => {
             input: { type: 'pneumaticcraft:fluid', fluid: 'minecraft:water', amount: 100 },
             temperature: { min_temp: 373 },
             results: [
-                { fluid: 'mekanism:brine', amount: 8 },
-                { fluid: 'mekanism:brine', amount: 2 }
+                { fluid: 'mekanism:brine', amount: 10 },
+                { fluid: 'mekanism:steam', amount: 90 }
             ],
             id: `${id_prefix}brine`
         },
         {
-            input: { type: 'pneumaticcraft:fluid', fluid: 'mekanism:brine', amount: 100 },
+            input: { type: 'pneumaticcraft:fluid', fluid: 'mekanism:brine', amount: 10 },
             temperature: { min_temp: 373 },
             results: [
-                { fluid: 'mekanism:lithium', amount: 8 },
-                { fluid: 'mekanism:lithium', amount: 2 }
+                { fluid: 'mekanism:lithium', amount: 1 },
+                { fluid: 'mekanism:steam', amount: 9 }
             ],
             id: `${id_prefix}lithium`
         }


### PR DESCRIPTION
Seems there's a bug with PNC's refinery that makes it fail to recognize a recipe if it initially receives less than is required to start. Example, lithium needs 100mb of brine to start, but the water > brine recipe outputs 10.

This leads to there being 10 brine in the second refinery and as it fills to 100+, it never rechecks the recipe.

Fix is to simply match the speeds so the first outputs 10 and the second needs 10 to start.

The recipe handler also requires 2 or more fluid outputs. I was cheesing this before by outputting 9/1 in two outputs. But with the lowered input for brine to lithium, I cannot do this. So now both machines output waste steam.

Renamed Liquid Steam to Dense Steam.