### PR TITLE
use length check to handle `with` in JEI Description

### DIFF
--- a/kubejs/client_scripts/item_modifiers/jei_descriptions.js
+++ b/kubejs/client_scripts/item_modifiers/jei_descriptions.js
@@ -491,9 +491,9 @@ onEvent('jei.information', (event) => {
 
     recipes.forEach((recipe) => {
         for (let i = 0; i < recipe.text.length; i++) {
-            try {
+            if (recipe.with && recipe.with.length > i) {
                 recipe.text[i] = Text.translate(recipe.text[i], recipe.with[i]);
-            } catch (e) {
+            } else {
                 recipe.text[i] = Text.translate(recipe.text[i]);
             }
         }


### PR DESCRIPTION
JavaScript's variable accessing is trickier than my expection. Errors will be reported by KubeJS at seemly completely random time. 
So, instead of painstakingly debugging(I've done so, really painstaking), let's just use `try-catch` .

Ported from https://github.com/ZZZank/Enlightened6/commit/21170382c9f805a5359eb4f3d4718ac0a5aa98a3