### PR TITLE
Fix misspelling in Astral Sorcery quest name

### DIFF
--- a/config/ftbquests/quests/chapters/astral_sorcery_wip.snbt
+++ b/config/ftbquests/quests/chapters/astral_sorcery_wip.snbt
@@ -586,7 +586,7 @@
 			}]
 		}
 		{
-			title: "Nocturnal \\\\& Illumination Powder"
+			title: "Nocturnal \\& Illumination Powder"
 			x: 8.5d
 			y: -9.5d
 			subtitle: "Letting the Dust Settle"


### PR DESCRIPTION
Fix misspelling in Astral Sorcery quest name