### PR TITLE
[Expert] Remove drawer controller from dank

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/dankstorage/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/dankstorage/shaped.js
@@ -22,7 +22,7 @@ onEvent('recipes', (event) => {
             key: {
                 A: 'resourcefulbees:coal_honeycomb_block',
                 B: 'framedcompactdrawers:framed_full_two',
-                C: 'framedcompactdrawers:framed_drawer_controller'
+                C: 'industrialforegoing:common_black_hole_unit'
             },
             id: 'dankstorage:1'
         }


### PR DESCRIPTION
Recipe for drawer controller came after these recipes. puts the dank too far back. 

![image](https://user-images.githubusercontent.com/9543430/142874597-701114ff-4785-4f7e-a293-0aefd840030c.png)
