### PR TITLE
[Expert] Pyrolizer back behind coke dust

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/replace_input.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/thermal/replace_input.js
@@ -10,6 +10,11 @@ onEvent('recipes', (event) => {
             replaceWith: 'thermal:fluid_cell'
         },
         {
+            replaceTarget: { id: 'thermal:machine_pyrolyzer' },
+            toReplace: '#forge:netherbricks',
+            replaceWith: 'immersiveengineering:blastbrick'
+        },
+        {
             replaceTarget: { id: 'thermal:machine_bottler' },
             toReplace: 'thermal:machine_frame',
             replaceWith: 'thermal:fluid_cell_frame'


### PR DESCRIPTION
This was originally behind coke dust as an upgrade to the IE coke oven, but that seems to have been lost along the way. Just puts it back there by using blast brick in the recipe. 

![image](https://user-images.githubusercontent.com/9543430/144266877-25391fb7-cd53-46bb-a938-852d619d9207.png)
