### PR TITLE
Fix players not getting waystones

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/base/player/logged_in.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/base/player/logged_in.js
@@ -2,7 +2,7 @@ onEvent('player.logged_in', (event) => {
     const startingItemsGameStage = 'starting_items';
     randomWaystone = () => {
         const waystones = ['waystones:waystone', 'waystones:mossy_waystone', 'waystones:sandy_waystone'];
-        return waystones[Math.floor(Math.random() * waystones.length + 1)];
+        return waystones[Math.floor(Math.random() * waystones.length)];
     };
 
     setMode = (player) => {


### PR DESCRIPTION
I wondered why I didn't get a waystone and neither do many players in my server. The math in this function gives an array index in the range of [1,3]. 3 is out of bounds so returns nothing. Corrected to be in the range [0,2] so it's within the array bounds.

random() -> [0,1) -> *3 -> [0,3) -> floor() -> [0,2]

Double checked and this gives a uniform distribution too.

Before:
![image](https://user-images.githubusercontent.com/4535529/146855560-eea340a1-4018-4143-b399-8ba0a60564fb.png)

After:
![image](https://user-images.githubusercontent.com/4535529/146855597-adbe6211-fde9-411c-aeeb-4e6e52a1e14e.png)
