### PR TITLE
[Expert] Minor fixes

### DIFF
--- a/config/ftbquests/quests/chapters/botania.snbt
+++ b/config/ftbquests/quests/chapters/botania.snbt
@@ -410,7 +410,24 @@
 			tasks: [{
 				id: "0000000000000522"
 				type: "item"
-				item: "botania:endoflame"
+				title: "Endoflame"
+				icon: "botania:endoflame"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "botania:endoflame"
+								Count: 1b
+							}
+							{
+								id: "botania:gourmaryllis"
+								Count: 1b
+							}
+						]
+					}
+				}
 			}]
 			rewards: [
 				{

--- a/config/ftbquests/quests/chapters/tinkers_construct.snbt
+++ b/config/ftbquests/quests/chapters/tinkers_construct.snbt
@@ -484,14 +484,25 @@
 			id: "1BECFB61E2216217"
 			tasks: [
 				{
-					id: "40C66C0A845AC4DC"
-					type: "item"
-					item: "tconstruct:seared_melter"
-				}
-				{
 					id: "66575D6B48FFD434"
 					type: "item"
-					item: "tconstruct:seared_heater"
+					title: "Seared Melter"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "tconstruct:seared_melter"
+									Count: 1b
+								}
+								{
+									id: "tconstruct:seared_heater"
+									Count: 1b
+								}
+							]
+						}
+					}
 				}
 				{
 					id: "78758910B6CD9108"

--- a/config/ftbquests/quests/chapters/tinkers_construct.snbt
+++ b/config/ftbquests/quests/chapters/tinkers_construct.snbt
@@ -47,6 +47,7 @@
 					level: 1s
 				}
 			]
+			HideFlags: 3
 			tic_materials: [
 				"tconstruct:hepatizon"
 				"tconstruct:wood"
@@ -111,6 +112,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:hepatizon"
 						"tconstruct:wood"
@@ -828,6 +830,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -929,6 +932,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -993,6 +997,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -1087,6 +1092,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -1155,6 +1161,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -1253,6 +1260,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -1317,6 +1325,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -1425,6 +1434,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -1489,6 +1499,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -1593,6 +1604,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -1661,6 +1673,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -1749,6 +1762,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -1817,6 +1831,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:stone"
 						"tconstruct:wood"
@@ -1901,6 +1916,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:stone"
 								"tconstruct:wood"
@@ -1958,6 +1974,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:stone"
 						"tconstruct:wood"
@@ -2042,6 +2059,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:stone"
 								"tconstruct:wood"
@@ -2094,6 +2112,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:stone"
 						"tconstruct:wood"
@@ -2175,6 +2194,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:stone"
 								"tconstruct:wood"
@@ -2227,6 +2247,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:stone"
 						"tconstruct:wood"
@@ -2309,6 +2330,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:stone"
 								"tconstruct:wood"
@@ -2371,6 +2393,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:stone"
 						"tconstruct:wood"
@@ -2462,6 +2485,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:stone"
 								"tconstruct:wood"
@@ -2524,6 +2548,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:stone"
 						"tconstruct:wood"
@@ -2615,6 +2640,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:stone"
 								"tconstruct:wood"
@@ -2707,6 +2733,7 @@
 							level: 1s
 						}
 					]
+					HideFlags: 3
 					tic_materials: [
 						"tconstruct:tinkers_bronze"
 						"tconstruct:wood"
@@ -2784,6 +2811,7 @@
 									level: 1s
 								}
 							]
+							HideFlags: 3
 							tic_materials: [
 								"tconstruct:tinkers_bronze"
 								"tconstruct:wood"
@@ -3260,6 +3288,7 @@
 								level: 1s
 							}
 						]
+						HideFlags: 3
 						Damage: 0
 						tic_persistent_data: {
 							abilities: 0

--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipes/remove.js
@@ -137,6 +137,8 @@ onEvent('recipes', (event) => {
         'tconstruct:smeltery/seared/seared_brick_kiln',
         'tconstruct:tables/book_substitute',
         'tconstruct:smeltery/melting/metal/netherite/lodestone',
+        'tconstruct:compat/refined_obsidian_ingot',
+        'tconstruct:smeltery/alloys/molten_refined_obsidian',
 
         'thermal:compat/refinedstorage/smelter_refinedstorage_alloy_quartz_enriched_iron',
 


### PR DESCRIPTION
Removes Refined Obsidian crafting from tinkers. 

Updates tinkers and botania quests to allow expert players to bypass some progression due to changes in progression in those mods. 