### PR TITLE
Fix Tallow/Leather Conflict in Redstone Furnace

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/blasting.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/minecraft/blasting.js
@@ -2,8 +2,8 @@ onEvent('recipes', (event) => {
     const id_prefix = 'enigmatica:base/minecraft/blasting/';
     const recipes = [
         {
-            input: 'minecraft:rotten_flesh',
-            output: 'occultism:tallow',
+            input: 'architects_palette:rotten_flesh_block',
+            output: Item.of('9x occultism:tallow'),
             xp: 0.5,
             id: `${id_prefix}tallow_from_flesh`
         },


### PR DESCRIPTION
Resolves #3721

Switch to using Rotten Flesh block instead of rotten flesh.

![image](https://user-images.githubusercontent.com/9543430/141695979-4b30b6ea-62bc-4f13-9299-071ce26e9021.png)
