### PR TITLE
Improve Gunpowder recipes and Add Wandering Traders to Occultism's villager sacrifice tag

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipes/remove.js
@@ -209,6 +209,8 @@ onEvent('recipes', (event) => {
         'powah:crafting/energy_cell_basic_2',
         'powah:crafting/cable_basic',
 
+        'quark:building/crafting/compressed/gunpowder_sack',
+
         'simplefarming:candy',
         'simplefarming:raw_chicken_wings',
 

--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/altar.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/naturesaura/altar.js
@@ -68,6 +68,22 @@ onEvent('recipes', (event) => {
                 catalyst: { item: 'naturesaura:conversion_catalyst' },
                 aura: 30000,
                 time: 250
+            },
+            {
+                input: 'minecraft:flint',
+                output: 'minecraft:gunpowder',
+                aura_type: 'naturesaura:nether',
+                catalyst: { item: 'naturesaura:conversion_catalyst' },
+                aura: 10000,
+                time: 60
+            },
+            {
+                input: 'supplementaries:flint_block',
+                output: 'thermal:gunpowder_block',
+                aura_type: 'naturesaura:nether',
+                catalyst: { item: 'naturesaura:conversion_catalyst' },
+                aura: 80000,
+                time: 480
             }
         ]
     };

--- a/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/occultism/humans.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/tags/entity/occultism/humans.js
@@ -1,0 +1,3 @@
+onEvent('entity_type.tags', (event) => {
+    event.get('occultism:humans').add('minecraft:wandering_trader');
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/constants/stonecuttables.js
@@ -2363,6 +2363,12 @@ const stonecuttables = [
         ],
         onlyAsOutput: [],
         onlyAsInput: []
+    },
+    {
+        name: 'gunpowder',
+        stones: ['quark:gunpowder_sack', 'thermal:gunpowder_block'],
+        onlyAsOutput: [],
+        onlyAsInput: []
     }
 ];
 


### PR DESCRIPTION
Add Wandering Traders to the Humans tag so they too may be sacrificed to the Occult.
Add Flint to Gunpowder recipe to Nature's Aura
Fix Recipe Conflict with gunpowder blocks. Thermal and Quark gunpowder blocks now stonecuttable.