### PR TITLE
[Expert] Create Swim Gear update and extra loots

### DIFF
--- a/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
+++ b/config/ftbquests/quests/chapters/expert__tier_2_wip.snbt
@@ -435,7 +435,7 @@
 		{
 			x: -0.5d
 			y: -2.5d
-			description: ["The link though tenuous, grows stronger. Channeling the spirits and their energies pave the way to Alchemy and from there, the deeper magics. "]
+			description: ["The link though tenuous, grows stronger. Channeling the spirits and their energies paves the way to Alchemy and from there, the deeper magics. "]
 			dependencies: ["7E371FBDE82532D9"]
 			id: "5A53DAE0FAC0A38F"
 			tasks: [{

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/apotheosis/tome_tower.js
@@ -332,6 +332,11 @@ onEvent('generic.loot_tables', (event) => {
                     item: 'ars_nouveau:mana_gem',
                     weight: 100,
                     count: [5, 9]
+                },
+                {
+                    item: 'bloodmagic:experiencebook',
+                    weight: 15,
+                    count: 1
                 }
             ]
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/astralsorcery/shrine_chest.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/astralsorcery/shrine_chest.js
@@ -68,6 +68,21 @@ onEvent('generic.loot_tables', (event) => {
                     item: Item.of('shrink:mob_bottle', '{entity:"minecraft:ocelot"}'),
                     count: 2,
                     weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"alexsmobs:moose"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"alexsmobs:rattlesnake"}'),
+                    count: 2,
+                    weight: 20
+                },
+                {
+                    item: Item.of('shrink:mob_bottle', '{entity:"alexsmobs:komodo_dragon"}'),
+                    count: 2,
+                    weight: 20
                 }
             ]
         }

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
@@ -70,8 +70,9 @@ onEvent('chest.loot_tables', (event) => {
 
     const underwater_chests = [
         'minecraft:shipwreck_supply',
-        'repurposed_structures:chests/dungeon/ocean',
-        'repurposed_structures:chests/mineshaft/ocean'
+        'repurposed_structures:dungeon/ocean',
+        'repurposed_structures:mineshaft/ocean',
+        'dungeons_plus:warped_garden/common'
     ];
     underwater_chests.forEach((underwater_chest) => {
         event.modify(underwater_chest, (table) => {

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
@@ -70,6 +70,8 @@ onEvent('chest.loot_tables', (event) => {
 
     const underwater_chests = [
         'minecraft:shipwreck_supply',
+        'minecraft:underwater_ruin_big',
+        'minecraft:underwater_ruin_small',
         'repurposed_structures:dungeon/ocean',
         'repurposed_structures:mineshaft/ocean',
         'dungeons_plus:warped_garden/common'

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
@@ -5,11 +5,13 @@ onEvent('chest.loot_tables', (event) => {
             entries: [
                 {
                     item: Item.of('minecraft:potion', '{Potion:"minecraft:water_breathing"}'),
-                    weight: 100
+                    weight: 100,
+                    count: [1, 3]
                 },
                 {
                     item: Item.of('minecraft:potion', '{Potion:"minecraft:long_water_breathing"}'),
-                    weight: 75
+                    weight: 75,
+                    count: [0, 2]
                 },
                 {
                     item: 'create:diving_helmet',

--- a/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/loot_tables/enigmatica/underwater_treasure_additions.js
@@ -1,0 +1,100 @@
+onEvent('chest.loot_tables', (event) => {
+    const pools = [
+        {
+            rolls: { min: 1, max: 5 },
+            entries: [
+                {
+                    item: Item.of('minecraft:potion', '{Potion:"minecraft:water_breathing"}'),
+                    weight: 100
+                },
+                {
+                    item: Item.of('minecraft:potion', '{Potion:"minecraft:long_water_breathing"}'),
+                    weight: 75
+                },
+                {
+                    item: 'create:diving_helmet',
+                    count: 1,
+                    weight: 25,
+                    enchantLevel: 15
+                },
+                {
+                    item: 'create:diving_boots',
+                    count: 1,
+                    weight: 25,
+                    enchantLevel: 15
+                },
+                {
+                    item: 'create:copper_backtank',
+                    count: 1,
+                    weight: 25,
+                    enchantLevel: 15
+                },
+                {
+                    item: 'thermal:diving_helmet',
+                    count: 1,
+                    weight: 50,
+                    enchantLevel: 10
+                },
+                {
+                    item: 'thermal:diving_chestplate',
+                    count: 1,
+                    weight: 50,
+                    enchantLevel: 10
+                },
+                {
+                    item: 'thermal:diving_boots',
+                    count: 1,
+                    weight: 50,
+                    enchantLevel: 10
+                },
+                {
+                    item: 'thermal:diving_leggings',
+                    count: 1,
+                    weight: 50,
+                    enchantLevel: 10
+                },
+                {
+                    item: 'artifacts:charm_of_sinking'
+                },
+                {
+                    item: 'artifacts:flippers'
+                },
+                {
+                    item: 'artifacts:snorkel'
+                }
+            ]
+        }
+    ];
+
+    const underwater_chests = [
+        'minecraft:shipwreck_supply',
+        'repurposed_structures:chests/dungeon/ocean',
+        'repurposed_structures:chests/mineshaft/ocean'
+    ];
+    underwater_chests.forEach((underwater_chest) => {
+        event.modify(underwater_chest, (table) => {
+            pools.forEach((pool) => {
+                table.addPool((newPool) => {
+                    newPool.setUniformRolls(pool.rolls.min, pool.rolls.max);
+                    pool.entries.forEach((entry) => {
+                        let count = 1,
+                            weight = 1;
+
+                        if (entry.count) {
+                            count = entry.count;
+                        }
+
+                        if (entry.weight) {
+                            weight = entry.weight;
+                        }
+
+                        const re = newPool.addItem(entry.item, weight, count);
+                        if (entry.enchantLevel) {
+                            re.enchantWithLevels(entry.enchantLevel, false);
+                        }
+                    });
+                });
+            });
+        });
+    });
+});

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/shaped.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/create/shaped.js
@@ -64,6 +64,38 @@ onEvent('recipes', (event) => {
                 C: 'create:andesite_casing'
             },
             id: 'create:crafting/kinetics/encased_chain_drive'
+        },
+        {
+            output: 'create:copper_backtank',
+            pattern: ['ABA', 'CDC', 'ECE'],
+            key: {
+                A: 'betterendforge:leather_stripe',
+                B: 'create:shaft',
+                C: '#forge:plates/copper',
+                D: 'mekanism:basic_chemical_tank',
+                E: '#forge:ingots/andesite_alloy'
+            },
+            id: 'create:crafting/appliances/copper_backtank'
+        },
+        {
+            output: 'create:diving_helmet',
+            pattern: ['ABA', 'BCB'],
+            key: {
+                A: 'thermal:diving_fabric',
+                B: '#forge:ingots/silicon_bronze',
+                C: '#forge:glass_panes/cyan'
+            },
+            id: 'create:crafting/appliances/diving_helmet'
+        },
+        {
+            output: 'create:diving_boots',
+            pattern: ['A A', 'B B', 'C C'],
+            key: {
+                A: 'thermal:diving_fabric',
+                B: '#forge:ingots/silicon_bronze',
+                C: '#forge:plates/lead'
+            },
+            id: 'create:crafting/appliances/diving_boots'
         }
     ];
 


### PR DESCRIPTION
Minor update to this gear. Requires a small amount of tech progression now to access the helm and boots. as a full tank equates to 15 minutes underwater. 

![image](https://user-images.githubusercontent.com/9543430/144159115-010c78e7-66f8-4cf9-abf1-ec9a0437a651.png)
![image](https://user-images.githubusercontent.com/9543430/144159136-f9f7a306-a6d8-42ad-82be-2e91ce078962.png)
![image](https://user-images.githubusercontent.com/9543430/144159149-505f67fa-6aa2-42d4-a542-7175375ec45e.png)

Loot changes for all modes:

Consequentially, this armor, as well as Thermal's Dive Suit, Potions of Waterbreathing, and some very rare Swimming related Artifacts are now available in underwater loot chests as well, offering more reward for risking the depths.

A few more animal friends find their way into the Astral loot table to round those out, as some of those creatures can be rather rare and are required for progression.

