### PR TITLE
[Expert] Aura Generation Tweak

### DIFF
--- a/kubejs/client_scripts/item_modifiers/tooltips.js
+++ b/kubejs/client_scripts/item_modifiers/tooltips.js
@@ -176,6 +176,10 @@ onEvent('item.tooltip', (event) => {
                 Text.of(`- Refinery`).aqua(),
                 Text.of(`- Sulfur Recovery Unit`).aqua()
             ]
+        },
+        {
+            items: [/natures\w+:\w+_generator/],
+            text: [Text.of(`Aura Generator`).green()]
         }
     ];
 

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/naturesaura/tree_ritual.js
@@ -103,7 +103,7 @@ onEvent('recipes', (event) => {
             inputs: [
                 { item: 'naturesaura:infused_iron' }, //top
                 { item: 'architects_palette:sunstone' }, //bottom
-                { item: 'ars_nouveau:glyph_grow' }, //left
+                { item: 'ars_nouveau:sylph_shards' }, //left
                 { item: 'naturesaura:token_joy' }, //right
                 { item: 'thermal:phytogro' }, //topleft
                 { item: 'botania:livingwood' }, //bottomright


### PR DESCRIPTION
Fairly minor. Makes canopy diminisher available a touch earlier by removing the dependence on the Alchemy Table

![image](https://user-images.githubusercontent.com/9543430/142795476-1396753f-1cb2-4ebc-8490-740f8ca9930e.png)

Also labels all Aura Generators for all modes:

![image](https://user-images.githubusercontent.com/9543430/142795520-ffaaaea2-41a1-4f2a-9a3a-3f1b7ff85f0a.png)

