### PR TITLE
Little Buzzy Tweaks

### DIFF
--- a/config/resourcefulbees/bees/metal/Frosty.json
+++ b/config/resourcefulbees/bees/metal/Frosty.json
@@ -1,6 +1,6 @@
 {
     "flower": "undergarden:gloomgourd",
-    "lore": "Tier 2:\nMating the Clogged Bee with the I-C-Bee\nyields chilled out, Frosty children.",
+    "lore": "Tier 2:\nMating the Clogged Bee with the I-C-Bee\nyields chilled out, Frosty children.\nMy Milkshake brings all the queens to the yard.",
     "loreColor": "#00AAAA",
     "maxTimeInHive": 4800,
     "sizeModifier": 1,
@@ -37,8 +37,8 @@
         "mainOutputWeight": 0.4,
         "mainOutputCount": 1,
 
-        "secondaryOutput": "emendatusenigmatica:cobalt_chunk",
-        "secondaryOutputWeight": 0.3,
+        "secondaryOutput": "thermal:blizz_powder",
+        "secondaryOutputWeight": 0.1,
         "secondaryOutputCount": 2,
 
         "bottleOutput": "minecraft:honey_bottle",

--- a/config/resourcefulbees/bees/natural/Creeper.json
+++ b/config/resourcefulbees/bees/natural/Creeper.json
@@ -44,11 +44,11 @@
         "mainOutputCount": 3,
 
         "secondaryOutput": "resourcefulbees:wax",
-        "secondaryOutputWeight": 0.5,
+        "secondaryOutputWeight": 0.6,
         "secondaryOutputCount": 3,
 
         "bottleOutput": "minecraft:honey_bottle",
-        "bottleOutputWeight": 0.25,
+        "bottleOutputWeight": 0.4,
         "bottleOutputCount": 1,
 
         "mainInputCount": 1

--- a/config/resourcefulbees/bees/natural/Forest.json
+++ b/config/resourcefulbees/bees/natural/Forest.json
@@ -38,7 +38,7 @@
         "mainOutputCount": 4,
 
         "secondaryOutput": "resourcefulbees:wax",
-        "secondaryOutputWeight": 0.5,
+        "secondaryOutputWeight": 0.6,
         "secondaryOutputCount": 3,
 
         "bottleOutput": "resourcefulbees:illuminating_honey_bottle",

--- a/config/resourcefulbees/bees/natural/Pigman.json
+++ b/config/resourcefulbees/bees/natural/Pigman.json
@@ -45,11 +45,11 @@
         "mainOutputCount": 6,
 
         "secondaryOutput": "resourcefulbees:wax",
-        "secondaryOutputWeight": 0.5,
+        "secondaryOutputWeight": 0.75,
         "secondaryOutputCount": 3,
 
         "bottleOutput": "minecraft:honey_bottle",
-        "bottleOutputWeight": 0.25,
+        "bottleOutputWeight": 0.4,
         "bottleOutputCount": 1,
 
         "mainInputCount": 1

--- a/config/resourcefulbees/bees/natural/RGBee.json
+++ b/config/resourcefulbees/bees/natural/RGBee.json
@@ -30,7 +30,7 @@
         "mainOutputCount": 2,
 
         "secondaryOutput": "quark:rainbow_rune",
-        "secondaryOutputWeight": 0.01,
+        "secondaryOutputWeight": 0.05,
         "secondaryOutputCount": 1,
 
         "bottleOutput": "resourcefulbees:rainbow_honey_bottle",

--- a/config/resourcefulbees/bees/natural/Sand.json
+++ b/config/resourcefulbees/bees/natural/Sand.json
@@ -43,7 +43,7 @@
         "secondaryOutputCount": 1,
 
         "bottleOutput": "minecraft:honey_bottle",
-        "bottleOutputWeight": 0.25,
+        "bottleOutputWeight": 0.4,
         "bottleOutputCount": 1,
 
         "mainInputCount": 1

--- a/config/resourcefulbees/bees/natural/Skeleton.json
+++ b/config/resourcefulbees/bees/natural/Skeleton.json
@@ -43,7 +43,7 @@
         "secondaryOutputCount": 2,
 
         "bottleOutput": "minecraft:honey_bottle",
-        "bottleOutputWeight": 0.25,
+        "bottleOutputWeight": 0.8,
         "bottleOutputCount": 1,
 
         "mainInputCount": 1

--- a/config/resourcefulbees/bees/natural/Slimy.json
+++ b/config/resourcefulbees/bees/natural/Slimy.json
@@ -40,11 +40,11 @@
         "mainOutputCount": 4,
 
         "secondaryOutput": "refinedstorage:processor_binding",
-        "secondaryOutputWeight": 0.02,
+        "secondaryOutputWeight": 0.05,
         "secondaryOutputCount": 1,
 
         "bottleOutput": "minecraft:honey_bottle",
-        "bottleOutputWeight": 0.25,
+        "bottleOutputWeight": 0.4,
         "bottleOutputCount": 1,
 
         "mainInputCount": 1

--- a/config/resourcefulbees/bees/natural/Zombie.json
+++ b/config/resourcefulbees/bees/natural/Zombie.json
@@ -40,11 +40,11 @@
         "mainOutputCount": 3,
 
         "secondaryOutput": "minecraft:leather",
-        "secondaryOutputWeight": 0.08,
+        "secondaryOutputWeight": 0.1,
         "secondaryOutputCount": 1,
 
         "bottleOutput": "minecraft:honey_bottle",
-        "bottleOutputWeight": 0.25,
+        "bottleOutputWeight": 0.4,
         "bottleOutputCount": 1,
 
         "mainInputCount": 1

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_epic.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_epic.json
@@ -5,112 +5,155 @@
             "rolls": 1,
             "entries": [
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:iron_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.03776067512895905,Operation:1,UUID:[-1207541730,-1263776829,-1439313122,-2011209013],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"iron\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[287125043,-76594110,-1156608721,2013250607],Age:0,TicksSincePollination:14,AngerTime:0,Motion:[-0.061626914871871934,0.14485856115182605,0.061626914871871934],Health:10.0,HasNectar:0,Color:\"#ffcc99\",LeftHanded:0,Air:300,OnGround:0,Rotation:[45.0,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.89120923709993,83.65707319191107,-115.89120923709993],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:clogged_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:gold_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.04988226533241591,Operation:1,UUID:[-1544817110,-1553904909,-1974379402,1770924971],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"gold\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1656555906,-1850521131,-2114768571,2015954931],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#FFDC00\",LeftHanded:0,Air:300,OnGround:1,Rotation:[18.148878,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:glowstone_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:slimy_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.013606562186442081,Operation:1,UUID:[-1798378031,-782940862,-1646942087,-1274928609],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"slimy\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2106735075,-1393999531,-1464116735,-631421951],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#73c262\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-76.92932,-39.664703],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:pigman_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:redstone_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.02171583473853723,Operation:1,UUID:[1341026862,-1320991644,-1721502208,1785350270],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"redstone\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[1116904453,419972642,-1399259999,90032775],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#aa0f01\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-0.7652893,-40.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:obsidian_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:nether_quartz_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.004435865221507377,Operation:1,UUID:[2069761863,-1974450039,-1332587149,788772581],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"nether_quartz\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[766701581,1367687438,-1783737777,2024356951],Age:0,TicksSincePollination:13,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#D4CABA\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-141.63295,-38.18873],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:clay_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:blaze_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.11251533095718043,Operation:1,UUID:[-1723845324,-487832759,-1907845729,-1118786055],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"blaze\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-581167871,-1550433063,-1854939199,-53356043],Age:0,TicksSincePollination:12,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#ff4500\",LeftHanded:0,Air:300,OnGround:1,Rotation:[95.94287,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "resourcefulbees:bee_jar",
-                    "functions": [
+                            "tag": "{Entity:\"resourcefulbees:gravel_bee\"}"
+                        },
                         {
-                            "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:obsidian_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.013314845678952851,Operation:1,UUID:[1896959653,-1267908223,-1664980160,1417694414],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"obsidian\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1279081246,1715486971,-1582167596,-1825003670],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#663399\",LeftHanded:1,Air:300,OnGround:1,Rotation:[-104.97218,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
-                },
+                }
+            ]
+        },
+        {
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "resourcefulbees:bee_jar",
-                    "functions": [
-                        {
-                            "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:pigman_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.019736818079820487,Operation:1,UUID:[597960220,-327661581,-1267830748,1772569299],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"pigman\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2018514627,2068793738,-1729941754,393700331],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#885956\",LeftHanded:1,Air:300,OnGround:1,Rotation:[-14.275696,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "resourcefulbees:bee_jar",
-                    "functions": [
-                        {
-                            "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:lapis_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.030548682081909265,Operation:1,UUID:[430561632,-1286320175,-1190363091,-2117531770],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"lapis\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[8849479,844778002,-1866845089,-2019090232],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#345ec3\",LeftHanded:0,Air:300,OnGround:1,Rotation:[114.32849,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
-                        }
-                    ]
-                },
-                {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:centrifuge_casing",
                     "functions": [
                         {
                             "function": "set_count",
+                            "count": 3
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 8,
+                    "name": "minecraft:honeycomb_block",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 8,
+                    "name": "resourcefulbees:wax_block",
+                    "functions": [
+                        {
+                            "function": "set_count",
                             "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 8,
+                    "name": "minecraft:honey_block",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "resourcefulbees:t2_hive_upgrade",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
                         }
                     ]
                 }

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_legendary.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_legendary.json
@@ -5,112 +5,223 @@
             "rolls": 1,
             "entries": [
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
+                    "type": "item",
+                    "weight": 6,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:ghast_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[537258484,7094555,-1441412745,1102607046],Amount:-0.009925729547141894,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"ghast\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-983703877,-1900002981,-1219349477,-1711482654],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#faebd7\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-19.179138,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:brutish_zombee_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
+                    "type": "item",
+                    "weight": 4,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:ender_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[821445019,1958495190,-1996088730,-1038027832],Amount:0.008588706823919592,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"ender\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-745806510,-902936683,-1367788183,1399644643],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[0.063647862602854,0.15372139312507307,0.06364766875955409],Health:10.0,HasNectar:0,Color:\"#339786\",LeftHanded:0,Air:300,OnGround:0,Rotation:[315.00046,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.1787399633461,83.8139317532715,-115.82126674597329],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:ender_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:tin_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1369032286,407978403,-1651282659,-2128219219],Amount:0.04451874101147999,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"tin\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[1987057706,-1210429701,-1421859662,-1468921959],Age:0,TicksSincePollination:11,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#7ec0ee\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-34.404938,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:emerald_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:osmium_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[268952999,1196050605,-1841934870,1445589286],Amount:-0.02712855125824559,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"osmium\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1540871553,-125415947,-1889461126,-1182135107],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[-0.03405229083276834,0.011368005735397585,0.03405229083276834],Health:10.0,HasNectar:0,Color:\"#aeeeee\",LeftHanded:0,Air:300,OnGround:0,Rotation:[45.0,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.43763317421703,82.51160000562668,-116.43763317421703],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:clockwork_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:silver_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-965996428,1310149543,-1904655739,-264983298],Amount:-0.05082876772775438,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"silver\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1113070170,-1376760993,-1500700483,-1148813167],Age:0,TicksSincePollination:13,AngerTime:0,Motion:[-0.06990507889141243,0.08741105109931153,0.0413646223817017],Health:10.0,HasNectar:0,Color:\"#c6e2ff\",LeftHanded:0,Air:300,OnGround:0,Rotation:[66.61311,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.00434864959759,82.90944818986426,-116.13834389340269],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:spelling_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:copper_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1737091899,-1932572034,-2050963869,-2050341085],Amount:-0.05996216689580944,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"copper\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1667226298,944524704,-1411285709,1012706218],Age:0,TicksSincePollination:14,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#a0522d\",LeftHanded:0,Air:300,OnGround:1,Rotation:[143.01979,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:soup_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
+                    "type": "item",
+                    "weight": 4,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:diamond_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-2032909478,-962247125,-1315128254,589700555],Amount:-0.09306339330855018,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"diamond\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2019018022,-1627241578,-1831587440,242505593],Age:0,TicksSincePollination:20,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#00ffff\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-89.75772,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:silver_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
+                    "type": "item",
+                    "weight": 4,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:nickel_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1282900993,-1457961216,-2038247564,363623167],Amount:-0.10027345262904151,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"nickel\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:1.0E-7},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1967587529,-832354529,-1685608283,475571344],Age:0,TicksSincePollination:17,AngerTime:0,Motion:[-0.060319048313708365,0.03420263421554696,0.0],Health:10.0,HasNectar:0,Color:\"#eed8ae\",LeftHanded:0,Air:300,OnGround:0,Rotation:[90.000595,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.28559810779034,82.56986865805014,-116.49999154392948],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:gold_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
+                    "type": "item",
+                    "weight": 5,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:lead_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[732767861,-1012710449,-2082914600,-981904681],Amount:0.021544288630234165,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"lead\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1485550679,2027571857,-1232127303,1077253812],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#483d8b\",LeftHanded:0,Air:300,OnGround:1,Rotation:[15.37689,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:iron_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "weight": 3,
+                    "name": "resourcefulbees:elite_centrifuge_casing",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 3
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
-                    "name": "resourcefulbees:bee_jar",
+                    "type": "item",
+                    "weight": 4,
+                    "name": "resourcefulbees:t2_hive_upgrade",
                     "functions": [
                         {
-                            "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:emerald_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1484871407,-1549188744,-1375894161,1813609911],Amount:0.07240741837451369,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"emerald\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-907487775,-904051415,-2136428292,-1854446217],Age:0,TicksSincePollination:16,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#18eb09\",LeftHanded:0,Air:300,OnGround:1,Rotation:[-41.74118,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.5,82.5,-116.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "function": "set_count",
+                            "count": {
+                                "min": 2,
+                                "max": 4
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 2,
+                    "name": "resourcefulbees:t3_hive_upgrade",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "resourcefulbees:t4_hive_upgrade",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 4,
+                    "name": "glassential:glass_ethereal",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 8,
+                                "max": 16
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 4,
+                    "name": "glassential:glass_light",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 16,
+                                "max": 32
+                            }
                         }
                     ]
                 }

