### PR TITLE
Make AIOT tools use SWORD affixes

### DIFF
--- a/config/apotheosis/deadly.cfg
+++ b/config/apotheosis/deadly.cfg
@@ -3,7 +3,12 @@
 affixes {
     # A list of type overrides for the affix loot system.  Format is <itemname>|<type>.  Types are SWORD, RANGED, PICKAXE, SHOVEL, AXE, SHIELD [default: [minecraft:stick|SWORD]]
     S:"Equipment Type Overrides" <
-        minecraft:stick|SWORD
+        aiotbotania:livingwood_aiot|SWORD
+        aiotbotania:livingrock_aiot|SWORD
+        aiotbotania:manasteel_aiot|SWORD
+        aiotbotania:elementium_aiot|SWORD
+        aiotbotania:terra_aiot|SWORD
+        aiotbotania:alfsteel_aiot|SWORD
      >
 
     # If mythic items are unbreakable. [default: true]


### PR DESCRIPTION
By default AIOT Tools only take PICKAXE affixes. I filed
https://github.com/Shadows-of-Fire/Apotheosis/issues/499

Suggesting that more than one affix type should be possible for AIOT
tools given that they have multiple tool types added to them. (ToolTypes
in the API not referring to the recipe)

The dev says there that this won't happen for 1.16 but will be
considered for 1.18

However the PICKAXE affixes are not especially useful for botania tools
(Placing torches, expanded mining area, improved mining level)

So I propose that they are recategorized as SWORD for the purpose of
affixes.

I thought about changing Paxel's as well but they don't include a sword
in their recipe so I decided against it.