### PR TITLE
Apotheosis Tome Towers and Astral Shrines loot tweaks

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
@@ -2,7 +2,7 @@ onEvent('server.datapack.high_priority', (event) => {
     let loot_table = {
         pools: [
             {
-                name: 'placebo_code_pool_15',
+                item: 'placebo_code_pool_15',
                 rolls: {
                     min: 6.0,
                     max: 9.0,
@@ -135,193 +135,173 @@ onEvent('server.datapack.high_priority', (event) => {
                         quality: 35
                     }
                 ]
-            },
-            {
-                rolls: {
-                    min: 6.0,
-                    max: 9.0
-                },
-                entries: [
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'eidolon:arcane_gold_ingot',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'thermal:lightning_charge',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'alexsmobs:kangaroo_hide',
-                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'alexsmobs:komodo_spit',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'alexsmobs:rattlesnake_rattle',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'eidolon:death_essence',
-                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'eidolon:ender_calx',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'astralsorcery:nocturnal_powder',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'astralsorcery:illumination_powder',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'botania:blacker_lotus',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'occultism:soul_gem',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'ars_nouveau:mana_gem',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:wilden_wing',
-                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:wilden_spike',
-                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:wilden_horn',
-                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:drygmy_shard',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:wixie_shards',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:carbuncle_shards',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'ars_nouveau:warp_scroll',
-                        functions: [{ function: 'set_count', count: { min: 1, max: 5 } }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'bloodmagic:intermediatecuttingfluid',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 100,
-                        name: 'alexsmobs:guster_eye',
-                        functions: [{ function: 'set_count', count: 1 }]
-                    },
-                    {
-                        type: 'item',
-                        weight: 50,
-                        name: 'ars_nouveau:potion_flask',
-                        functions: [
-                            { function: 'set_count', count: { min: 1, max: 2 } },
-                            {
-                                function: 'set_nbt',
-                                tag: `{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:\"minecraft:milk_bucket\",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:9600,Id:90b,Amplifier:0b}],Potion:\"ars_nouveau:spell_damage_long\"}`
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                rolls: { min: 0, max: 1 },
-                entries: [
-                    {
-                        type: 'item',
-                        weight: 1,
-                        name: 'ars_nouveau:caster_tome',
-                        functions: [
-                            {
-                                function: 'set_nbt',
-                                tag: `{flavor:\"Gusts of wind, sharp as blades.\",color:\"1,1,1\",spell_0:\"[projectile, split, split, pierce, pierce, gust, amplify, amplify, cut, amplify]\",display:{Name:'{\"italic\":true,\"color\":\"dark_purple\",\"text\":\"Wind Blades\"}'},current_slot:0,max_slot:1}`
-                            }
-                        ]
-                    },
-                    {
-                        type: 'item',
-                        weight: 1,
-                        name: 'ars_nouveau:caster_tome',
-                        functions: [
-                            {
-                                function: 'set_nbt',
-                                tag: `{flavor:\"Creates a fire that quickly freezes to ice.\",color:\"255,25,180\",spell_0:\"[projectile, ignite, delay, conjure_water, freeze]\",display:{Name:'{\"italic\":true,\"color\":\"dark_purple\",\"text\":\"Farfalla\\'s Frosty Flames\"}'},current_slot:0,max_slot:1}`
-                            }
-                        ]
-                    },
-                    {
-                        type: 'item',
-                        weight: 1,
-                        name: 'ars_nouveau:caster_tome',
-                        functions: [
-                            {
-                                function: 'set_nbt',
-                                tag: `{flavor:\"Believe it!\",color:\"1,1,1\",spell_0:\"[underfoot, linger, accelerate, accelerate, accelerate, aoe, aoe, aoe, summon_decoy]\",display:{Name:'{\"italic\":true,\"color\":\"dark_purple\",\"text\":\"Multi Shadow Clone\"}'},current_slot:0,max_slot:1}`
-                            }
-                        ]
-                    }
-                ]
             }
         ]
     };
 
     event.addJson(`apotheosis:loot_tables/tome_tower.json`, loot_table);
+});
+
+onEvent('generic.loot_tables', (event) => {
+    const pools = [
+        {
+            // Caster Tomes: 50:50 chance of one.
+            rolls: { min: 0, max: 1 },
+            entries: [
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Gusts of wind, sharp as blades.",color:"1,1,1",spell_0:"[projectile, split, split, pierce, pierce, gust, amplify, amplify, cut, amplify]",display:{item:\'{"italic":true,"color":"dark_purple","text":"Wind Blades"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Believe it!",color:"1,1,1",spell_0:"[underfoot, linger, accelerate, accelerate, accelerate, aoe, aoe, aoe, summon_decoy]",display:{item:\'{"italic":true,"color":"dark_purple","text":"Multi Shadow Clone"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Creates a fire that quickly freezes to ice.",color:"255,25,180",spell_0:"[projectile, ignite, delay, conjure_water, freeze]",display:{item:\'{"italic":true,"color":"dark_purple","text":"Farfalla\\\'s Frosty Flames"}\'},current_slot:0,max_slot:1}'
+                    )
+                }
+            ]
+        },
+        {
+            // Magic Reagents and oddities.
+            rolls: { min: 6, max: 9 },
+            entries: [
+                {
+                    item: Item.of(
+                        'ars_nouveau:potion_flask',
+                        '{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:"minecraft:milk_bucket",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:9600,Id:90b,Amplifier:0b}],Potion:"ars_nouveau:spell_damage_long"}'
+                    ),
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'ars_nouveau:wilden_spike',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'ars_nouveau:wilden_horn',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'ars_nouveau:wilden_wing',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'eidolon:death_essence',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'alexsmobs:guster_eye',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'alexsmobs:kangaroo_hide',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'botania:blacker_lotus',
+                    weight: 50
+                },
+                {
+                    item: 'occultism:soul_gem',
+                    weight: 50
+                },
+                {
+                    item: 'ars_nouveau:drygmy_shard',
+                    weight: 50
+                },
+                {
+                    item: 'ars_nouveau:wixie_shards',
+                    weight: 50
+                },
+                {
+                    item: 'ars_nouveau:carbuncle_shards',
+                    weight: 50
+                },
+                {
+                    item: 'bloodmagic:intermediatecuttingfluid',
+                    weight: 50
+                },
+                {
+                    item: 'ars_nouveau:warp_scroll',
+                    weight: 100,
+                    count: [1, 5]
+                },
+                {
+                    item: 'eidolon:arcane_gold_ingot',
+                    weight: 100,
+                    count: [2, 7]
+                },
+                {
+                    item: 'thermal:lightning_charge',
+                    weight: 100,
+                    count: [2, 7]
+                },
+                {
+                    item: 'alexsmobs:komodo_spit',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'alexsmobs:rattlesnake_rattle',
+                    weight: 50,
+                    count: [1, 2]
+                },
+                {
+                    item: 'eidolon:ender_calx',
+                    weight: 50,
+                    count: [2, 7]
+                },
+                {
+                    item: 'astralsorcery:nocturnal_powder',
+                    weight: 50,
+                    count: [2, 7]
+                },
+                {
+                    item: 'astralsorcery:illumination_powder',
+                    weight: 50,
+                    count: [2, 7]
+                },
+                {
+                    item: 'ars_nouveau:mana_gem',
+                    weight: 100,
+                    count: [5, 9]
+                }
+            ]
+        }
+    ];
+
+    event.modify('apotheosis:tome_tower', (table) => {
+        pools.forEach((pool) => {
+            table.addPool((newPool) => {
+                newPool.setUniformRolls(pool.rolls.min, pool.rolls.max);
+                pool.entries.forEach((entry) => {
+                    let count = 1,
+                        weight = 1;
+
+                    if (entry.count) {
+                        count = entry.count;
+                    }
+
+                    if (entry.weight) {
+                        weight = entry.weight;
+                    }
+
+                    newPool.addItem(entry.item, weight, count);
+                });
+            });
+        });
+    });
 });

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
@@ -1,0 +1,157 @@
+onEvent('server.datapack.high_priority', (event) => {
+    let loot_table = {
+        pools: [
+            {
+                name: 'placebo_code_pool_15',
+                rolls: {
+                    min: 6.0,
+                    max: 9.0,
+                    type: 'minecraft:uniform'
+                },
+                entries: [
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:null_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:armor_head_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:armor_chest_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:armor_legs_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:armor_feet_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:weapon_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:digger_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:fishing_rod_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:bow_book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 5,
+                        quality: 5,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'minecraft:book', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 16,
+                        quality: 10,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:common_tome', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 13,
+                        quality: 10,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:uncommon_tome', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 10,
+                        quality: 10,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:rare_tome', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 7,
+                        quality: 10,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:epic_tome', count: 1 }
+                    },
+                    {
+                        type: 'placebo:stack_entry',
+                        weight: 4,
+                        quality: 10,
+                        min: 1,
+                        max: 1,
+                        stack: { item: 'apotheosis:mythic_tome', count: 1 }
+                    },
+                    {
+                        type: 'apotheosis:affix_entry',
+                        weight: 20,
+                        quality: 35
+                    }
+                ]
+            },
+            {
+                rolls: {
+                    min: 6.0,
+                    max: 9.0
+                },
+                entries: [
+                    {
+                        type: 'item',
+                        weight: 1,
+                        name: 'thermal:lightning_charge',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 15 } }]
+                    }
+                ]
+            }
+        ]
+    };
+
+    event.addJson(`apotheosis:loot_tables/tome_tower.json`, loot_table);
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
@@ -264,6 +264,12 @@ onEvent('server.datapack.high_priority', (event) => {
                     },
                     {
                         type: 'item',
+                        weight: 100,
+                        name: 'alexsmobs:guster_eye',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
                         weight: 50,
                         name: 'ars_nouveau:potion_flask',
                         functions: [

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
@@ -165,6 +165,60 @@ onEvent('generic.loot_tables', (event) => {
                         'ars_nouveau:caster_tome',
                         '{flavor:"Creates a fire that quickly freezes to ice.",color:"255,25,180",spell_0:"[projectile, ignite, delay, conjure_water, freeze]",display:{item:\'{"italic":true,"color":"dark_purple","text":"Farfalla\\\'s Frosty Flames"}\'},current_slot:0,max_slot:1}'
                     )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Creates a temporary tunnel of blocks.",color:"255,25,180",spell_0:"[touch, intangible, aoe, aoe, pierce, pierce, pierce, pierce, pierce, extend_time]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"The Shadow\\\'s Temporary Tunnel"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Builds a small hut around the user.",color:"255,25,180",spell_0:"[underfoot, phantom_block, aoe, aoe, aoe, pierce, pierce, pierce]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Xacris\\\' Tiny Hut"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"The squid\'s Lovecraftian roots appear to make it immune.",color:"255,25,180",spell_0:"[projectile, launch, amplify, amplify, delay, pull, amplify, amplify]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Gootastic\\\'s Telekinetic Fishing Rod"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Cures status effects and grants regeneration.",color:"255,25,180",spell_0:"[touch, rune, dispel, heal, extend_time]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Rune of Renewing"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Sometimes you just need to get over that wall.",color:"255,25,180",spell_0:"[self, launch, delay, leap, slowfall]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Vault"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Creates three snaring projectiles.",color:"255,25,180",spell_0:"[projectile, split, split, snare, extend_time, extend_time]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Arachne\\\'s Weaving"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"A classic.",color:"255,25,180",spell_0:"[projectile, ignite, explosion, amplify, amplify, aoe, aoe]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Fireball!"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"Teleportation, with style!",color:"255,25,180",spell_0:"[projectile, blink, explosion, aoe]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Warp Impact"}\'},current_slot:0,max_slot:1}'
+                    )
+                },
+                {
+                    item: Item.of(
+                        'ars_nouveau:caster_tome',
+                        '{flavor:"",color:"255,25,180",spell_0:"[projectile, launch, amplify, amplify, delay, explosion, amplify]",display:{Name:\'{"italic":true,"color":"dark_purple","text":"Bailey\\\'s Bovine Rocket"}\'},current_slot:0,max_slot:1}'
+                    )
                 }
             ]
         },

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
@@ -144,9 +144,173 @@ onEvent('server.datapack.high_priority', (event) => {
                 entries: [
                     {
                         type: 'item',
-                        weight: 1,
+                        weight: 100,
+                        name: 'eidolon:arcane_gold_ingot',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
                         name: 'thermal:lightning_charge',
-                        functions: [{ function: 'set_count', count: { min: 5, max: 15 } }]
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
+                        name: 'alexsmobs:kangaroo_hide',
+                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
+                        name: 'alexsmobs:komodo_spit',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
+                        name: 'alexsmobs:rattlesnake_rattle',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'eidolon:death_essence',
+                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'eidolon:ender_calx',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'astralsorcery:nocturnal_powder',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'astralsorcery:illumination_powder',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'botania:blacker_lotus',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'occultism:soul_gem',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
+                        name: 'ars_nouveau:mana_gem',
+                        functions: [{ function: 'set_count', count: { min: 5, max: 7 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:wilden_wing',
+                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:wilden_spike',
+                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:wilden_horn',
+                        functions: [{ function: 'set_count', count: { min: 1, max: 2 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:drygmy_shard',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:wixie_shards',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:carbuncle_shards',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
+                        name: 'ars_nouveau:warp_scroll',
+                        functions: [{ function: 'set_count', count: { min: 1, max: 5 } }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 100,
+                        name: 'bloodmagic:intermediatecuttingfluid',
+                        functions: [{ function: 'set_count', count: 1 }]
+                    },
+                    {
+                        type: 'item',
+                        weight: 50,
+                        name: 'ars_nouveau:potion_flask',
+                        functions: [
+                            { function: 'set_count', count: { min: 1, max: 2 } },
+                            {
+                                function: 'set_nbt',
+                                tag: `{count:8,CustomPotionEffects:[{Ambient:0b,CurativeItems:[{id:\"minecraft:milk_bucket\",Count:1b}],ShowIcon:1b,ShowParticles:1b,Duration:9600,Id:90b,Amplifier:0b}],Potion:\"ars_nouveau:spell_damage_long\"}`
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                rolls: { min: 0, max: 1 },
+                entries: [
+                    {
+                        type: 'item',
+                        weight: 1,
+                        name: 'ars_nouveau:caster_tome',
+                        functions: [
+                            {
+                                function: 'set_nbt',
+                                tag: `{flavor:\"Gusts of wind, sharp as blades.\",color:\"1,1,1\",spell_0:\"[projectile, split, split, pierce, pierce, gust, amplify, amplify, cut, amplify]\",display:{Name:'{\"italic\":true,\"color\":\"dark_purple\",\"text\":\"Wind Blades\"}'},current_slot:0,max_slot:1}`
+                            }
+                        ]
+                    },
+                    {
+                        type: 'item',
+                        weight: 1,
+                        name: 'ars_nouveau:caster_tome',
+                        functions: [
+                            {
+                                function: 'set_nbt',
+                                tag: `{flavor:\"Creates a fire that quickly freezes to ice.\",color:\"255,25,180\",spell_0:\"[projectile, ignite, delay, conjure_water, freeze]\",display:{Name:'{\"italic\":true,\"color\":\"dark_purple\",\"text\":\"Farfalla\\'s Frosty Flames\"}'},current_slot:0,max_slot:1}`
+                            }
+                        ]
+                    },
+                    {
+                        type: 'item',
+                        weight: 1,
+                        name: 'ars_nouveau:caster_tome',
+                        functions: [
+                            {
+                                function: 'set_nbt',
+                                tag: `{flavor:\"Believe it!\",color:\"1,1,1\",spell_0:\"[underfoot, linger, accelerate, accelerate, accelerate, aoe, aoe, aoe, summon_decoy]\",display:{Name:'{\"italic\":true,\"color\":\"dark_purple\",\"text\":\"Multi Shadow Clone\"}'},current_slot:0,max_slot:1}`
+                            }
+                        ]
                     }
                 ]
             }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/astralsorcery/shrine_chest.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/astralsorcery/shrine_chest.js
@@ -1,0 +1,97 @@
+onEvent('generic.loot_tables', (event) => {
+    const pools = [
+        {
+            // Animals
+            rolls: { min: 0, max: 1 },
+            entries: [
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:cow"}'),
+                    count: 2,
+                    weight: 100
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:sheep"}'),
+                    count: 2,
+                    weight: 100
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:chicken"}'),
+                    count: 2,
+                    weight: 100
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:pig"}'),
+                    count: 2,
+                    weight: 100
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:llama"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:polar_bear"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:rabbit"}'),
+                    count: 2,
+                    weight: 100
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:turtle"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:wolf"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:fox"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:parrot"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:panda"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"minecraft:ocelot"}'),
+                    count: 2,
+                    weight: 20
+                }
+            ]
+        }
+    ];
+
+    event.modify('astralsorcery:shrine_chest', (table) => {
+        pools.forEach((pool) => {
+            table.addPool((newPool) => {
+                newPool.setUniformRolls(pool.rolls.min, pool.rolls.max);
+                pool.entries.forEach((entry) => {
+                    let count = 1,
+                        weight = 1;
+
+                    if (entry.count) {
+                        count = entry.count;
+                    }
+
+                    if (entry.weight) {
+                        weight = entry.weight;
+                    }
+
+                    newPool.addItem(entry.item, weight, count);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Introduces a bunch of 'magical' type reagents as extra loot in Apotheosis tome towers. The original loot table rolls first, then the new ones as extra, so this shouldn't take anything away or make them rarer.

Still want to add some more caster tomes to this, only have 3 so far. Just need ideas for spells. 

Similarly, I've added a 'breeding pair' of animals to the Astral Shrines. Each chest has a 50% chance to have 1 pair of Shrink bottles with animals in them. 