--- a/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_rare.json
+++ b/kubejs/data/enigmatica/loot_tables/chests/quest_resourceful_bees_loot_rare.json
@@ -5,74 +5,181 @@
             "rolls": 1,
             "entries": [
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:coal_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1502084261,404045911,-2036350325,-1382479013],Amount:0.009820156640921557,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"coal\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-530298486,997411316,-1615973353,516174548],Age:0,TicksSincePollination:14,AngerTime:0,Motion:[0.06781557272384404,0.16427450739521868,-0.06781585349882853],Health:10.0,HasNectar:0,Color:\"#303030\",LeftHanded:0,Air:300,OnGround:0,Rotation:[225.00081,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[93.26535201841719,84.18627668990302,-119.26536074810575],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:coal_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:rgbee_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[-1879255474,-341487687,-1958102753,1067334919],Amount:-0.07617916294406485,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"rgbee\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:0.0},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1760308052,1083983260,-1158210155,-1121206146],Age:0,TicksSincePollination:15,AngerTime:0,Motion:[-0.05567068597973056,0.07719494815674387,-0.05567068597973056],Health:10.0,HasNectar:0,Color:\"rainbow\",LeftHanded:0,Air:300,OnGround:0,Rotation:[135.0,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.12346572287262,82.8202532414989,-118.87653427712738],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:rgbee_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:skeleton_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":200},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Operation:1,UUID:[632314797,1649036610,-1916246567,-2081020520],Amount:0.010503948595751936,Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:1.0,Name:\"forge:swim_speed\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"skeleton\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"citadel:extended_entity_data_citadel\":{},\"mekanism:radiation\":{radiation:1.0E-7},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-1200750323,-643807998,-1661475736,-2139815504],Age:0,TicksSincePollination:212,AngerTime:0,Motion:[0.04169481601608948,-0.025363391244413436,-0.07531976444622393],Health:10.0,HasNectar:0,Color:\"#F6F2E6\",LeftHanded:0,Air:300,OnGround:0,Rotation:[195.44348,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[85.2699248070104,83.91637306064253,-115.58410403080899],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:skeleton_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:zombie_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.0936862303490246,Operation:1,UUID:[-312680417,-1419164042,-1527043506,-1765698721],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"zombie\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-2040481035,945045742,-1214201871,-1569838191],Age:0,TicksSincePollination:23,AngerTime:0,Motion:[0.04977567304691388,0.056133012261532944,0.049773433040176],Health:10.0,HasNectar:0,Color:\"#2F4E32\",LeftHanded:0,Air:300,OnGround:0,Rotation:[315.00055,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.7572860797814,82.67334987529985,-118.24273130840417],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:zombie_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Entity:\"resourcefulbees:clay_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{\"naturesaura:time_alive\":40},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:-0.07599753525026656,Operation:1,UUID:[-249541829,-1915793692,-1681318223,1393815701],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"clay\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-511091075,-1393343214,-1556101410,-1503293438],Age:0,TicksSincePollination:20,AngerTime:0,Motion:[0.0,-0.0784000015258789,0.0],Health:10.0,HasNectar:0,Color:\"#fffaf0\",LeftHanded:0,Air:300,OnGround:1,Rotation:[100.90365,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[92.5,82.5,-117.5],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:creeper_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "resourcefulbees:bee_jar",
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{NoGravity:1,Entity:\"resourcefulbees:creeper_bee\",Brain:{memories:{}},HurtByTimestamp:0,ForgeData:{},HasStung:0,Attributes:[{Base:0.30000001192092896,Name:\"minecraft:generic.movement_speed\"},{Base:48.0,Modifiers:[{Amount:0.030389709675037565,Operation:1,UUID:[509519592,-315143884,-1193781020,-1429426110],Name:\"Random spawn bonus\"}],Name:\"minecraft:generic.follow_range\"},{Base:0.08,Name:\"forge:entity_gravity\"},{Base:0.0,Name:\"minecraft:generic.knockback_resistance\"},{Base:1.0,Name:\"forge:swim_speed\"}],Invulnerable:0,FallFlying:0,ForcedAge:0,PortalCooldown:0,AbsorptionAmount:0.0,BeeType:\"creeper\",FallDistance:0.0,InLove:0,CanUpdate:1,DeathTime:0,ForgeCaps:{\"structure_gel:gel_entity\":{portal:\"structure_gel:empty\"},\"mekanism:radiation\":{radiation:0.0},\"citadel:extended_entity_data_citadel\":{},\"pneumaticcraft:hacking\":{},\"shrink:shrunk\":{width:0.7,isshrinking:0,defaulteyeheight:0.3,fixed:0,isshrunk:0,height:0.6}},HandDropChances:[0.085,0.085],CannotEnterHiveTicks:0,PersistenceRequired:0,FeedCount:0,UUID:[-234873933,-157857309,-1277655463,-1602572860],Age:0,TicksSincePollination:13,AngerTime:0,Motion:[-0.07873024048655934,0.07719494815674387,0.0],Health:10.0,HasNectar:0,Color:\"#0C9F0A\",LeftHanded:0,Air:300,OnGround:0,Rotation:[90.0009,0.0],HandItems:[{},{}],ArmorDropChances:[0.085,0.085,0.085,0.085],Pos:[91.96750010947478,82.8202532414989,-118.49999154392948],Fire:-1,ArmorItems:[{},{},{},{}],CropsGrownSincePollination:0,CanPickUpLoot:0,HurtTime:0}"
+                            "tag": "{Entity:\"resourcefulbees:forest_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
                         }
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:sand_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:rocky_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:icy_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:slimy_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 1,
+                    "name": "resourcefulbees:bee_jar",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Entity:\"resourcefulbees:water_bee\"}"
+                        },
+                        {
+                            "function": "set_count",
+                            "count": 2
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "weight": 4,
                     "name": "minecraft:glass_bottle",
                     "functions": [
                         {
@@ -82,8 +189,8 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
-                    "weight": 1,
+                    "type": "item",
+                    "weight": 4,
                     "name": "minecraft:shears",
                     "functions": [
                         {
@@ -93,7 +200,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "minecraft:comparator",
                     "functions": [
@@ -104,7 +211,7 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "minecraft:dropper",
                     "functions": [
@@ -115,13 +222,46 @@
                     ]
                 },
                 {
-                    "type": "minecraft:item",
+                    "type": "item",
                     "weight": 1,
                     "name": "minecraft:observer",
                     "functions": [
                         {
                             "function": "set_count",
                             "count": 8
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 4,
+                    "name": "naturesaura:animal_container",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 8,
+                    "name": "minecraft:honeycomb",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 4
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "weight": 8,
+                    "name": "resourcefulbees:wax",
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 16
                         }
                     ]
                 }


### PR DESCRIPTION
Fixes up loot tables for RBees quests, removing all the extra NBT and making sure gifted bees don't break progression. Almost all of the bees given are world-gen, and they come in pairs. Tables have 2 pools, one for a bee pair, and one for other useful bee-related stuff.

Bump up spawning bees honey/wax output - both can be a bit hard to come by, and are required for progressing in RBees.

Cobalt secondary makes it strictly better than Cobalt bee; blizz powder isn't as good as Blizz bee though.