### PR TITLE
Update base/RBees/shaped.js

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/recipetypes/resourcefulbees/shaped.js
@@ -587,9 +587,9 @@ onEvent('recipes', (event) => {
 
     newRecipes.forEach((recipe) => {
         if (recipe.id) {
-            event.shaped(recipe.output, recipe.pattern, recipe.key).id(recipe.id);
+            event.shaped(recipe.output, recipe.pattern, recipe.key).noMirror().id(recipe.id);
         } else {
-            event.shaped(recipe.output, recipe.pattern, recipe.key);
+            event.shaped(recipe.output, recipe.pattern, recipe.key).noMirror();
         }
     });
 });


### PR DESCRIPTION
Adds `.noMirror()` to the shaped recipes here, which should hopefully remove current and future recipe collisions due to recipe mirroring.